### PR TITLE
chore(husky)/ update pre-push and pre-commit hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,8 +1,8 @@
 # Commit message validation hook
 # Validates commit messages against Conventional Commits format
-# Blocks commits that don't follow the format
+# Warns if commit message doesn't follow the format (non-blocking)
 
 echo "Validating commit message..."
 
-npx --no -- commitlint --edit "$1"
+npx --no -- commitlint --edit "$1" || echo "Warning: Commit message does not follow convention"
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,95 @@
-# Branch naming validation hook
+# Pre-push validation hook
+# 1. Validates full project build succeeds
+# 2. Runs all test suites
+# 3. Validates schema types are in sync
+# 4. Validates branch name against pattern: <type>/CORPCAL-<number>-<short-description>
+
+# ============================================
+# Build Verification
+# ============================================
+# Ensures the entire project builds successfully before pushing
+# This catches compilation errors, type errors, and build configuration issues
+
+echo "Running full build verification..."
+
+npm run build --silent 2>/dev/null || {
+  echo ""
+  echo "Build failed! Please fix build errors before pushing."
+  echo ""
+  exit 1
+}
+
+echo "Build verification passed."
+echo ""
+
+# ============================================
+# Test Suite Execution
+# ============================================
+# Runs all test suites across all workspaces
+# This ensures all tests pass before pushing to remote
+
+echo "Running test suites..."
+
+# Run calendar-service tests (Jest)
+npm run test --workspace=calendar-service --silent 2>/dev/null || {
+  echo ""
+  echo "Calendar service tests failed! Please fix test failures before pushing."
+  echo ""
+  exit 1
+}
+
+# Run calendar-ui tests (Vitest)
+# Use --run flag to ensure Vitest runs once instead of watch mode
+npm run test --workspace=calendar-ui -- --run --silent 2>/dev/null || {
+  echo ""
+  echo "Calendar UI tests failed! Please fix test failures before pushing."
+  echo ""
+  exit 1
+}
+
+echo "All tests passed."
+echo ""
+
+# ============================================
+# Type Validation
+# ============================================
+# Ensures database schemas and shared types are in sync
+# This runs for all branches to catch type drift early
+# Note: Packages are already built from the build verification step above
+
+echo "Running type validation..."
+
+# Run type validation
+npm run validate-types --workspace=packages/shared --silent 2>/dev/null
+validation_result=$?
+
+if [ $validation_result -ne 0 ]; then
+  echo ""
+  echo "Type validation failed!"
+  echo ""
+  echo "Schema types are out of sync. Please fix the following:"
+  echo "  1. Run: npm run validate-types --workspace=packages/shared"
+  echo "  2. Review the output for type mismatches"
+  echo "  3. Update schemas or types as needed"
+  echo ""
+  echo "See docs/SCHEMA_README.md for guidance on schema updates."
+  echo ""
+  exit 1
+fi
+
+echo "Type validation passed."
+echo ""
+
+# ============================================
+# Branch Naming Validation
+# ============================================
 # Validates branch name against pattern: <type>/CORPCAL-<number>-<short-description>
 # Blocks push if branch name is invalid
 
 # Get the current branch name
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 
-# Skip validation for main/master branches
+# Skip branch naming validation for main/master branches
 if [ "$branch_name" = "main" ] || [ "$branch_name" = "master" ] || [ "$branch_name" = "develop" ]; then
   exit 0
 fi
@@ -18,7 +102,7 @@ pattern="^(feat|fix|docs|style|refactor|test|build|chore)/CORPCAL-[0-9]+-[a-z0-9
 
 if ! echo "$branch_name" | grep -qE "$pattern"; then
   echo ""
-  echo "❌ Invalid branch name: $branch_name"
+  echo "Invalid branch name: $branch_name"
   echo ""
   echo "Branch names must follow the format: <type>/CORPCAL-<number>-<short-description>"
   echo ""
@@ -27,15 +111,14 @@ if ! echo "$branch_name" | grep -qE "$pattern"; then
   echo "Description: all lowercase, hyphens allowed, no spaces"
   echo ""
   echo "Example:"
-  echo "  ✅ feat/CORPCAL-123-add-user-authentication"
+  echo "  feat/CORPCAL-123-add-user-authentication"
   echo ""
-  echo "❌ Invalid examples:"
-  echo "  ❌ feature/CORPCAL-123 (wrong type)"
-  echo "  ❌ feat/corcal-123 (wrong Jira key format)"
-  echo "  ❌ feat/CORPCAL-123 (missing description)"
+  echo "Invalid examples:"
+  echo "  feature/CORPCAL-123 (wrong type)"
+  echo "  feat/corcal-123 (wrong Jira key format)"
+  echo "  feat/CORPCAL-123 (missing description)"
   echo ""
   exit 1
 fi
 
 echo "Branch name is valid: $branch_name"
-


### PR DESCRIPTION
**Summary**

This PR follows a team discussion about the utility of pre-commit/pre-push hooks and commit syntax linting.
The team decided to keep commit syntax linting for now, but noted that it is cumbersome and should be made non-blocking. Having the hooks be non-blocking allows us to still run checks (versus `--no-verify`, which skips all checks; though `--no-verify` is still available for wip commits.

**Details**
- make commitlint syntax validation non-blocking
- add full build and test run to pre-push
- push is blocked by test or build failures

**Testing**
Manually tested that the commit/push commitlint still runs as non-blocking. Both run with warning, as expected.

<img width="678" height="198" alt="Screenshot 2026-01-06 at 1 17 16 PM" src="https://github.com/user-attachments/assets/4baeedde-e6aa-4fc9-b2a6-2b9ec1d74223" />

**Notes**

In the future, we may want to consider enforcing commit syntax on push only. This would keep the history clean in remote and encourage us to squash and tidy commits.