### PR TITLE
fix(cicd): job reorder to generate types before build

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -26,15 +26,15 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Build project
+        run: npm run build
+
       - name: Check linting and types
         run: npm run lint:check
 
       # Security audit: check for known vulnerabilities in dependencies
       - name: Run npm audit
         run: npm audit --audit-level=moderate
-
-      - name: Build project
-        run: npm run build
 
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
## Summary

Pipeline quality check jobs were failing. This is in part because the packages are not built - and subsequently generated types are not generated - before linting runs. This is causing linting errors.

There may be additional issues related to Typescript or npm versions, but these look to be aligned.

## Changes

- reorder jobs so that the build runs before linting. This will generate types required for the linter.

## Testing
Not able to test locally, but changes cannot adversely affect (as currently the jobs are failing). Will review if the jobs pass or fail.