### PR TITLE
Feat/CORPCAL-000 er diagram

### DIFF
--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -189,6 +189,12 @@ If a migration fails or causes issues:
 | `npm run db:migrate --workspace=packages/database`            | Run incremental migrations (production)                             |
 | `npm run db:studio --workspace=packages/database`             | Open Drizzle Studio for visual DB exploration                       |
 | `npm run seed --workspace=calendar-service`                   | Seed lookup tables and sample data                                  |
+| `npm run erd:build --workspace=packages/database`             | Generate a static ER diagram from Drizzle schema (Liam ERD)         |
+| `npm run erd:serve --workspace=packages/database`             | Serve the generated ER diagram locally (view in browser)            |
+
+### ER diagram (Liam ERD)
+
+[Liam ERD](https://liambx.com/docs/parser/supported-formats/drizzle) generates a static ER diagram from the Drizzle schema in `src/schema/*.ts`. It does not watch for changes; rerun `erd:build` after schema updates. Output is written to `dist/` (gitignored). To view the diagram, run `erd:serve` and open the URL shown in your browser.
 
 ### db:push vs db:migrate
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -37,7 +37,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:cov": "vitest run --coverage"
+    "test:cov": "vitest run --coverage",
+    "erd:build": "npx @liam-hq/cli erd build --format drizzle --input \"src/schema/*.ts\"",
+    "erd:serve": "npx serve dist/"
   },
   "dependencies": {
     "drizzle-orm": "^0.44.7",


### PR DESCRIPTION
## Summary
This PR improves our schema documentation with a suggestion of using Liam ERD locally.
While Drizzle-kit studio is still in development (does not create ERDs yet), we do not have a solid option for creating ER diagrams.
Liam ERD seems like a good option in the meantime, as it infers directly from the Drizzle schema. No direct dependencies in the project, but requires install of the Liam ERD cli tool and [serve](https://www.npmjs.com/package/serve) locally.

Since we aren't adding anything to the package, I think it is a low barrier for adoption, and we can always switch if we find something better.

Note: the diagram is static (needs to be regenerated with any schema changes) and kept locally in the packages/database/dist folder.

## Changes
Added convenience scripts to packages/database package.json and updated the database readme.

- build the diagram (static)`run npm run erd:build --workspace=packages/database`
- then serve locally `npm run erd:serve --workspace=packages/database`


<img width="2197" height="1212" alt="Screenshot 2026-02-05 at 7 27 42 PM" src="https://github.com/user-attachments/assets/f23a1069-a25e-41aa-969b-507a4b778a77" />