### PR TITLE
Feat/CORPCAL-156 users teams admin UI

### DIFF
--- a/calendar-service/src/common/utils/parse-query-ids.ts
+++ b/calendar-service/src/common/utils/parse-query-ids.ts
@@ -1,0 +1,11 @@
+/**
+ * Parses a comma-separated string of numeric IDs (e.g. from query params) into an array of numbers.
+ * Returns an empty array for undefined, null, or blank input. Invalid segments are filtered out.
+ */
+export function parseCommaSeparatedIds(value: string | undefined): number[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+}

--- a/calendar-service/src/lookups/lookups.controller.ts
+++ b/calendar-service/src/lookups/lookups.controller.ts
@@ -88,6 +88,7 @@ import {
 import { AppLogger } from '../common/logger/logger.service';
 import { ParseOptionalIntPipe } from '../common/pipes/parse-optional-int.pipe';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { parseCommaSeparatedIds } from '../common/utils/parse-query-ids';
 import { RequirePermission } from '../policy/decorators/require-permission.decorator';
 import { LookupsService } from './lookups.service';
 
@@ -270,13 +271,7 @@ export class LookupsController {
     organizationId?: number,
     @Query('userIds') userIds?: string
   ): Promise<{ success: boolean; data: LookupItem[] }> {
-    // Parse comma-separated userIds string into array of numbers
-    const parsedUserIds = userIds
-      ? userIds
-          .split(',')
-          .map((id) => parseInt(id.trim(), 10))
-          .filter((id) => !isNaN(id))
-      : undefined;
+    const parsedUserIds = userIds ? parseCommaSeparatedIds(userIds) : undefined;
 
     const params: LookupQueryParams = {
       userId,

--- a/calendar-service/src/users/users.controller.spec.ts
+++ b/calendar-service/src/users/users.controller.spec.ts
@@ -69,7 +69,7 @@ describe('UsersController', () => {
       const result = await controller.findAll(undefined);
 
       expect(result).toEqual({ success: true, data: users });
-      expect(mockUsersService.findAll).toHaveBeenCalledWith(undefined);
+      expect(mockUsersService.findAll).toHaveBeenCalledWith(undefined, [], []);
       expect(mockUsersService.findAll).toHaveBeenCalledTimes(1);
     });
 
@@ -79,7 +79,7 @@ describe('UsersController', () => {
 
       await controller.findAll('john');
 
-      expect(mockUsersService.findAll).toHaveBeenCalledWith('john');
+      expect(mockUsersService.findAll).toHaveBeenCalledWith('john', [], []);
     });
   });
 

--- a/calendar-service/src/users/users.controller.ts
+++ b/calendar-service/src/users/users.controller.ts
@@ -33,6 +33,7 @@ import {
 
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { parseCommaSeparatedIds } from '../common/utils/parse-query-ids';
 import { RequirePermission } from '../policy/decorators/require-permission.decorator';
 import {
   AddUserToTeamDto,
@@ -56,12 +57,22 @@ export class UsersController {
   @ApiOperation({
     summary: 'List users',
     description:
-      'Returns all users with team memberships and roles. Optional search by name, email, username.',
+      'Returns all users with team memberships and roles. Optional search by name, email, username; filter by teamIds or roleIds (comma-separated).',
   })
   @ApiQuery({
     name: 'search',
     required: false,
     description: 'Search by display name, username, or email',
+  })
+  @ApiQuery({
+    name: 'teamIds',
+    required: false,
+    description: 'Filter users in any of these teams (comma-separated IDs)',
+  })
+  @ApiQuery({
+    name: 'roleIds',
+    required: false,
+    description: 'Filter users with any of these roles (comma-separated IDs)',
   })
   @ApiResponse({
     status: 200,
@@ -70,9 +81,13 @@ export class UsersController {
   })
   @Get()
   async findAll(
-    @Query('search') search?: string
+    @Query('search') search?: string,
+    @Query('teamIds') teamIdsParam?: string,
+    @Query('roleIds') roleIdsParam?: string
   ): Promise<{ success: boolean; data: UserListItem[] }> {
-    const data = await this.usersService.findAll(search);
+    const teamIds = parseCommaSeparatedIds(teamIdsParam);
+    const roleIds = parseCommaSeparatedIds(roleIdsParam);
+    const data = await this.usersService.findAll(search, teamIds, roleIds);
     return { success: true, data };
   }
 

--- a/calendar-service/src/users/users.service.ts
+++ b/calendar-service/src/users/users.service.ts
@@ -50,13 +50,35 @@ export class UsersService {
     });
   }
 
-  async findAll(search?: string): Promise<UserListItem[]> {
+  async findAll(
+    search?: string,
+    teamIds?: number[],
+    roleIds?: number[]
+  ): Promise<UserListItem[]> {
     const conditions = [];
     if (search?.trim()) {
       const term = `%${search.trim().toLowerCase()}%`;
       conditions.push(
         sql`(lower(${users.adDisplayName}) like ${term} OR lower(${users.adUsername}) like ${term} OR lower(${users.adEmail}) like ${term})`
       );
+    }
+    if (roleIds?.length) {
+      conditions.push(inArray(users.roleId, roleIds));
+    }
+    if (teamIds && teamIds.length > 0) {
+      const filterTeamIds = teamIds;
+      const userIdsInTeams = await this.databaseService.db
+        .selectDistinct({ userId: userTeams.userId })
+        .from(userTeams)
+        .where(
+          and(
+            inArray(userTeams.teamId, filterTeamIds),
+            eq(userTeams.isActive, true)
+          )
+        );
+      const ids = userIdsInTeams.map((r) => r.userId);
+      if (ids.length === 0) return [];
+      conditions.push(inArray(users.id, ids));
     }
 
     const userRows = await this.databaseService.db
@@ -67,6 +89,7 @@ export class UsersService {
         adEmail: users.adEmail,
         roleId: users.roleId,
         isActive: users.isActive,
+        lastUpdatedDateTime: users.lastUpdatedDateTime,
       })
       .from(users)
       .where(conditions.length ? and(...conditions) : undefined)
@@ -86,13 +109,13 @@ export class UsersService {
       .from(userTeams)
       .where(eq(userTeams.isActive, true));
 
-    const teamIds = [...new Set(teamRows.map((t) => t.teamId))];
+    const distinctTeamIds = [...new Set(teamRows.map((t) => t.teamId))];
     const teamNameRows =
-      teamIds.length > 0
+      distinctTeamIds.length > 0
         ? await this.databaseService.db
             .select({ id: teams.id, name: teams.name })
             .from(teams)
-            .where(inArray(teams.id, teamIds))
+            .where(inArray(teams.id, distinctTeamIds))
         : [];
     const teamNameMap = new Map(teamNameRows.map((t) => [t.id, t.name]));
 
@@ -119,6 +142,11 @@ export class UsersService {
       roleName: roleMap.get(u.roleId) ?? 'Unknown',
       isActive: u.isActive,
       teams: teamsByUser.get(u.id) ?? [],
+      lastUpdatedDateTime: u.lastUpdatedDateTime
+        ? u.lastUpdatedDateTime instanceof Date
+          ? u.lastUpdatedDateTime.toISOString()
+          : String(u.lastUpdatedDateTime)
+        : null,
     }));
   }
 

--- a/calendar-ui/README.md
+++ b/calendar-ui/README.md
@@ -1,3 +1,60 @@
-# bcs-marzipan
-Redefined Corporate Calendar for Hub
+# Calendar UI
 
+Frontend for the Corporate Calendar (bcs-marzipan).
+
+## Stack
+
+- **React 19** + **TypeScript** + **Vite**
+- **Tailwind CSS v4** (with `@tailwindcss/vite`)
+- **Radix UI** primitives (Shadcn-style components in `src/components/ui/`)
+- **TanStack** Query (data) and Table (pagination/sorting)
+- **React Router 7**, **Lucide** icons, **react-hook-form** + **Zod**
+
+## Scripts
+
+| Script       | Command                            | Description                   |
+| ------------ | ---------------------------------- | ----------------------------- |
+| `dev`        | `vite`                             | Dev server                    |
+| `build`      | `tsc && vite build`                | Type-check + production build |
+| `preview`    | `vite preview`                     | Preview production build      |
+| `test`       | `vitest run`                       | Run tests                     |
+| `test:watch` | `vitest`                           | Tests in watch mode           |
+| `test:cov`   | `vitest run --coverage`            | Coverage                      |
+| `lint`       | `eslint "src/**/*.{ts,tsx}" --fix` | Lint + fix                    |
+| `typecheck`  | `tsc --noEmit`                     | Type-check only               |
+
+## CSS globals
+
+Main entry: **`src/styles/globals.css`**.
+
+- **Tailwind** (`@import 'tailwindcss'`) and **tw-animate-css**
+- **BCSans** `@font-face` (Regular, Italic, Light, Bold; woff2)
+- **`:root` / `.dark`** theme variables: semantic tokens (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, etc.), radius, chart/sidebar/link colors
+- **BC Gov brand**: `--bc-blue`, `--bc-blue-light`, `--bc-gold`, `--bc-gold-dark`; `--tabs-underline`, `--link`
+- **Tailwind theme** mapping in `@theme` / `@theme inline` so utilities (`bg-background`, `text-foreground`, etc.) use the CSS vars
+- **Base**: `body` uses BCSans; `body[data-scroll-locked]` overrides Radix scroll-lock margin so layout doesn’t jump
+
+`src/styles/App.css` is legacy; new styles use Tailwind and globals.
+
+## File structure
+
+```
+src/
+  api/           # API clients (axios, react-query usage)
+  components/    # Feature and shared components
+    Table/       # Pagination, summary bar, sort; see README for management-table UX
+    ui/          # Shadcn-style primitives (button, dialog, select, etc.)
+    users/       # User management (filters, modals, tab content)
+    teams/       # Team management
+    admin/       # Lookup/admin UIs
+  contexts/      # Auth and other React context
+  hooks/         # useAuth, useFormLookups, etc.
+  lib/           # utils, form helpers, error handling
+  pages/         # Route-level views (UserManagement, Dashboard, etc.)
+  schemas/       # Zod schemas
+  styles/        # globals.css, App.css
+```
+
+## Docs
+
+- **[Management tables UX](src/components/Table/README.md)** – Sticky header, scrolling, skeleton loading, column widths, filters, sort, and pagination. Users/Teams tables as reference.

--- a/calendar-ui/src/App.tsx
+++ b/calendar-ui/src/App.tsx
@@ -51,7 +51,7 @@ const Settings = lazyWithRetry(() =>
   import('./pages/Settings').then((m) => ({ default: m.Settings }))
 );
 const Users = lazyWithRetry(() =>
-  import('./pages/Users').then((m) => ({ default: m.Users }))
+  import('./pages/UserManagement').then((m) => ({ default: m.Users }))
 );
 
 function App() {

--- a/calendar-ui/src/api/teamsApi.ts
+++ b/calendar-ui/src/api/teamsApi.ts
@@ -1,0 +1,61 @@
+/**
+ * Teams CRUD API for admin (list all including inactive, get, create, update, history).
+ */
+import type {
+  CreateTeamBody,
+  TeamDetail,
+  TeamHistoryEntry,
+  TeamListItem,
+  UpdateTeamBody,
+} from '@corpcal/shared/api/types';
+
+import api from './axios';
+
+export async function fetchTeamsList(
+  activeOnly = true
+): Promise<TeamListItem[]> {
+  const response = await api.get<{
+    success: boolean;
+    data: TeamListItem[];
+  }>('/teams', {
+    params: { activeOnly: activeOnly ? 'true' : 'false' },
+  });
+  return response.data.data;
+}
+
+export async function fetchTeamById(id: number): Promise<TeamDetail | null> {
+  const response = await api.get<{
+    success: boolean;
+    data: TeamDetail | null;
+  }>(`/teams/${id}`);
+  return response.data.data;
+}
+
+export async function createTeam(body: CreateTeamBody): Promise<TeamDetail> {
+  const response = await api.post<{ success: boolean; data: TeamDetail }>(
+    '/teams',
+    body
+  );
+  return response.data.data;
+}
+
+export async function updateTeam(
+  id: number,
+  body: UpdateTeamBody
+): Promise<TeamDetail> {
+  const response = await api.patch<{ success: boolean; data: TeamDetail }>(
+    `/teams/${id}`,
+    body
+  );
+  return response.data.data;
+}
+
+export async function fetchTeamHistory(
+  teamId: number
+): Promise<TeamHistoryEntry[]> {
+  const response = await api.get<{
+    success: boolean;
+    data: TeamHistoryEntry[];
+  }>(`/teams/${teamId}/history`);
+  return response.data.data;
+}

--- a/calendar-ui/src/api/usersApi.ts
+++ b/calendar-ui/src/api/usersApi.ts
@@ -15,11 +15,29 @@ import type {
 
 import api from './axios';
 
-export async function fetchUsers(search?: string): Promise<UserListItem[]> {
-  const params = search ? { search: search.trim() } : {};
+export interface FetchUsersParams {
+  search?: string;
+  teamIds?: number[];
+  roleIds?: number[];
+}
+
+export async function fetchUsers(
+  params?: FetchUsersParams
+): Promise<UserListItem[]> {
+  const search = params?.search?.trim();
+  const teamIds = params?.teamIds?.length
+    ? params.teamIds.join(',')
+    : undefined;
+  const roleIds = params?.roleIds?.length
+    ? params.roleIds.join(',')
+    : undefined;
+  const query: Record<string, string> = {};
+  if (search) query.search = search;
+  if (teamIds) query.teamIds = teamIds;
+  if (roleIds) query.roleIds = roleIds;
   const response = await api.get<{ success: boolean; data: UserListItem[] }>(
     '/users',
-    { params }
+    { params: Object.keys(query).length ? query : undefined }
   );
   return response.data.data;
 }

--- a/calendar-ui/src/components/PageHeader.tsx
+++ b/calendar-ui/src/components/PageHeader.tsx
@@ -18,10 +18,12 @@ export function PageHeader({
   className = '',
 }: PageHeaderProps) {
   return (
-    <div className={`mb-8 flex items-center justify-between ${className}`}>
+    <div
+      className={`${className} mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between`}
+    >
       <div>
-        <h1 className="mb-2 text-3xl font-bold">{title}</h1>
-        {description && <p className="text-muted-foreground">{description}</p>}
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        <p className="text-sm text-slate-600">{description}</p>
       </div>
       {action && <div className="shrink-0">{action}</div>}
     </div>

--- a/calendar-ui/src/components/Table/README.md
+++ b/calendar-ui/src/components/Table/README.md
@@ -1,0 +1,130 @@
+# Management tables UX
+
+This document describes the UX patterns used in the **Users** and **Teams** management tables. The **Users** table is the exemplar; follow its structure (tabs, filters, sort, table summary, table, pagination) when adding or changing similar screens.
+
+## Exemplar reference
+
+- **Page:** `src/pages/UserManagement.tsx` – tabs (Users / Teams), modals, drawers.
+- **Tab content:** `src/components/users/UsersTabContent.tsx` – filters, summary bar, table, pagination.
+- **Filters:** `src/components/users/UserManagementFilters.tsx` – keyword, multi-select filters, sort dropdown.
+
+## Key UX improvements
+
+### 1. Sticky header
+
+The table header stays visible while the body scrolls so column labels remain in view.
+
+```tsx
+<thead className="sticky top-0 z-10 border-b border-slate-200 bg-slate-50 shadow-[0_1px_0_0_rgba(0,0,0,0.05)]">
+```
+
+The scroll container is the **wrapper div** (see below), not the window, so `sticky top-0` is relative to that container.
+
+### 2. Fixed-height scroll container (no layout flicker)
+
+The table lives in a fixed-height wrapper so the header and chrome don’t jump when data loads or changes. Only the tbody content scrolls.
+
+```tsx
+const TABLE_SCROLL_HEIGHT = 'min(480px, 60vh)';
+
+<div
+  className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white"
+  style={{ height: TABLE_SCROLL_HEIGHT }}
+>
+  <div ref={tableScrollRef} className="min-h-0 flex-1 overflow-auto">
+    <table className="w-full min-w-[640px] table-fixed border-collapse" ...>
+```
+
+- Outer div: fixed height, `overflow-hidden`, flex column.
+- Inner div: `min-h-0 flex-1 overflow-auto` so it takes remaining space and scrolls. Use a ref on this element for scroll control (e.g. scroll-to-top on page change).
+
+### 3. Scroll-to-top on explicit page/size changes
+
+When the user changes page or page size, scroll the table body back to the top so they see the new page from the start.
+
+```tsx
+const tableScrollRef = useRef<HTMLDivElement>(null);
+
+<TablePagination
+  onPageChange={(p) => {
+    setPagination((prev) => ({ ...prev, pageIndex: p - 1 }));
+    tableScrollRef.current?.scrollTo({ top: 0 });
+  }}
+  onPageSizeChange={(ps) => {
+    setPagination((prev) => ({ ...prev, pageSize: ps, pageIndex: 0 }));
+    tableScrollRef.current?.scrollTo({ top: 0 });
+  }}
+  ...
+/>
+```
+
+### 4. Skeleton rows while loading
+
+Show a fixed number of skeleton rows in the tbody during the initial fetch so the table doesn’t pop from empty to full. Match column count and approximate cell widths for a stable layout.
+
+```tsx
+const SKELETON_ROW_COUNT = 8;
+
+{isLoading ? (
+  Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+    <tr key={i} className="border-b border-slate-100" aria-hidden>
+      <td className="px-4 py-3"><Skeleton className="h-5 w-28" /></td>
+      ...
+    </tr>
+  ))
+) : (
+  // data rows or empty state
+)}
+```
+
+Use `aria-hidden` on skeleton rows so they’re ignored by assistive tech.
+
+### 5. Percentage column widths (no width jump)
+
+Use `table-fixed` plus a `<colgroup>` with percentage widths so column widths don’t change when content or filters change.
+
+```tsx
+<table
+  className="w-full min-w-[640px] table-fixed border-collapse"
+  role="grid"
+  aria-colcount={TABLE_COLUMN_COUNT}
+>
+  <colgroup>
+    <col style={{ width: '16%' }} />
+    <col style={{ width: '20%' }} />
+    ...
+  </colgroup>
+  <thead>...</thead>
+  <tbody>...</tbody>
+</table>
+```
+
+Set `TABLE_COLUMN_COUNT` to the number of columns and use it for empty-state `colSpan`.
+
+### 6. Structure order (exemplar: Users tab)
+
+1. **Filters** – e.g. `UserManagementFilters` / `TeamManagementFilters`: keyword, dropdowns, sort.
+2. **TableSummaryBar** – “Showing N users” and optional checkboxes (e.g. “Show inactive”).
+3. **Table container** – fixed height, scroll div, table with sticky header and percentage cols.
+4. **TablePagination** – only when there is at least one item; wire `onPageChange` / `onPageSizeChange` and scroll ref as above.
+
+### 7. Sort
+
+- Use `SortIndicator` in sortable `<th>` cells; pass `sortKey`, `sortDirection`, and column id.
+- Drive sort state from the parent (e.g. `UsersTabContent`) and pass a single `onSortChange(key, direction)` to the filters component, which can use `SortDropdown` or equivalent.
+
+### 8. Accessibility
+
+- `role="grid"` and `aria-colcount` on the table.
+- Pagination: `aria-label` (e.g. “Users table pagination”), `aria-current="page"` on the current page button.
+- Skeleton rows: `aria-hidden`.
+- Empty state: one cell with `colSpan={TABLE_COLUMN_COUNT}` and clear message.
+
+## Related components
+
+| Component         | Purpose                                       |
+| ----------------- | --------------------------------------------- |
+| `TablePagination` | Page nav, page-size selector, scroll callback |
+| `TableSummaryBar` | “Showing N items” + optional boolean filters  |
+| `SortIndicator`   | Arrow in header for active sort column        |
+| `SortDropdown`    | Used inside filter bars for sort selection    |

--- a/calendar-ui/src/components/Table/SortDropdown.tsx
+++ b/calendar-ui/src/components/Table/SortDropdown.tsx
@@ -1,0 +1,110 @@
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronDown } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+export interface SortColumnConfig {
+  id: string;
+  label: string;
+  defaultDirection?: 'asc' | 'desc';
+}
+
+interface SortDropdownProps {
+  columns: SortColumnConfig[];
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  /** Default sort when none selected (used for initial display). */
+  defaultSortKey: string;
+  defaultSortDirection: 'asc' | 'desc';
+  triggerClassName?: string;
+  ariaLabel?: string;
+}
+
+function directionLabel(
+  column: SortColumnConfig,
+  direction: 'asc' | 'desc'
+): string {
+  const isDateLike = column.defaultDirection === 'desc';
+  if (isDateLike) {
+    return direction === 'desc' ? 'Newest' : 'Oldest';
+  }
+  return direction === 'asc' ? 'A–Z' : 'Z–A';
+}
+
+export function SortDropdown({
+  columns,
+  sortKey,
+  sortDirection,
+  onSortChange,
+  defaultSortKey,
+  defaultSortDirection,
+  triggerClassName,
+  ariaLabel = 'Sort by',
+}: SortDropdownProps) {
+  const effectiveKey = sortKey ?? defaultSortKey;
+  const effectiveDirection =
+    sortKey !== null ? sortDirection : defaultSortDirection;
+  const activeColumn = columns.find((c) => c.id === effectiveKey);
+  const triggerLabel = activeColumn
+    ? `${activeColumn.label} ${directionLabel(activeColumn, effectiveDirection)}`
+    : 'Sort by';
+
+  const handleSelect = (col: SortColumnConfig) => {
+    const isActive = effectiveKey === col.id;
+    if (isActive) {
+      onSortChange(col.id, effectiveDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      onSortChange(col.id, col.defaultDirection ?? 'asc');
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            'h-10 min-w-[140px] justify-between gap-2',
+            triggerClassName
+          )}
+          aria-label={
+            activeColumn
+              ? `${ariaLabel} ${activeColumn.label}, ${effectiveDirection === 'asc' ? 'ascending' : 'descending'}`
+              : ariaLabel
+          }
+        >
+          <ArrowUpDown className="h-4 w-4 shrink-0" />
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {columns.map((col) => {
+          const isActive = effectiveKey === col.id;
+          const direction = isActive
+            ? effectiveDirection
+            : (col.defaultDirection ?? 'asc');
+          const SortIcon = direction === 'asc' ? ArrowUp : ArrowDown;
+          return (
+            <DropdownMenuItem key={col.id} onSelect={() => handleSelect(col)}>
+              {isActive ? (
+                <SortIcon className="h-4 w-4 shrink-0" aria-hidden />
+              ) : (
+                <span className="w-4 shrink-0" aria-hidden />
+              )}
+              {col.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/Table/SortIndicator.tsx
+++ b/calendar-ui/src/components/Table/SortIndicator.tsx
@@ -1,0 +1,29 @@
+import { ArrowDown, ArrowUp } from 'lucide-react';
+
+interface SortIndicatorProps {
+  columnId: string;
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  className?: string;
+}
+
+/**
+ * Renders an up or down arrow when this column is the active sort column; otherwise returns null.
+ * Use next to table header content to show current sort state.
+ */
+export function SortIndicator({
+  columnId,
+  sortKey,
+  sortDirection,
+  className,
+}: SortIndicatorProps) {
+  if (sortKey !== columnId) return null;
+  const Icon = sortDirection === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <Icon
+      className={className}
+      aria-hidden
+      aria-label={`Sorted ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+    />
+  );
+}

--- a/calendar-ui/src/components/Table/TablePagination.tsx
+++ b/calendar-ui/src/components/Table/TablePagination.tsx
@@ -1,0 +1,187 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+const DEFAULT_PAGE_SIZE = 10;
+
+export interface TablePaginationProps {
+  /** Total number of items across all pages */
+  totalItems: number;
+  /** Current 1-based page index */
+  page: number;
+  /** Number of items per page */
+  pageSize: number;
+  /** Called when user changes page (1-based) */
+  onPageChange: (page: number) => void;
+  /** Called when user changes page size */
+  onPageSizeChange: (pageSize: number) => void;
+  /** Options for "results per page" dropdown. Defaults to [10, 25, 50, 100] */
+  pageSizeOptions?: readonly number[];
+  /** Accessible label for the pagination region */
+  'aria-label'?: string;
+  className?: string;
+}
+
+/**
+ * Returns an array of page numbers and ellipsis markers to display.
+ * e.g. [1, 2, 3, 'ellipsis', 16] or [1, 'ellipsis', 5, 6, 7, 'ellipsis', 16]
+ */
+function getPageNumbersToShow(
+  currentPage: number,
+  totalPages: number,
+  maxVisible: number = 5
+): (number | 'ellipsis')[] {
+  if (totalPages <= 0) return [];
+  if (totalPages <= maxVisible) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const pages: (number | 'ellipsis')[] = [];
+  const half = Math.floor(maxVisible / 2);
+
+  let start = Math.max(1, currentPage - half);
+  const end = Math.min(totalPages, start + maxVisible - 1);
+  if (end - start + 1 < maxVisible) {
+    start = Math.max(1, end - maxVisible + 1);
+  }
+
+  if (start > 1) {
+    pages.push(1);
+    if (start > 2) pages.push('ellipsis');
+  }
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+  if (end < totalPages) {
+    if (end < totalPages - 1) pages.push('ellipsis');
+    pages.push(totalPages);
+  }
+  return pages;
+}
+
+export function TablePagination({
+  totalItems,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  'aria-label': ariaLabel = 'Table pagination',
+  className,
+}: TablePaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const currentPage = Math.max(1, Math.min(page, totalPages));
+  const pageNumbers = getPageNumbersToShow(currentPage, totalPages);
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  const handlePrev = () => {
+    if (hasPrev) onPageChange(currentPage - 1);
+  };
+
+  const handleNext = () => {
+    if (hasNext) onPageChange(currentPage + 1);
+  };
+
+  return (
+    <div
+      role="navigation"
+      aria-label={ariaLabel}
+      className={cn(
+        'flex flex-wrap items-center justify-center gap-4 py-3 sm:justify-between',
+        className
+      )}
+    >
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handlePrev}
+          disabled={!hasPrev}
+          aria-label="Previous page"
+          className="h-9 px-2"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="ml-1">Prev</span>
+        </Button>
+        <div className="flex items-center gap-0.5">
+          {pageNumbers.map((item, idx) =>
+            item === 'ellipsis' ? (
+              <span
+                key={`ellipsis-${idx}`}
+                className="flex h-9 min-w-9 items-center justify-center px-2 text-slate-500"
+                aria-hidden
+              >
+                ...
+              </span>
+            ) : (
+              <Button
+                key={item}
+                variant="ghost"
+                size="sm"
+                onClick={() => onPageChange(item)}
+                aria-label={`Page ${item}`}
+                aria-current={item === currentPage ? 'page' : undefined}
+                className={cn(
+                  'relative h-9 min-w-9 px-2 font-normal',
+                  item === currentPage &&
+                    'text-primary bg-transparent font-medium'
+                )}
+              >
+                {item}
+                {item === currentPage && (
+                  <span
+                    className="bg-primary absolute right-2 bottom-0 left-2 h-0.5 rounded-full"
+                    aria-hidden
+                  />
+                )}
+              </Button>
+            )
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleNext}
+          disabled={!hasNext}
+          aria-label="Next page"
+          className="h-9 px-2"
+        >
+          <span className="mr-1">Next</span>
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-slate-600">
+        <span>Show</span>
+        <Select
+          value={String(pageSize)}
+          onValueChange={(v) => onPageSizeChange(Number(v))}
+        >
+          <SelectTrigger className="h-9 w-18" aria-label="Results per page">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {pageSizeOptions.map((size) => (
+              <SelectItem key={size} value={String(size)}>
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span>results per page</span>
+      </div>
+    </div>
+  );
+}
+
+export { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE_OPTIONS };

--- a/calendar-ui/src/components/Table/TableSummaryBar.tsx
+++ b/calendar-ui/src/components/Table/TableSummaryBar.tsx
@@ -1,0 +1,58 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+
+export interface BooleanFilter {
+  id: string;
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+interface TableSummaryBarProps {
+  count: number;
+  singularLabel: string;
+  pluralLabel?: string;
+  filters?: BooleanFilter[];
+  className?: string;
+}
+
+export function TableSummaryBar({
+  count,
+  singularLabel,
+  pluralLabel,
+  filters = [],
+  className,
+}: TableSummaryBarProps) {
+  const label =
+    count === 1 ? singularLabel : (pluralLabel ?? singularLabel + 's');
+
+  return (
+    <div
+      className={cn(
+        'mb-2 flex flex-wrap items-center justify-between gap-4 text-sm text-slate-500',
+        className
+      )}
+    >
+      <span>
+        Showing {count} {label}
+      </span>
+      {filters.length > 0 && (
+        <div className="flex flex-wrap items-center gap-4">
+          {filters.map((filter) => (
+            <label
+              key={filter.id}
+              className="flex cursor-pointer items-center gap-2 text-sm text-slate-500"
+            >
+              <Checkbox
+                checked={filter.checked}
+                onCheckedChange={(v) => filter.onCheckedChange(v === true)}
+                aria-label={filter.label}
+              />
+              {filter.label}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/calendar-ui/src/components/Table/TableSummaryBar.tsx
+++ b/calendar-ui/src/components/Table/TableSummaryBar.tsx
@@ -29,7 +29,7 @@ export function TableSummaryBar({
   return (
     <div
       className={cn(
-        'mb-2 flex flex-wrap items-center justify-between gap-4 text-sm text-slate-500',
+        'mb-2 flex flex-wrap items-center justify-between gap-4 text-sm text-stone-500',
         className
       )}
     >
@@ -41,12 +41,13 @@ export function TableSummaryBar({
           {filters.map((filter) => (
             <label
               key={filter.id}
-              className="flex cursor-pointer items-center gap-2 text-sm text-slate-500"
+              className="flex cursor-pointer items-center gap-2 text-sm text-stone-500"
             >
               <Checkbox
                 checked={filter.checked}
                 onCheckedChange={(v) => filter.onCheckedChange(v === true)}
                 aria-label={filter.label}
+                className="border-stone-500"
               />
               {filter.label}
             </label>

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -1,0 +1,230 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
+import { fetchMinistries } from '@/api/lookupsApi';
+import { createTeam, fetchTeamById, updateTeam } from '@/api/teamsApi';
+import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+
+interface TeamEditModalProps {
+  /** When null, modal is in create mode. Otherwise edit mode for this team. */
+  team: TeamListItem | null;
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function TeamEditModal({
+  team,
+  open,
+  onClose,
+  onSaved,
+}: TeamEditModalProps) {
+  const isCreate = team === null;
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isActive, setIsActive] = useState(true);
+  const [ministryIds, setMinistryIds] = useState<string[]>([]);
+
+  const { data: detail, isLoading: isLoadingDetail } =
+    useQuery<TeamDetail | null>({
+      queryKey: ['team', team?.id],
+      queryFn: () => (team ? fetchTeamById(team.id) : Promise.resolve(null)),
+      enabled: open && !!team?.id,
+    });
+
+  const { data: ministries = [] } = useQuery({
+    queryKey: ['lookups', 'ministries'],
+    queryFn: fetchMinistries,
+    enabled: open,
+  });
+
+  const ministryOptions = useMemo(
+    () =>
+      ministries.map((m) => ({
+        value: String(m.id),
+        label: m.displayName ?? m.name ?? String(m.id),
+      })),
+    [ministries]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    if (isCreate) {
+      setName('');
+      setDisplayName('');
+      setDescription('');
+      setIsActive(true);
+      setMinistryIds([]);
+    } else if (detail) {
+      setName(detail.name);
+      setDisplayName(detail.displayName ?? '');
+      setDescription(detail.description ?? '');
+      setIsActive(detail.isActive);
+      setMinistryIds(detail.ministries.map((m) => String(m.ministryId)));
+    }
+  }, [open, isCreate, detail]);
+
+  const createMutation = useMutation({
+    mutationFn: createTeam,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      toast.success('Team created');
+      onSaved();
+      onClose();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to create team');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: number;
+      body: Parameters<typeof updateTeam>[1];
+    }) => updateTeam(id, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      toast.success('Team updated');
+      onSaved();
+      onClose();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to update team');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      toast.error('Name is required');
+      return;
+    }
+    if (isCreate) {
+      createMutation.mutate({
+        name: trimmedName,
+        displayName: displayName.trim() || undefined,
+        description: description.trim() || undefined,
+        isActive,
+        ministryIds: ministryIds.length ? ministryIds : undefined,
+      });
+    } else if (team) {
+      updateMutation.mutate({
+        id: team.id,
+        body: {
+          name: trimmedName,
+          displayName: displayName.trim() || undefined,
+          description: description.trim() || undefined,
+          isActive,
+          ministryIds: ministryIds.length ? ministryIds : undefined,
+        },
+      });
+    }
+  };
+
+  const handleMinistryToggle = (value: string) => {
+    setMinistryIds((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
+  };
+
+  const isLoading = !isCreate && isLoadingDetail;
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isCreate ? 'Create team' : 'Edit team'}</DialogTitle>
+        </DialogHeader>
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="team-name">Name *</Label>
+              <Input
+                id="team-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Team name"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="team-display-name">Display name</Label>
+              <Input
+                id="team-display-name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Short or display name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="team-description">Description</Label>
+              <Textarea
+                id="team-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description"
+                rows={3}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="team-active"
+                checked={isActive}
+                onCheckedChange={setIsActive}
+              />
+              <Label htmlFor="team-active">Active</Label>
+            </div>
+            <div className="space-y-2">
+              <Label>Ministries</Label>
+              <Combobox
+                options={ministryOptions}
+                selectedValues={ministryIds}
+                onSelect={handleMinistryToggle}
+                placeholder="Select ministries..."
+                searchPlaceholder="Search ministries..."
+                emptyMessage="No ministries found."
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                {isCreate ? 'Create' : 'Save'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/calendar-ui/src/components/teams/TeamHistoryDrawer.tsx
+++ b/calendar-ui/src/components/teams/TeamHistoryDrawer.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+
+import type { TeamHistoryEntry, TeamListItem } from '@corpcal/shared/api/types';
+import { fetchTeamHistory } from '@/api/teamsApi';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface TeamHistoryDrawerProps {
+  team: TeamListItem | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+function formatHistoryValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value);
+  return JSON.stringify(value);
+}
+
+function ChangeList({ changes }: { changes: TeamHistoryEntry['changes'] }) {
+  if (!changes || changes.length === 0) return null;
+  return (
+    <ul className="mt-1 list-inside list-disc text-sm text-slate-600">
+      {changes.map((c, i) => (
+        <li key={i}>
+          <span className="font-medium">{c.field}</span>:{' '}
+          {formatHistoryValue(c.oldValue)} → {formatHistoryValue(c.newValue)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function TeamHistoryDrawer({
+  team,
+  open,
+  onClose,
+}: TeamHistoryDrawerProps) {
+  const { data: history = [], isLoading } = useQuery({
+    queryKey: ['teamHistory', team?.id],
+    queryFn: () => (team ? fetchTeamHistory(team.id) : Promise.resolve([])),
+    enabled: open && !!team?.id,
+  });
+
+  const title = team
+    ? team.displayName || team.name || `Team ${team.id}`
+    : 'Team';
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[80vh] w-full max-w-xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>History: {title}</DialogTitle>
+        </DialogHeader>
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {history.length === 0 ? (
+              <p className="text-slate-500">No history entries.</p>
+            ) : (
+              history.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                >
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium text-slate-900">
+                      {entry.actionType.replace(/_/g, ' ')}
+                    </span>
+                    <span className="text-slate-500">
+                      {entry.timestamp
+                        ? new Date(entry.timestamp).toLocaleString()
+                        : ''}
+                    </span>
+                  </div>
+                  {entry.changedByUserName && (
+                    <p className="mt-1 text-xs text-slate-600">
+                      By {entry.changedByUserName}
+                    </p>
+                  )}
+                  <ChangeList changes={entry.changes} />
+                  {entry.notes && (
+                    <p className="mt-2 text-sm text-slate-600">{entry.notes}</p>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        )}
+        <div className="mt-4 flex justify-end">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/calendar-ui/src/components/teams/TeamManagementFilters.tsx
+++ b/calendar-ui/src/components/teams/TeamManagementFilters.tsx
@@ -1,0 +1,72 @@
+import { Search } from 'lucide-react';
+
+import {
+  SortDropdown,
+  type SortColumnConfig,
+} from '@/components/Table/SortDropdown';
+import { Input } from '@/components/ui/input';
+
+const TEAM_SORT_COLUMNS: SortColumnConfig[] = [
+  { id: 'displayName', label: 'Display name', defaultDirection: 'asc' },
+  { id: 'members', label: 'Members', defaultDirection: 'asc' },
+];
+
+interface TeamManagementFiltersProps {
+  keyword: string;
+  onKeywordChange: (value: string) => void;
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  defaultSortKey: string;
+  defaultSortDirection: 'asc' | 'desc';
+  className?: string;
+}
+
+/**
+ * Filter bar for the Teams table: keyword search and sort dropdown.
+ * Matches the style and layout of UserManagementFilters (search + sort on the right).
+ */
+export function TeamManagementFilters({
+  keyword,
+  onKeywordChange,
+  sortKey,
+  sortDirection,
+  onSortChange,
+  defaultSortKey,
+  defaultSortDirection,
+  className,
+}: TeamManagementFiltersProps) {
+  return (
+    <div
+      className={className}
+      role="search"
+      aria-label="Filter teams by keyword and sort"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center gap-2" />
+        <div className="flex items-center gap-2">
+          <div className="relative max-w-md min-w-[240px] flex-1">
+            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              placeholder="Search teams..."
+              value={keyword}
+              onChange={(e) => onKeywordChange(e.target.value)}
+              className="pl-8"
+              aria-label="Keyword search"
+            />
+          </div>
+          <SortDropdown
+            columns={TEAM_SORT_COLUMNS}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={onSortChange}
+            defaultSortKey={defaultSortKey}
+            defaultSortDirection={defaultSortDirection}
+            ariaLabel="Sort by"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -1,10 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
+import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type ColumnDef,
+} from '@tanstack/react-table';
 import { History, MoreHorizontal, Pencil } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import type { TeamListItem } from '@corpcal/shared/api/types';
 import { fetchTeamsList } from '@/api/teamsApi';
 import { SortIndicator } from '@/components/Table/SortIndicator';
+import { TablePagination } from '@/components/Table/TablePagination';
 import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { TeamManagementFilters } from '@/components/teams/TeamManagementFilters';
 import { Button } from '@/components/ui/button';
@@ -22,6 +29,7 @@ const TABLE_COLUMN_COUNT = 6;
 
 const DEFAULT_SORT_KEY = 'displayName';
 const DEFAULT_SORT_DIRECTION = 'asc' as const;
+const DEFAULT_PAGE_SIZE = 10;
 
 type TeamSortKey = 'displayName' | 'members';
 
@@ -84,6 +92,11 @@ export function TeamsTabContent({
     DEFAULT_SORT_DIRECTION
   );
   const [showInactive, setShowInactive] = useState(false);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+  const tableScrollRef = useRef<HTMLDivElement>(null);
 
   const { data: teams = [], isLoading } = useQuery({
     queryKey: ['teams', 'list', showInactive],
@@ -108,6 +121,24 @@ export function TeamsTabContent({
     const dir = sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
     return [...filteredTeams].sort((a, b) => compareTeams(a, b, key, dir));
   }, [filteredTeams, sortKey, sortDirection]);
+
+  const teamColumns = useMemo<ColumnDef<TeamListItem>[]>(
+    () => [{ id: '_', header: () => null, cell: () => null }],
+    []
+  );
+
+  const table = useReactTable({
+    data: sortedTeams,
+    columns: teamColumns,
+    getRowId: (row) => String(row.id),
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: { pagination },
+    onPaginationChange: setPagination,
+    autoResetPageIndex: true,
+  });
+
+  const pageRows = table.getRowModel().rows.map((row) => row.original);
 
   const handleSortChange = (key: string | null, direction: 'asc' | 'desc') => {
     setSortKey(key as TeamSortKey | null);
@@ -144,7 +175,7 @@ export function TeamsTabContent({
         className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white"
         style={{ height: TABLE_SCROLL_HEIGHT }}
       >
-        <div className="min-h-0 flex-1 overflow-auto">
+        <div ref={tableScrollRef} className="min-h-0 flex-1 overflow-auto">
           <table
             className="w-full min-w-[640px] table-fixed border-collapse"
             role="grid"
@@ -242,7 +273,7 @@ export function TeamsTabContent({
                   </td>
                 </tr>
               ) : (
-                sortedTeams.map((team) => (
+                pageRows.map((team) => (
                   <tr
                     key={team.id}
                     className="border-b border-slate-100 hover:bg-slate-50/50"
@@ -303,6 +334,22 @@ export function TeamsTabContent({
           </table>
         </div>
       </div>
+      {sortedTeams.length > 0 && (
+        <TablePagination
+          totalItems={sortedTeams.length}
+          page={pagination.pageIndex + 1}
+          pageSize={pagination.pageSize}
+          onPageChange={(p) => {
+            setPagination((prev) => ({ ...prev, pageIndex: p - 1 }));
+            tableScrollRef.current?.scrollTo({ top: 0 });
+          }}
+          onPageSizeChange={(ps) => {
+            setPagination((prev) => ({ ...prev, pageSize: ps, pageIndex: 0 }));
+            tableScrollRef.current?.scrollTo({ top: 0 });
+          }}
+          aria-label="Teams table pagination"
+        />
+      )}
     </div>
   );
 }

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { History, Loader2, MoreHorizontal, Pencil } from 'lucide-react';
-import { useState } from 'react';
+import { History, MoreHorizontal, Pencil } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import type { TeamListItem } from '@corpcal/shared/api/types';
 import { fetchTeamsList } from '@/api/teamsApi';
+import { SortIndicator } from '@/components/Table/SortIndicator';
 import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
+import { TeamManagementFilters } from '@/components/teams/TeamManagementFilters';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -12,6 +14,36 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const TABLE_SCROLL_HEIGHT = 'min(480px, 60vh)';
+const SKELETON_ROW_COUNT = 8;
+const TABLE_COLUMN_COUNT = 6;
+
+const DEFAULT_SORT_KEY = 'displayName';
+const DEFAULT_SORT_DIRECTION = 'asc' as const;
+
+type TeamSortKey = 'displayName' | 'members';
+
+function compareTeams(
+  a: TeamListItem,
+  b: TeamListItem,
+  sortKey: TeamSortKey,
+  direction: 'asc' | 'desc'
+): number {
+  const mult = direction === 'asc' ? 1 : -1;
+  switch (sortKey) {
+    case 'displayName': {
+      const na = (a.displayName ?? a.name ?? '').toLowerCase();
+      const nb = (b.displayName ?? b.name ?? '').toLowerCase();
+      return mult * na.localeCompare(nb);
+    }
+    case 'members':
+      return mult * (a.memberCount - b.memberCount);
+    default:
+      return 0;
+  }
+}
 
 interface TeamsTabContentProps {
   canCreate: boolean;
@@ -46,6 +78,11 @@ export function TeamsTabContent({
   onViewHistory,
   onDeactivate,
 }: TeamsTabContentProps) {
+  const [keyword, setKeyword] = useState('');
+  const [sortKey, setSortKey] = useState<TeamSortKey | null>(DEFAULT_SORT_KEY);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
+    DEFAULT_SORT_DIRECTION
+  );
   const [showInactive, setShowInactive] = useState(false);
 
   const { data: teams = [], isLoading } = useQuery({
@@ -53,10 +90,45 @@ export function TeamsTabContent({
     queryFn: () => fetchTeamsList(!showInactive),
   });
 
+  const filteredTeams = useMemo(() => {
+    if (!keyword.trim()) return teams;
+    const q = keyword.trim().toLowerCase();
+    return teams.filter((team) => {
+      const displayName = (team.displayName ?? '').toLowerCase();
+      const name = (team.name ?? '').toLowerCase();
+      const description = (team.description ?? '').toLowerCase();
+      return (
+        displayName.includes(q) || name.includes(q) || description.includes(q)
+      );
+    });
+  }, [teams, keyword]);
+
+  const sortedTeams = useMemo(() => {
+    const key = sortKey ?? DEFAULT_SORT_KEY;
+    const dir = sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
+    return [...filteredTeams].sort((a, b) => compareTeams(a, b, key, dir));
+  }, [filteredTeams, sortKey, sortDirection]);
+
+  const handleSortChange = (key: string | null, direction: 'asc' | 'desc') => {
+    setSortKey(key as TeamSortKey | null);
+    setSortDirection(direction);
+  };
+
   return (
     <div className="space-y-4">
+      <TeamManagementFilters
+        keyword={keyword}
+        onKeywordChange={setKeyword}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
+        defaultSortKey={DEFAULT_SORT_KEY}
+        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        className="mb-4"
+      />
+
       <TableSummaryBar
-        count={teams.length}
+        count={sortedTeams.length}
         singularLabel="team"
         pluralLabel="teams"
         filters={[
@@ -68,26 +140,58 @@ export function TeamsTabContent({
           },
         ]}
       />
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-        </div>
-      ) : (
-        <div className="rounded-lg border border-slate-200 bg-white">
-          <table className="w-full table-auto border-collapse">
-            <thead>
-              <tr className="border-b border-slate-200 bg-slate-50">
+      <div
+        className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white"
+        style={{ height: TABLE_SCROLL_HEIGHT }}
+      >
+        <div className="min-h-0 flex-1 overflow-auto">
+          <table
+            className="w-full min-w-[640px] table-fixed border-collapse"
+            role="grid"
+            aria-colcount={TABLE_COLUMN_COUNT}
+          >
+            <colgroup>
+              <col style={{ width: '22%' }} />
+              <col style={{ width: '30%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '12%' }} />
+            </colgroup>
+            <thead className="sticky top-0 z-10 border-b border-slate-200 bg-slate-50 shadow-[0_1px_0_0_rgba(0,0,0,0.05)]">
+              <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Name
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Display name
+                  <span className="inline-flex items-center gap-1">
+                    Display name
+                    <SortIndicator
+                      columnId="displayName"
+                      sortKey={sortKey}
+                      sortDirection={
+                        sortKey !== null
+                          ? sortDirection
+                          : DEFAULT_SORT_DIRECTION
+                      }
+                      className="h-4 w-4"
+                    />
+                  </span>
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Description
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Members
+                  <span className="inline-flex items-center gap-1">
+                    Members
+                    <SortIndicator
+                      columnId="members"
+                      sortKey={sortKey}
+                      sortDirection={
+                        sortKey !== null
+                          ? sortDirection
+                          : DEFAULT_SORT_DIRECTION
+                      }
+                      className="h-4 w-4"
+                    />
+                  </span>
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Ministries
@@ -95,82 +199,110 @@ export function TeamsTabContent({
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Status
                 </th>
-                <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Actions
                 </th>
               </tr>
             </thead>
             <tbody>
-              {teams.map((team) => (
-                <tr
-                  key={team.id}
-                  className="border-b border-slate-100 hover:bg-slate-50/50"
-                >
-                  <td className="px-4 py-3 font-medium text-slate-900">
-                    {team.name}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {team.displayName ?? '-'}
-                  </td>
-                  <td className="max-w-[200px] truncate px-4 py-3 text-slate-600">
-                    {team.description ?? '-'}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {team.memberCount}{' '}
-                    {team.memberCount === 1 ? 'member' : 'members'}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {team.ministryCount}{' '}
-                    {team.ministryCount === 1 ? 'ministry' : 'ministries'}
-                  </td>
-                  <td className="px-4 py-3">{statusBadge(team.isActive)}</td>
-                  <td className="px-4 py-3">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8"
-                          aria-label="Actions"
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        {canEdit && (
-                          <DropdownMenuItem onClick={() => onEditTeam(team)}>
-                            <Pencil className="h-4 w-4" />
-                            Edit
-                          </DropdownMenuItem>
-                        )}
-                        <DropdownMenuItem onClick={() => onViewHistory(team)}>
-                          <History className="h-4 w-4" />
-                          View history
-                        </DropdownMenuItem>
-                        {canDelete && team.isActive && onDeactivate && (
-                          <DropdownMenuItem
-                            onClick={() => onDeactivate(team)}
-                            variant="destructive"
-                          >
-                            Deactivate
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+              {isLoading ? (
+                Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+                  <tr key={i} className="border-b border-slate-100" aria-hidden>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-32" />
+                    </td>
+                    <td className="max-w-[200px] px-4 py-3">
+                      <Skeleton className="h-5 w-full max-w-[180px]" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-16" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-20" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-14" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-8 w-8 rounded" />
+                    </td>
+                  </tr>
+                ))
+              ) : sortedTeams.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={TABLE_COLUMN_COUNT}
+                    className="px-4 py-12 text-center text-slate-500"
+                  >
+                    {keyword.trim()
+                      ? 'No teams match your search'
+                      : showInactive
+                        ? 'No teams found'
+                        : 'No active teams. Show inactive to see all.'}
                   </td>
                 </tr>
-              ))}
+              ) : (
+                sortedTeams.map((team) => (
+                  <tr
+                    key={team.id}
+                    className="border-b border-slate-100 hover:bg-slate-50/50"
+                  >
+                    <td className="px-4 py-3 font-medium text-slate-900">
+                      {team.displayName ?? team.name ?? '-'}
+                    </td>
+                    <td className="max-w-[200px] truncate px-4 py-3 text-slate-600">
+                      {team.description ?? '-'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {team.memberCount}{' '}
+                      {team.memberCount === 1 ? 'member' : 'members'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {team.ministryCount}{' '}
+                      {team.ministryCount === 1 ? 'ministry' : 'ministries'}
+                    </td>
+                    <td className="px-4 py-3">{statusBadge(team.isActive)}</td>
+                    <td className="px-4 py-3">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            aria-label="Actions"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {canEdit && (
+                            <DropdownMenuItem onClick={() => onEditTeam(team)}>
+                              <Pencil className="h-4 w-4" />
+                              Edit
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem onClick={() => onViewHistory(team)}>
+                            <History className="h-4 w-4" />
+                            View history
+                          </DropdownMenuItem>
+                          {canDelete && team.isActive && onDeactivate && (
+                            <DropdownMenuItem
+                              onClick={() => onDeactivate(team)}
+                              variant="destructive"
+                            >
+                              Deactivate
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
-          {teams.length === 0 && (
-            <div className="py-12 text-center text-slate-500">
-              {showInactive
-                ? 'No teams found'
-                : 'No active teams. Show inactive to see all.'}
-            </div>
-          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -38,10 +38,10 @@ function statusBadge(isActive: boolean) {
 }
 
 export function TeamsTabContent({
-  canCreate,
+  // canCreate,
   canEdit,
   canDelete,
-  onAddTeam,
+  // onAddTeam,
   onEditTeam,
   onViewHistory,
   onDeactivate,

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -6,7 +6,7 @@ import {
   type ColumnDef,
 } from '@tanstack/react-table';
 import { History, MoreHorizontal, Pencil } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { TeamListItem } from '@corpcal/shared/api/types';
 import { fetchTeamsList } from '@/api/teamsApi';
@@ -127,6 +127,29 @@ export function TeamsTabContent({
     []
   );
 
+  const onPaginationChangeStable = useCallback(
+    (
+      updaterOrValue:
+        | ((prev: typeof pagination) => typeof pagination)
+        | typeof pagination
+    ) => {
+      setPagination((prev) => {
+        const next =
+          typeof updaterOrValue === 'function'
+            ? updaterOrValue(prev)
+            : updaterOrValue;
+        if (
+          next.pageIndex === prev.pageIndex &&
+          next.pageSize === prev.pageSize
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    },
+    []
+  );
+
   const table = useReactTable({
     data: sortedTeams,
     columns: teamColumns,
@@ -134,7 +157,7 @@ export function TeamsTabContent({
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     state: { pagination },
-    onPaginationChange: setPagination,
+    onPaginationChange: onPaginationChangeStable,
     autoResetPageIndex: true,
   });
 

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -1,0 +1,181 @@
+import { useQuery } from '@tanstack/react-query';
+import { History, Loader2, MoreHorizontal, Pencil, Plus } from 'lucide-react';
+import { useState } from 'react';
+
+import type { TeamListItem } from '@corpcal/shared/api/types';
+import { fetchTeamsList } from '@/api/teamsApi';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface TeamsTabContentProps {
+  canCreate: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  onAddTeam: () => void;
+  onEditTeam: (team: TeamListItem) => void;
+  onViewHistory: (team: TeamListItem) => void;
+  onDeactivate?: (team: TeamListItem) => void;
+}
+
+function statusBadge(isActive: boolean) {
+  return (
+    <span
+      className={
+        isActive
+          ? 'rounded bg-green-100 px-2 py-0.5 text-xs text-green-800'
+          : 'rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600'
+      }
+    >
+      {isActive ? 'Active' : 'Inactive'}
+    </span>
+  );
+}
+
+export function TeamsTabContent({
+  canCreate,
+  canEdit,
+  canDelete,
+  onAddTeam,
+  onEditTeam,
+  onViewHistory,
+  onDeactivate,
+}: TeamsTabContentProps) {
+  const [showInactive, setShowInactive] = useState(false);
+
+  const { data: teams = [], isLoading } = useQuery({
+    queryKey: ['teams', 'list', showInactive],
+    queryFn: () => fetchTeamsList(!showInactive),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <label className="flex items-center gap-2 text-sm text-slate-600">
+          <Checkbox
+            checked={showInactive}
+            onCheckedChange={(v) => setShowInactive(v === true)}
+          />
+          Show inactive
+        </label>
+        {canCreate && (
+          <Button onClick={onAddTeam}>
+            <Plus className="h-4 w-4" />
+            Add team
+          </Button>
+        )}
+      </div>
+      <div className="mb-2 text-sm text-slate-500">
+        {teams.length} {teams.length === 1 ? 'team' : 'teams'}
+      </div>
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+        </div>
+      ) : (
+        <div className="rounded-lg border border-slate-200 bg-white">
+          <table className="w-full table-auto border-collapse">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50">
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Display name
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Description
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Members
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Ministries
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Status
+                </th>
+                <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {teams.map((team) => (
+                <tr
+                  key={team.id}
+                  className="border-b border-slate-100 hover:bg-slate-50/50"
+                >
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    {team.name}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {team.displayName ?? '-'}
+                  </td>
+                  <td className="max-w-[200px] truncate px-4 py-3 text-slate-600">
+                    {team.description ?? '-'}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {team.memberCount}{' '}
+                    {team.memberCount === 1 ? 'member' : 'members'}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {team.ministryCount}{' '}
+                    {team.ministryCount === 1 ? 'ministry' : 'ministries'}
+                  </td>
+                  <td className="px-4 py-3">{statusBadge(team.isActive)}</td>
+                  <td className="px-4 py-3">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          aria-label="Actions"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {canEdit && (
+                          <DropdownMenuItem onClick={() => onEditTeam(team)}>
+                            <Pencil className="h-4 w-4" />
+                            Edit
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuItem onClick={() => onViewHistory(team)}>
+                          <History className="h-4 w-4" />
+                          View history
+                        </DropdownMenuItem>
+                        {canDelete && team.isActive && onDeactivate && (
+                          <DropdownMenuItem
+                            onClick={() => onDeactivate(team)}
+                            variant="destructive"
+                          >
+                            Deactivate
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {teams.length === 0 && (
+            <div className="py-12 text-center text-slate-500">
+              {showInactive
+                ? 'No teams found'
+                : 'No active teams. Show inactive to see all.'}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { History, Loader2, MoreHorizontal, Pencil, Plus } from 'lucide-react';
+import { History, Loader2, MoreHorizontal, Pencil } from 'lucide-react';
 import { useState } from 'react';
 
 import type { TeamListItem } from '@corpcal/shared/api/types';
 import { fetchTeamsList } from '@/api/teamsApi';
+import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,24 +55,19 @@ export function TeamsTabContent({
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <label className="flex items-center gap-2 text-sm text-slate-600">
-          <Checkbox
-            checked={showInactive}
-            onCheckedChange={(v) => setShowInactive(v === true)}
-          />
-          Show inactive
-        </label>
-        {canCreate && (
-          <Button onClick={onAddTeam}>
-            <Plus className="h-4 w-4" />
-            Add team
-          </Button>
-        )}
-      </div>
-      <div className="mb-2 text-sm text-slate-500">
-        {teams.length} {teams.length === 1 ? 'team' : 'teams'}
-      </div>
+      <TableSummaryBar
+        count={teams.length}
+        singularLabel="team"
+        pluralLabel="teams"
+        filters={[
+          {
+            id: 'show-inactive',
+            label: 'Show inactive',
+            checked: showInactive,
+            onCheckedChange: setShowInactive,
+          },
+        ]}
+      />
       {isLoading ? (
         <div className="flex justify-center py-12">
           <Loader2 className="h-8 w-8 animate-spin text-slate-400" />

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -6,7 +6,7 @@ import {
   type ColumnDef,
 } from '@tanstack/react-table';
 import { History, MoreHorizontal, Pencil } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { TeamListItem } from '@corpcal/shared/api/types';
 import { fetchTeamsList } from '@/api/teamsApi';
@@ -23,8 +23,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 
-const TABLE_SCROLL_HEIGHT = 'min(480px, 60vh)';
+const TABLE_SCROLL_HEIGHT = 'max(240px, min(600px, 60vh, 100vh - 400px))';
 const SKELETON_ROW_COUNT = 8;
+const SKELETON_DELAY_MS = 300;
 const TABLE_COLUMN_COUNT = 6;
 
 const DEFAULT_SORT_KEY = 'displayName';
@@ -102,6 +103,19 @@ export function TeamsTabContent({
     queryKey: ['teams', 'list', showInactive],
     queryFn: () => fetchTeamsList(!showInactive),
   });
+
+  const [showSkeleton, setShowSkeleton] = useState(false);
+  useEffect(() => {
+    if (!isLoading) {
+      setShowSkeleton(false);
+      return;
+    }
+    const id = window.setTimeout(
+      () => setShowSkeleton(true),
+      SKELETON_DELAY_MS
+    );
+    return () => window.clearTimeout(id);
+  }, [isLoading]);
 
   const filteredTeams = useMemo(() => {
     if (!keyword.trim()) return teams;
@@ -259,7 +273,7 @@ export function TeamsTabContent({
               </tr>
             </thead>
             <tbody>
-              {isLoading ? (
+              {isLoading && showSkeleton ? (
                 Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
                   <tr key={i} className="border-b border-slate-100" aria-hidden>
                     <td className="px-4 py-3">

--- a/calendar-ui/src/components/ui/button.tsx
+++ b/calendar-ui/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+        link: 'text-link underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/calendar-ui/src/components/ui/skeleton.tsx
+++ b/calendar-ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-accent animate-pulse rounded-md', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/calendar-ui/src/components/ui/tabs.tsx
+++ b/calendar-ui/src/components/ui/tabs.tsx
@@ -24,16 +24,21 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  'rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
+  'rounded-lg data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
   {
     variants: {
       variant: {
         default: 'bg-muted',
         line: 'gap-1 bg-transparent',
       },
+      size: {
+        sm: 'p-[3px] group-data-[orientation=horizontal]/tabs:h-9',
+        med: 'p-1 group-data-[orientation=horizontal]/tabs:h-11',
+      },
     },
     defaultVariants: {
       variant: 'default',
+      size: 'sm',
     },
   }
 );
@@ -41,6 +46,7 @@ const tabsListVariants = cva(
 function TabsList({
   className,
   variant = 'default',
+  size = 'sm',
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List> &
   VariantProps<typeof tabsListVariants>) {
@@ -48,7 +54,8 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       data-variant={variant}
-      className={cn(tabsListVariants({ variant }), className)}
+      data-size={size}
+      className={cn(tabsListVariants({ variant, size }), className)}
       {...props}
     />
   );
@@ -63,9 +70,10 @@ function TabsTrigger({
       data-slot="tabs-trigger"
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[size=med]/tabs-list:px-3 group-data-[size=med]/tabs-list:py-1.5 group-data-[size=med]/tabs-list:text-base group-data-[size=med]/tabs-list:[&_svg:not([class*='size-'])]:size-5",
         'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
         'data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground',
-        'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        'after:bg-tabs-underline after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
         className
       )}
       {...props}

--- a/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
+++ b/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
@@ -1,13 +1,13 @@
 import { ChevronDown, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 
 export interface FilterCheckboxOption {
@@ -36,7 +36,6 @@ export function FilterCheckboxDropdown({
   disabled = false,
   className,
 }: FilterCheckboxDropdownProps) {
-  const [open, setOpen] = useState(false);
   const hasSelection = selectedValues.length > 0;
 
   const handleToggle = useCallback(
@@ -60,8 +59,8 @@ export function FilterCheckboxDropdown({
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button
           variant={hasSelection ? 'default' : 'outline'}
           size="sm"
@@ -75,43 +74,45 @@ export function FilterCheckboxDropdown({
             {hasSelection ? `${label} (${selectedValues.length})` : label}
           </span>
           {hasSelection ? (
-            <button
-              type="button"
+            <span
+              role="button"
+              tabIndex={0}
               onClick={handleClear}
-              className="ml-1 rounded p-0.5 hover:bg-white/20"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onChange([]);
+                }
+              }}
+              className="ml-1 inline-flex cursor-pointer rounded p-0.5 hover:bg-white/20"
               aria-label={`Clear ${label} filter`}
             >
               <X className="h-3.5 w-3.5" />
-            </button>
+            </span>
           ) : (
             <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
           )}
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-56 p-0" align="start">
-        <div className="max-h-64 overflow-auto p-2">
-          {options.length === 0 ? (
-            <p className="text-muted-foreground py-2 text-center text-sm">
-              No options
-            </p>
-          ) : (
-            <div className="space-y-1">
-              {options.map((opt) => (
-                <label
-                  key={opt.value}
-                  className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-                >
-                  <Checkbox
-                    checked={selectedValues.includes(opt.value)}
-                    onCheckedChange={() => handleToggle(opt.value)}
-                  />
-                  <span className="flex-1 truncate">{opt.label}</span>
-                </label>
-              ))}
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-h-64 overflow-auto" align="start">
+        {options.length === 0 ? (
+          <p className="text-muted-foreground py-2 text-center text-sm">
+            No options
+          </p>
+        ) : (
+          options.map((opt) => (
+            <DropdownMenuCheckboxItem
+              key={opt.value}
+              checked={selectedValues.includes(opt.value)}
+              onCheckedChange={() => handleToggle(opt.value)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              <span className="truncate">{opt.label}</span>
+            </DropdownMenuCheckboxItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
+++ b/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
@@ -1,0 +1,117 @@
+import { ChevronDown, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export interface FilterCheckboxOption {
+  value: string;
+  label: string;
+}
+
+interface FilterCheckboxDropdownProps {
+  label: string;
+  options: FilterCheckboxOption[];
+  selectedValues: string[];
+  onChange: (values: string[]) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Multi-select filter dropdown with checkboxes.
+ * States: unselected (gray button + chevron), open (dropdown with checkboxes), active (primary button + count + clear X).
+ */
+export function FilterCheckboxDropdown({
+  label,
+  options,
+  selectedValues,
+  onChange,
+  disabled = false,
+  className,
+}: FilterCheckboxDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const hasSelection = selectedValues.length > 0;
+
+  const handleToggle = useCallback(
+    (value: string) => {
+      if (selectedValues.includes(value)) {
+        onChange(selectedValues.filter((v) => v !== value));
+      } else {
+        onChange([...selectedValues, value]);
+      }
+    },
+    [onChange, selectedValues]
+  );
+
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onChange([]);
+    },
+    [onChange]
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={hasSelection ? 'default' : 'outline'}
+          size="sm"
+          disabled={disabled}
+          className={cn(
+            'min-w-[100px] justify-between gap-1 font-normal',
+            className
+          )}
+        >
+          <span className="truncate">
+            {hasSelection ? `${label} (${selectedValues.length})` : label}
+          </span>
+          {hasSelection ? (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="ml-1 rounded p-0.5 hover:bg-white/20"
+              aria-label={`Clear ${label} filter`}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          ) : (
+            <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-0" align="start">
+        <div className="max-h-64 overflow-auto p-2">
+          {options.length === 0 ? (
+            <p className="text-muted-foreground py-2 text-center text-sm">
+              No options
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {options.map((opt) => (
+                <label
+                  key={opt.value}
+                  className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+                >
+                  <Checkbox
+                    checked={selectedValues.includes(opt.value)}
+                    onCheckedChange={() => handleToggle(opt.value)}
+                  />
+                  <span className="flex-1 truncate">{opt.label}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -79,7 +79,7 @@ export function TransferActivitiesDialog({
 
   const { data: searchUsers = [], isFetching: isSearching } = useQuery({
     queryKey: ['users', userSearch],
-    queryFn: () => fetchUsers(userSearch.trim() || undefined),
+    queryFn: () => fetchUsers({ search: userSearch.trim() || undefined }),
     enabled: comboboxOpen,
   });
 

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface UserCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal for the "Add user" flow. User creation is not yet supported by the API;
+ * users are added when they first sign in. This modal explains that and can be
+ * extended when a create-user endpoint is available.
+ */
+export function UserCreateModal({ open, onClose }: UserCreateModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add user</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-slate-600">
+          User creation is not yet available. Users are added to the system when
+          they first sign in to the application.
+        </p>
+        <DialogFooter>
+          <Button onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/calendar-ui/src/components/users/UserManagementFilters.tsx
+++ b/calendar-ui/src/components/users/UserManagementFilters.tsx
@@ -1,6 +1,10 @@
 import { Check, ChevronDown, Search, X } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
+import {
+  SortDropdown,
+  type SortColumnConfig,
+} from '@/components/Table/SortDropdown';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -19,6 +23,12 @@ import {
 } from '@/components/ui/popover';
 import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
 import { cn } from '@/lib/utils';
+
+const USER_SORT_COLUMNS: SortColumnConfig[] = [
+  { id: 'name', label: 'Name', defaultDirection: 'asc' },
+  { id: 'role', label: 'Role', defaultDirection: 'asc' },
+  { id: 'lastUpdated', label: 'Last updated', defaultDirection: 'desc' },
+];
 
 export interface FilterOption {
   value: string;
@@ -42,6 +52,11 @@ interface UserManagementFiltersProps {
   roleOptions: FilterOption[];
   /** Placeholder for Job filter (disabled until AD integration). */
   jobOptions?: FilterOption[];
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  defaultSortKey: string;
+  defaultSortDirection: 'asc' | 'desc';
   className?: string;
 }
 
@@ -59,6 +74,11 @@ export function UserManagementFilters({
   teamOptions,
   roleOptions,
   jobOptions = [],
+  sortKey,
+  sortDirection,
+  onSortChange,
+  defaultSortKey,
+  defaultSortDirection,
   className,
 }: UserManagementFiltersProps) {
   const teamSelectedValues = teamIds.map(String);
@@ -113,109 +133,140 @@ export function UserManagementFilters({
     [onRoleIdsChange]
   );
 
+  const hasDropdownFiltersActive = teamIds.length > 0 || roleIds.length > 0;
+  const handleClearDropdownFilters = useCallback(() => {
+    onTeamIdsChange([]);
+    onRoleIdsChange([]);
+  }, [onTeamIdsChange, onRoleIdsChange]);
+
   return (
     <div
       className={className}
       role="search"
       aria-label="Filter users by team, job, role, and keyword"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <Popover open={teamPopoverOpen} onOpenChange={setTeamPopoverOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              variant={hasTeamSelection ? 'default' : 'outline'}
-              size="sm"
-              className="min-w-[100px] justify-between gap-1 font-normal"
-            >
-              <span className="truncate">
-                {hasTeamSelection ? `Team (${teamIds.length})` : 'Team'}
-              </span>
-              {hasTeamSelection ? (
-                <button
-                  type="button"
-                  onClick={handleTeamClear}
-                  className="ml-1 rounded p-0.5 hover:bg-white/20"
-                  aria-label="Clear Team filter"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              ) : (
-                <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-              )}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-72 p-0" align="start">
-            <Command className="rounded-md border-0" shouldFilter={false}>
-              <CommandInput
-                placeholder="Search teams..."
-                value={teamSearch}
-                onValueChange={setTeamSearch}
-              />
-              {selectedTeamOptions.length > 0 && (
-                <div className="border-b px-2 py-2">
-                  <div className="flex flex-wrap gap-1.5">
-                    {selectedTeamOptions.map((opt) => (
-                      <Badge
-                        key={opt.value}
-                        variant="secondary"
-                        className="cursor-pointer gap-1 pr-1 text-xs"
-                        onClick={() => handleTeamSelect(opt.value)}
-                      >
-                        {opt.label}
-                        <X className="h-3 w-3" />
-                      </Badge>
-                    ))}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Popover open={teamPopoverOpen} onOpenChange={setTeamPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant={hasTeamSelection ? 'default' : 'outline'}
+                size="sm"
+                className="min-w-[100px] justify-between gap-1 font-normal"
+              >
+                <span className="truncate">
+                  {hasTeamSelection ? `Team (${teamIds.length})` : 'Team'}
+                </span>
+                {hasTeamSelection ? (
+                  <button
+                    type="button"
+                    onClick={handleTeamClear}
+                    className="ml-1 rounded p-0.5 hover:bg-white/20"
+                    aria-label="Clear Team filter"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                ) : (
+                  <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 p-0" align="start">
+              <Command className="rounded-md border-0" shouldFilter={false}>
+                <CommandInput
+                  placeholder="Search teams..."
+                  value={teamSearch}
+                  onValueChange={setTeamSearch}
+                />
+                {selectedTeamOptions.length > 0 && (
+                  <div className="border-b px-2 py-2">
+                    <div className="flex flex-wrap gap-1.5">
+                      {selectedTeamOptions.map((opt) => (
+                        <Badge
+                          key={opt.value}
+                          variant="secondary"
+                          className="cursor-pointer gap-1 pr-1 text-xs"
+                          onClick={() => handleTeamSelect(opt.value)}
+                        >
+                          {opt.label}
+                          <X className="h-3 w-3" />
+                        </Badge>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
-              <CommandList>
-                <CommandEmpty>No teams found.</CommandEmpty>
-                <CommandGroup>
-                  {filteredTeamOptions.map((opt) => {
-                    const isSelected = teamSelectedValues.includes(opt.value);
-                    return (
-                      <CommandItem
-                        key={opt.value}
-                        value={opt.value}
-                        onSelect={() => handleTeamSelectAndClose(opt.value)}
-                      >
-                        <Check
-                          className={cn(
-                            'mr-2 h-4 w-4',
-                            isSelected ? 'opacity-100' : 'opacity-0'
-                          )}
-                        />
-                        {opt.label}
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-        <FilterCheckboxDropdown
-          label="Job"
-          options={jobOptions}
-          selectedValues={[]}
-          onChange={() => {}}
-          disabled
-        />
-        <FilterCheckboxDropdown
-          label="Role"
-          options={roleOptions}
-          selectedValues={roleSelectedValues}
-          onChange={handleRoleIdsChange}
-        />
-        <div className="relative max-w-sm min-w-[180px] flex-1">
-          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
-          <Input
-            type="search"
-            placeholder="Search by name, email, username..."
-            value={keyword}
-            onChange={(e) => onKeywordChange(e.target.value)}
-            className="pl-8"
-            aria-label="Keyword search"
+                )}
+                <CommandList>
+                  <CommandEmpty>No teams found.</CommandEmpty>
+                  <CommandGroup>
+                    {filteredTeamOptions.map((opt) => {
+                      const isSelected = teamSelectedValues.includes(opt.value);
+                      return (
+                        <CommandItem
+                          key={opt.value}
+                          value={opt.value}
+                          onSelect={() => handleTeamSelectAndClose(opt.value)}
+                        >
+                          <Check
+                            className={cn(
+                              'mr-2 h-4 w-4',
+                              isSelected ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                          {opt.label}
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          <FilterCheckboxDropdown
+            label="Job"
+            options={jobOptions}
+            selectedValues={[]}
+            onChange={() => {}}
+            disabled
+          />
+          <FilterCheckboxDropdown
+            label="Role"
+            options={roleOptions}
+            selectedValues={roleSelectedValues}
+            onChange={handleRoleIdsChange}
+          />
+          {hasDropdownFiltersActive && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="animate-in fade-in ml-4 duration-200"
+              onClick={handleClearDropdownFilters}
+              aria-label="Clear all filters"
+            >
+              Clear all filters
+            </Button>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative max-w-md min-w-[240px] flex-1">
+            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              placeholder="Search by name, email, username..."
+              value={keyword}
+              onChange={(e) => onKeywordChange(e.target.value)}
+              className="pl-8"
+              aria-label="Keyword search"
+            />
+          </div>
+          <SortDropdown
+            columns={USER_SORT_COLUMNS}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={onSortChange}
+            defaultSortKey={defaultSortKey}
+            defaultSortDirection={defaultSortDirection}
+            ariaLabel="Sort by"
           />
         </div>
       </div>

--- a/calendar-ui/src/components/users/UserManagementFilters.tsx
+++ b/calendar-ui/src/components/users/UserManagementFilters.tsx
@@ -15,12 +15,12 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import { Input } from '@/components/ui/input';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
 import { cn } from '@/lib/utils';
 
@@ -62,7 +62,6 @@ interface UserManagementFiltersProps {
 
 /**
  * Filter bar for the Users table: Team (combobox), Role (checkbox dropdown), Job (disabled), and keyword search.
- * Uses Shad/cn components only.
  */
 export function UserManagementFilters({
   keyword,
@@ -95,7 +94,6 @@ export function UserManagementFilters({
     [teamIds, onTeamIdsChange]
   );
 
-  const [teamPopoverOpen, setTeamPopoverOpen] = useState(false);
   const [teamSearch, setTeamSearch] = useState('');
   const filteredTeamOptions = useMemo(() => {
     if (!teamSearch.trim()) return teamOptions;
@@ -115,7 +113,17 @@ export function UserManagementFilters({
     },
     [onTeamIdsChange]
   );
-  const handleTeamSelectAndClose = useCallback(
+  const handleTeamClearKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onTeamIdsChange([]);
+      }
+    },
+    [onTeamIdsChange]
+  );
+  const handleTeamSelectItem = useCallback(
     (value: string) => {
       handleTeamSelect(value);
       setTeamSearch('');
@@ -147,8 +155,8 @@ export function UserManagementFilters({
     >
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-2">
-          <Popover open={teamPopoverOpen} onOpenChange={setTeamPopoverOpen}>
-            <PopoverTrigger asChild>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button
                 variant={hasTeamSelection ? 'default' : 'outline'}
                 size="sm"
@@ -158,20 +166,22 @@ export function UserManagementFilters({
                   {hasTeamSelection ? `Team (${teamIds.length})` : 'Team'}
                 </span>
                 {hasTeamSelection ? (
-                  <button
-                    type="button"
+                  <span
+                    role="button"
+                    tabIndex={0}
                     onClick={handleTeamClear}
-                    className="ml-1 rounded p-0.5 hover:bg-white/20"
+                    onKeyDown={handleTeamClearKeyDown}
+                    className="ml-1 inline-flex cursor-pointer rounded p-0.5 hover:bg-white/20"
                     aria-label="Clear Team filter"
                   >
                     <X className="h-3.5 w-3.5" />
-                  </button>
+                  </span>
                 ) : (
                   <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
                 )}
               </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-72 p-0" align="start">
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-72 p-0" align="start">
               <Command className="rounded-md border-0" shouldFilter={false}>
                 <CommandInput
                   placeholder="Search teams..."
@@ -204,7 +214,7 @@ export function UserManagementFilters({
                         <CommandItem
                           key={opt.value}
                           value={opt.value}
-                          onSelect={() => handleTeamSelectAndClose(opt.value)}
+                          onSelect={() => handleTeamSelectItem(opt.value)}
                         >
                           <Check
                             className={cn(
@@ -219,8 +229,8 @@ export function UserManagementFilters({
                   </CommandGroup>
                 </CommandList>
               </Command>
-            </PopoverContent>
-          </Popover>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <FilterCheckboxDropdown
             label="Job"
             options={jobOptions}

--- a/calendar-ui/src/components/users/UserManagementFilters.tsx
+++ b/calendar-ui/src/components/users/UserManagementFilters.tsx
@@ -1,0 +1,224 @@
+import { Check, ChevronDown, Search, X } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
+import { cn } from '@/lib/utils';
+
+export interface FilterOption {
+  value: string;
+  label: string;
+}
+
+export interface UserManagementFiltersState {
+  keyword: string;
+  teamIds: number[];
+  roleIds: number[];
+}
+
+interface UserManagementFiltersProps {
+  keyword: string;
+  teamIds: number[];
+  roleIds: number[];
+  onKeywordChange: (value: string) => void;
+  onTeamIdsChange: (value: number[]) => void;
+  onRoleIdsChange: (value: number[]) => void;
+  teamOptions: FilterOption[];
+  roleOptions: FilterOption[];
+  /** Placeholder for Job filter (disabled until AD integration). */
+  jobOptions?: FilterOption[];
+  className?: string;
+}
+
+/**
+ * Filter bar for the Users table: Team (combobox), Role (checkbox dropdown), Job (disabled), and keyword search.
+ * Uses Shad/cn components only.
+ */
+export function UserManagementFilters({
+  keyword,
+  teamIds,
+  roleIds,
+  onKeywordChange,
+  onTeamIdsChange,
+  onRoleIdsChange,
+  teamOptions,
+  roleOptions,
+  jobOptions = [],
+  className,
+}: UserManagementFiltersProps) {
+  const teamSelectedValues = teamIds.map(String);
+  const handleTeamSelect = useCallback(
+    (value: string) => {
+      const id = parseInt(value, 10);
+      if (Number.isNaN(id)) return;
+      if (teamIds.includes(id)) {
+        onTeamIdsChange(teamIds.filter((t) => t !== id));
+      } else {
+        onTeamIdsChange([...teamIds, id].sort((a, b) => a - b));
+      }
+    },
+    [teamIds, onTeamIdsChange]
+  );
+
+  const [teamPopoverOpen, setTeamPopoverOpen] = useState(false);
+  const [teamSearch, setTeamSearch] = useState('');
+  const filteredTeamOptions = useMemo(() => {
+    if (!teamSearch.trim()) return teamOptions;
+    const q = teamSearch.toLowerCase();
+    return teamOptions.filter((opt) => opt.label.toLowerCase().includes(q));
+  }, [teamOptions, teamSearch]);
+  const selectedTeamOptions = useMemo(
+    () => teamOptions.filter((opt) => teamSelectedValues.includes(opt.value)),
+    [teamOptions, teamSelectedValues]
+  );
+  const hasTeamSelection = teamIds.length > 0;
+  const handleTeamClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onTeamIdsChange([]);
+    },
+    [onTeamIdsChange]
+  );
+  const handleTeamSelectAndClose = useCallback(
+    (value: string) => {
+      handleTeamSelect(value);
+      setTeamSearch('');
+    },
+    [handleTeamSelect]
+  );
+
+  const roleSelectedValues = roleIds.map(String);
+  const handleRoleIdsChange = useCallback(
+    (values: string[]) => {
+      onRoleIdsChange(
+        values.map((v) => parseInt(v, 10)).filter((n) => !Number.isNaN(n))
+      );
+    },
+    [onRoleIdsChange]
+  );
+
+  return (
+    <div
+      className={className}
+      role="search"
+      aria-label="Filter users by team, job, role, and keyword"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Popover open={teamPopoverOpen} onOpenChange={setTeamPopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant={hasTeamSelection ? 'default' : 'outline'}
+              size="sm"
+              className="min-w-[100px] justify-between gap-1 font-normal"
+            >
+              <span className="truncate">
+                {hasTeamSelection ? `Team (${teamIds.length})` : 'Team'}
+              </span>
+              {hasTeamSelection ? (
+                <button
+                  type="button"
+                  onClick={handleTeamClear}
+                  className="ml-1 rounded p-0.5 hover:bg-white/20"
+                  aria-label="Clear Team filter"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              ) : (
+                <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="start">
+            <Command className="rounded-md border-0" shouldFilter={false}>
+              <CommandInput
+                placeholder="Search teams..."
+                value={teamSearch}
+                onValueChange={setTeamSearch}
+              />
+              {selectedTeamOptions.length > 0 && (
+                <div className="border-b px-2 py-2">
+                  <div className="flex flex-wrap gap-1.5">
+                    {selectedTeamOptions.map((opt) => (
+                      <Badge
+                        key={opt.value}
+                        variant="secondary"
+                        className="cursor-pointer gap-1 pr-1 text-xs"
+                        onClick={() => handleTeamSelect(opt.value)}
+                      >
+                        {opt.label}
+                        <X className="h-3 w-3" />
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <CommandList>
+                <CommandEmpty>No teams found.</CommandEmpty>
+                <CommandGroup>
+                  {filteredTeamOptions.map((opt) => {
+                    const isSelected = teamSelectedValues.includes(opt.value);
+                    return (
+                      <CommandItem
+                        key={opt.value}
+                        value={opt.value}
+                        onSelect={() => handleTeamSelectAndClose(opt.value)}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            isSelected ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        {opt.label}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        <FilterCheckboxDropdown
+          label="Job"
+          options={jobOptions}
+          selectedValues={[]}
+          onChange={() => {}}
+          disabled
+        />
+        <FilterCheckboxDropdown
+          label="Role"
+          options={roleOptions}
+          selectedValues={roleSelectedValues}
+          onChange={handleRoleIdsChange}
+        />
+        <div className="relative max-w-sm min-w-[180px] flex-1">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+          <Input
+            type="search"
+            placeholder="Search by name, email, username..."
+            value={keyword}
+            onChange={(e) => onKeywordChange(e.target.value)}
+            className="pl-8"
+            aria-label="Keyword search"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -1,0 +1,392 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  ArrowLeftRight,
+  History,
+  Loader2,
+  MoreHorizontal,
+  Pencil,
+  UsersRound,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import type { UserListItem } from '@corpcal/shared/api/types';
+import { fetchRoles, fetchTeams, fetchUsers } from '@/api/usersApi';
+import { SortIndicator } from '@/components/Table/SortIndicator';
+import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { UserManagementFilters } from '@/components/users/UserManagementFilters';
+
+const IDIR_PLACEHOLDER = 'MYIDIR';
+const DEFAULT_SORT_KEY = 'name';
+const DEFAULT_SORT_DIRECTION = 'asc' as const;
+
+type UserSortKey = 'name' | 'role' | 'lastUpdated';
+
+function displayName(user: UserListItem): string {
+  return user.adDisplayName || user.adUsername || `User ${user.id}`;
+}
+
+function formatLastUpdated(iso: string | null | undefined): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? '-'
+      : d.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        });
+  } catch {
+    return '-';
+  }
+}
+
+function statusBadge(isActive: boolean) {
+  return (
+    <span
+      className={
+        isActive
+          ? 'rounded bg-green-100 px-2 py-0.5 text-xs text-green-800'
+          : 'rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600'
+      }
+    >
+      {isActive ? 'Active' : 'Inactive'}
+    </span>
+  );
+}
+
+function compareUsers(
+  a: UserListItem,
+  b: UserListItem,
+  sortKey: UserSortKey,
+  direction: 'asc' | 'desc'
+): number {
+  const mult = direction === 'asc' ? 1 : -1;
+  switch (sortKey) {
+    case 'name': {
+      const na = (a.adDisplayName ?? a.adUsername ?? '').toLowerCase();
+      const nb = (b.adDisplayName ?? b.adUsername ?? '').toLowerCase();
+      return mult * na.localeCompare(nb);
+    }
+    case 'role': {
+      const ra = (a.roleName ?? '').toLowerCase();
+      const rb = (b.roleName ?? '').toLowerCase();
+      return mult * ra.localeCompare(rb);
+    }
+    case 'lastUpdated': {
+      const ta = new Date(
+        (a as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
+      ).getTime();
+      const tb = new Date(
+        (b as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
+      ).getTime();
+      return mult * (ta - tb);
+    }
+    default:
+      return 0;
+  }
+}
+
+export interface UsersTabContentProps {
+  canEdit: boolean;
+  canTransfer: boolean;
+  onEditUser: (user: UserListItem) => void;
+  onTransfer: (user: UserListItem) => void;
+  onViewHistory: (user: UserListItem) => void;
+  onDeactivate: (user: UserListItem) => void;
+  onReactivate: (user: UserListItem) => void;
+}
+
+export function UsersTabContent({
+  canEdit,
+  canTransfer,
+  onEditUser,
+  onTransfer,
+  onViewHistory,
+  onDeactivate,
+  onReactivate,
+}: UsersTabContentProps) {
+  const [keyword, setKeyword] = useState('');
+  const [teamIds, setTeamIds] = useState<number[]>([]);
+  const [roleIds, setRoleIds] = useState<number[]>([]);
+  const [sortKey, setSortKey] = useState<UserSortKey | null>(DEFAULT_SORT_KEY);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
+    DEFAULT_SORT_DIRECTION
+  );
+  const [showInactive, setShowInactive] = useState(false);
+
+  const fetchUsersParams = useMemo(
+    () => ({
+      search: keyword || undefined,
+      teamIds: teamIds.length ? teamIds : undefined,
+      roleIds: roleIds.length ? roleIds : undefined,
+    }),
+    [keyword, teamIds, roleIds]
+  );
+
+  const { data: users = [], isLoading } = useQuery({
+    queryKey: ['users', fetchUsersParams],
+    queryFn: () => fetchUsers(fetchUsersParams),
+  });
+
+  const { data: teamsForFilter = [] } = useQuery({
+    queryKey: ['teams'],
+    queryFn: fetchTeams,
+  });
+
+  const { data: rolesForFilter = [] } = useQuery({
+    queryKey: ['roles'],
+    queryFn: fetchRoles,
+  });
+
+  const teamOptions = useMemo(
+    () =>
+      teamsForFilter.map((t) => ({
+        value: String(t.id),
+        label: t.displayName || t.name,
+      })),
+    [teamsForFilter]
+  );
+
+  const roleOptions = useMemo(
+    () => rolesForFilter.map((r) => ({ value: String(r.id), label: r.name })),
+    [rolesForFilter]
+  );
+
+  const sortedUsers = useMemo(() => {
+    const key = sortKey ?? DEFAULT_SORT_KEY;
+    const dir = sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
+    return [...users].sort((a, b) => compareUsers(a, b, key, dir));
+  }, [users, sortKey, sortDirection]);
+
+  const displayedUsers = useMemo(() => {
+    if (showInactive) return sortedUsers;
+    return sortedUsers.filter((u) => u.isActive);
+  }, [sortedUsers, showInactive]);
+
+  const handleSortChange = (key: string | null, direction: 'asc' | 'desc') => {
+    setSortKey(key as UserSortKey | null);
+    setSortDirection(direction);
+  };
+
+  return (
+    <div className="space-y-4">
+      <UserManagementFilters
+        keyword={keyword}
+        teamIds={teamIds}
+        roleIds={roleIds}
+        onKeywordChange={setKeyword}
+        onTeamIdsChange={setTeamIds}
+        onRoleIdsChange={setRoleIds}
+        teamOptions={teamOptions}
+        roleOptions={roleOptions}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
+        defaultSortKey={DEFAULT_SORT_KEY}
+        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        className="mb-4"
+      />
+
+      <TableSummaryBar
+        count={displayedUsers.length}
+        singularLabel="user"
+        pluralLabel="users"
+        filters={[
+          {
+            id: 'show-inactive',
+            label: 'Show inactive',
+            checked: showInactive,
+            onCheckedChange: setShowInactive,
+          },
+        ]}
+      />
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+        </div>
+      ) : (
+        <div className="rounded-lg border border-slate-200 bg-white">
+          <table className="w-full table-auto border-collapse">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50">
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  <span className="inline-flex items-center gap-1">
+                    Name
+                    <SortIndicator
+                      columnId="name"
+                      sortKey={sortKey}
+                      sortDirection={
+                        sortKey !== null
+                          ? sortDirection
+                          : DEFAULT_SORT_DIRECTION
+                      }
+                      className="h-4 w-4"
+                    />
+                  </span>
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Email
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  IDIR
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  <span className="inline-flex items-center gap-1">
+                    Role
+                    <SortIndicator
+                      columnId="role"
+                      sortKey={sortKey}
+                      sortDirection={
+                        sortKey !== null
+                          ? sortDirection
+                          : DEFAULT_SORT_DIRECTION
+                      }
+                      className="h-4 w-4"
+                    />
+                  </span>
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Teams
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  <span className="inline-flex items-center gap-1">
+                    Last updated
+                    <SortIndicator
+                      columnId="lastUpdated"
+                      sortKey={sortKey}
+                      sortDirection={
+                        sortKey !== null
+                          ? sortDirection
+                          : DEFAULT_SORT_DIRECTION
+                      }
+                      className="h-4 w-4"
+                    />
+                  </span>
+                </th>
+                <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {displayedUsers.map((user) => (
+                <tr
+                  key={user.id}
+                  className="border-b border-slate-100 hover:bg-slate-50/50"
+                >
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    {displayName(user)}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {user.adEmail ?? '-'}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {IDIR_PLACEHOLDER}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
+                      {user.roleName}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {user.teams.length === 0 ? (
+                        <span className="text-slate-400">-</span>
+                      ) : (
+                        user.teams.map((t) => (
+                          <span
+                            key={t.teamId}
+                            className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
+                          >
+                            {t.teamName}
+                            {t.role !== 'member' ? ` (${t.role})` : ''}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">{statusBadge(user.isActive)}</td>
+                  <td className="px-4 py-3 text-sm text-slate-600">
+                    {formatLastUpdated(
+                      (user as { lastUpdatedDateTime?: string | null })
+                        .lastUpdatedDateTime
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          aria-label="Actions"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {canEdit && (
+                          <DropdownMenuItem onClick={() => onEditUser(user)}>
+                            <Pencil className="h-4 w-4" />
+                            Edit
+                          </DropdownMenuItem>
+                        )}
+                        {canEdit && (
+                          <DropdownMenuItem onClick={() => onEditUser(user)}>
+                            <UsersRound className="h-4 w-4" />
+                            Add to team / Edit teams
+                          </DropdownMenuItem>
+                        )}
+                        {canTransfer && (
+                          <DropdownMenuItem onClick={() => onTransfer(user)}>
+                            <ArrowLeftRight className="h-4 w-4" />
+                            Transfer activities
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuItem onClick={() => onViewHistory(user)}>
+                          <History className="h-4 w-4" />
+                          View history
+                        </DropdownMenuItem>
+                        {canEdit && user.isActive && (
+                          <DropdownMenuItem
+                            onClick={() => onDeactivate(user)}
+                            variant="destructive"
+                          >
+                            Deactivate
+                          </DropdownMenuItem>
+                        )}
+                        {canEdit && !user.isActive && (
+                          <DropdownMenuItem onClick={() => onReactivate(user)}>
+                            Reactivate
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {displayedUsers.length === 0 && (
+            <div className="py-12 text-center text-slate-500">
+              {keyword || teamIds.length > 0 || roleIds.length > 0
+                ? 'No users match your filters'
+                : 'No users found'}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -12,7 +12,7 @@ import {
   Pencil,
   UsersRound,
 } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { UserListItem } from '@corpcal/shared/api/types';
 import { fetchRoles, fetchTeams, fetchUsers } from '@/api/usersApi';
@@ -30,8 +30,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { UserManagementFilters } from '@/components/users/UserManagementFilters';
 
 const IDIR_PLACEHOLDER = 'MYIDIR';
-const TABLE_SCROLL_HEIGHT = 'min(480px, 60vh)';
+const TABLE_SCROLL_HEIGHT = 'max(240px, min(600px, 60vh, 100vh - 400px))';
 const SKELETON_ROW_COUNT = 8;
+const SKELETON_DELAY_MS = 300;
 const TABLE_COLUMN_COUNT = 8;
 const DEFAULT_SORT_KEY = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc' as const;
@@ -151,6 +152,19 @@ export function UsersTabContent({
     queryKey: ['users', fetchUsersParams],
     queryFn: () => fetchUsers(fetchUsersParams),
   });
+
+  const [showSkeleton, setShowSkeleton] = useState(false);
+  useEffect(() => {
+    if (!isLoading) {
+      setShowSkeleton(false);
+      return;
+    }
+    const id = window.setTimeout(
+      () => setShowSkeleton(true),
+      SKELETON_DELAY_MS
+    );
+    return () => window.clearTimeout(id);
+  }, [isLoading]);
 
   const { data: teamsForFilter = [] } = useQuery({
     queryKey: ['teams'],
@@ -350,7 +364,7 @@ export function UsersTabContent({
               </tr>
             </thead>
             <tbody>
-              {isLoading ? (
+              {isLoading && showSkeleton ? (
                 Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
                   <tr key={i} className="border-b border-slate-100" aria-hidden>
                     <td className="px-4 py-3">

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -1,16 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type ColumnDef,
+} from '@tanstack/react-table';
+import {
   ArrowLeftRight,
   History,
   MoreHorizontal,
   Pencil,
   UsersRound,
 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import type { UserListItem } from '@corpcal/shared/api/types';
 import { fetchRoles, fetchTeams, fetchUsers } from '@/api/usersApi';
 import { SortIndicator } from '@/components/Table/SortIndicator';
+import { TablePagination } from '@/components/Table/TablePagination';
 import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { Button } from '@/components/ui/button';
 import {
@@ -28,6 +35,7 @@ const SKELETON_ROW_COUNT = 8;
 const TABLE_COLUMN_COUNT = 8;
 const DEFAULT_SORT_KEY = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc' as const;
+const DEFAULT_PAGE_SIZE = 10;
 
 type UserSortKey = 'name' | 'role' | 'lastUpdated';
 
@@ -124,6 +132,11 @@ export function UsersTabContent({
     DEFAULT_SORT_DIRECTION
   );
   const [showInactive, setShowInactive] = useState(false);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+  const tableScrollRef = useRef<HTMLDivElement>(null);
 
   const fetchUsersParams = useMemo(
     () => ({
@@ -174,6 +187,24 @@ export function UsersTabContent({
     return sortedUsers.filter((u) => u.isActive);
   }, [sortedUsers, showInactive]);
 
+  const userColumns = useMemo<ColumnDef<UserListItem>[]>(
+    () => [{ id: '_', header: () => null, cell: () => null }],
+    []
+  );
+
+  const table = useReactTable({
+    data: displayedUsers,
+    columns: userColumns,
+    getRowId: (row) => String(row.id),
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: { pagination },
+    onPaginationChange: setPagination,
+    autoResetPageIndex: true,
+  });
+
+  const pageRows = table.getRowModel().rows.map((row) => row.original);
+
   const handleSortChange = (key: string | null, direction: 'asc' | 'desc') => {
     setSortKey(key as UserSortKey | null);
     setSortDirection(direction);
@@ -215,7 +246,7 @@ export function UsersTabContent({
         className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white"
         style={{ height: TABLE_SCROLL_HEIGHT }}
       >
-        <div className="min-h-0 flex-1 overflow-auto">
+        <div ref={tableScrollRef} className="min-h-0 flex-1 overflow-auto">
           <table
             className="w-full min-w-[640px] table-fixed border-collapse"
             role="grid"
@@ -337,7 +368,7 @@ export function UsersTabContent({
                   </td>
                 </tr>
               ) : (
-                displayedUsers.map((user) => (
+                pageRows.map((user) => (
                   <tr
                     key={user.id}
                     className="border-b border-slate-100 hover:bg-slate-50/50"
@@ -440,6 +471,22 @@ export function UsersTabContent({
           </table>
         </div>
       </div>
+      {displayedUsers.length > 0 && (
+        <TablePagination
+          totalItems={displayedUsers.length}
+          page={pagination.pageIndex + 1}
+          pageSize={pagination.pageSize}
+          onPageChange={(p) => {
+            setPagination((prev) => ({ ...prev, pageIndex: p - 1 }));
+            tableScrollRef.current?.scrollTo({ top: 0 });
+          }}
+          onPageSizeChange={(ps) => {
+            setPagination((prev) => ({ ...prev, pageSize: ps, pageIndex: 0 }));
+            tableScrollRef.current?.scrollTo({ top: 0 });
+          }}
+          aria-label="Users table pagination"
+        />
+      )}
     </div>
   );
 }

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -12,7 +12,7 @@ import {
   Pencil,
   UsersRound,
 } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { UserListItem } from '@corpcal/shared/api/types';
 import { fetchRoles, fetchTeams, fetchUsers } from '@/api/usersApi';
@@ -192,6 +192,29 @@ export function UsersTabContent({
     []
   );
 
+  const onPaginationChangeStable = useCallback(
+    (
+      updaterOrValue:
+        | ((prev: typeof pagination) => typeof pagination)
+        | typeof pagination
+    ) => {
+      setPagination((prev) => {
+        const next =
+          typeof updaterOrValue === 'function'
+            ? updaterOrValue(prev)
+            : updaterOrValue;
+        if (
+          next.pageIndex === prev.pageIndex &&
+          next.pageSize === prev.pageSize
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    },
+    []
+  );
+
   const table = useReactTable({
     data: displayedUsers,
     columns: userColumns,
@@ -199,7 +222,7 @@ export function UsersTabContent({
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     state: { pagination },
-    onPaginationChange: setPagination,
+    onPaginationChange: onPaginationChangeStable,
     autoResetPageIndex: true,
   });
 

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import {
   ArrowLeftRight,
   History,
-  Loader2,
   MoreHorizontal,
   Pencil,
   UsersRound,
@@ -20,9 +19,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Skeleton } from '@/components/ui/skeleton';
 import { UserManagementFilters } from '@/components/users/UserManagementFilters';
 
 const IDIR_PLACEHOLDER = 'MYIDIR';
+const TABLE_SCROLL_HEIGHT = 'min(480px, 60vh)';
+const SKELETON_ROW_COUNT = 8;
+const TABLE_COLUMN_COUNT = 8;
 const DEFAULT_SORT_KEY = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc' as const;
 
@@ -208,15 +211,28 @@ export function UsersTabContent({
           },
         ]}
       />
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-        </div>
-      ) : (
-        <div className="rounded-lg border border-slate-200 bg-white">
-          <table className="w-full table-auto border-collapse">
-            <thead>
-              <tr className="border-b border-slate-200 bg-slate-50">
+      <div
+        className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white"
+        style={{ height: TABLE_SCROLL_HEIGHT }}
+      >
+        <div className="min-h-0 flex-1 overflow-auto">
+          <table
+            className="w-full min-w-[640px] table-fixed border-collapse"
+            role="grid"
+            aria-colcount={TABLE_COLUMN_COUNT}
+          >
+            <colgroup>
+              <col style={{ width: '16%' }} />
+              <col style={{ width: '20%' }} />
+              <col style={{ width: '8%' }} />
+              <col style={{ width: '12%' }} />
+              <col style={{ width: '18%' }} />
+              <col style={{ width: '8%' }} />
+              <col style={{ width: '10%' }} />
+              <col style={{ width: '8%' }} />
+            </colgroup>
+            <thead className="sticky top-0 z-10 border-b border-slate-200 bg-slate-50 shadow-[0_1px_0_0_rgba(0,0,0,0.05)]">
+              <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   <span className="inline-flex items-center gap-1">
                     Name
@@ -274,119 +290,156 @@ export function UsersTabContent({
                     />
                   </span>
                 </th>
-                <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
+                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Actions
                 </th>
               </tr>
             </thead>
             <tbody>
-              {displayedUsers.map((user) => (
-                <tr
-                  key={user.id}
-                  className="border-b border-slate-100 hover:bg-slate-50/50"
-                >
-                  <td className="px-4 py-3 font-medium text-slate-900">
-                    {displayName(user)}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {user.adEmail ?? '-'}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {IDIR_PLACEHOLDER}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
-                      {user.roleName}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {user.teams.length === 0 ? (
-                        <span className="text-slate-400">-</span>
-                      ) : (
-                        user.teams.map((t) => (
-                          <span
-                            key={t.teamId}
-                            className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
-                          >
-                            {t.teamName}
-                            {t.role !== 'member' ? ` (${t.role})` : ''}
-                          </span>
-                        ))
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">{statusBadge(user.isActive)}</td>
-                  <td className="px-4 py-3 text-sm text-slate-600">
-                    {formatLastUpdated(
-                      (user as { lastUpdatedDateTime?: string | null })
-                        .lastUpdatedDateTime
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8"
-                          aria-label="Actions"
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        {canEdit && (
-                          <DropdownMenuItem onClick={() => onEditUser(user)}>
-                            <Pencil className="h-4 w-4" />
-                            Edit
-                          </DropdownMenuItem>
-                        )}
-                        {canEdit && (
-                          <DropdownMenuItem onClick={() => onEditUser(user)}>
-                            <UsersRound className="h-4 w-4" />
-                            Add to team / Edit teams
-                          </DropdownMenuItem>
-                        )}
-                        {canTransfer && (
-                          <DropdownMenuItem onClick={() => onTransfer(user)}>
-                            <ArrowLeftRight className="h-4 w-4" />
-                            Transfer activities
-                          </DropdownMenuItem>
-                        )}
-                        <DropdownMenuItem onClick={() => onViewHistory(user)}>
-                          <History className="h-4 w-4" />
-                          View history
-                        </DropdownMenuItem>
-                        {canEdit && user.isActive && (
-                          <DropdownMenuItem
-                            onClick={() => onDeactivate(user)}
-                            variant="destructive"
-                          >
-                            Deactivate
-                          </DropdownMenuItem>
-                        )}
-                        {canEdit && !user.isActive && (
-                          <DropdownMenuItem onClick={() => onReactivate(user)}>
-                            Reactivate
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+              {isLoading ? (
+                Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+                  <tr key={i} className="border-b border-slate-100" aria-hidden>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-28" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-36" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-14" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-20" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-24" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-14" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-5 w-20" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Skeleton className="h-8 w-8 rounded" />
+                    </td>
+                  </tr>
+                ))
+              ) : displayedUsers.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={TABLE_COLUMN_COUNT}
+                    className="px-4 py-12 text-center text-slate-500"
+                  >
+                    {keyword || teamIds.length > 0 || roleIds.length > 0
+                      ? 'No users match your filters'
+                      : 'No users found'}
                   </td>
                 </tr>
-              ))}
+              ) : (
+                displayedUsers.map((user) => (
+                  <tr
+                    key={user.id}
+                    className="border-b border-slate-100 hover:bg-slate-50/50"
+                  >
+                    <td className="px-4 py-3 font-medium text-slate-900">
+                      {displayName(user)}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {user.adEmail ?? '-'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {IDIR_PLACEHOLDER}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
+                        {user.roleName}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {user.teams.length === 0 ? (
+                          <span className="text-slate-400">-</span>
+                        ) : (
+                          user.teams.map((t) => (
+                            <span
+                              key={t.teamId}
+                              className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
+                            >
+                              {t.teamName}
+                              {t.role !== 'member' ? ` (${t.role})` : ''}
+                            </span>
+                          ))
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">{statusBadge(user.isActive)}</td>
+                    <td className="px-4 py-3 text-sm text-slate-600">
+                      {formatLastUpdated(
+                        (user as { lastUpdatedDateTime?: string | null })
+                          .lastUpdatedDateTime
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            aria-label="Actions"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {canEdit && (
+                            <DropdownMenuItem onClick={() => onEditUser(user)}>
+                              <Pencil className="h-4 w-4" />
+                              Edit
+                            </DropdownMenuItem>
+                          )}
+                          {canEdit && (
+                            <DropdownMenuItem onClick={() => onEditUser(user)}>
+                              <UsersRound className="h-4 w-4" />
+                              Add to team / Edit teams
+                            </DropdownMenuItem>
+                          )}
+                          {canTransfer && (
+                            <DropdownMenuItem onClick={() => onTransfer(user)}>
+                              <ArrowLeftRight className="h-4 w-4" />
+                              Transfer activities
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem onClick={() => onViewHistory(user)}>
+                            <History className="h-4 w-4" />
+                            View history
+                          </DropdownMenuItem>
+                          {canEdit && user.isActive && (
+                            <DropdownMenuItem
+                              onClick={() => onDeactivate(user)}
+                              variant="destructive"
+                            >
+                              Deactivate
+                            </DropdownMenuItem>
+                          )}
+                          {canEdit && !user.isActive && (
+                            <DropdownMenuItem
+                              onClick={() => onReactivate(user)}
+                            >
+                              Reactivate
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
-          {displayedUsers.length === 0 && (
-            <div className="py-12 text-center text-slate-500">
-              {keyword || teamIds.length > 0 || roleIds.length > 0
-                ? 'No users match your filters'
-                : 'No users found'}
-            </div>
-          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -111,7 +111,10 @@ export function Users() {
         description="Manage user accounts, teams, and roles"
         action={
           canCreateUser && (
-            <Button onClick={() => setShowCreateUser(true)}>
+            <Button
+              onClick={() => setShowCreateUser(true)}
+              className="bg-(--bcsds-button-primary-background) text-white hover:bg-(--bcsds-button-primary-background)/95"
+            >
               <Plus className="h-4 w-4" />
               Add user
             </Button>

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -1,136 +1,33 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  ArrowLeftRight,
-  History,
-  Loader2,
-  MoreHorizontal,
-  Pencil,
-  Plus,
-  UsersRound,
-} from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
 import { toast } from 'sonner';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
 import type { TeamListItem, UserListItem } from '@corpcal/shared/api/types';
 import { updateTeam } from '@/api/teamsApi';
-import {
-  fetchRoles,
-  fetchTeams,
-  fetchUsers,
-  removeUserFromTeam,
-  updateUser,
-} from '@/api/usersApi';
+import { removeUserFromTeam, updateUser } from '@/api/usersApi';
 import { PageHeader } from '@/components/PageHeader';
-import { SortIndicator } from '@/components/Table/SortIndicator';
-import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { TeamEditModal } from '@/components/teams/TeamEditModal';
 import { TeamHistoryDrawer } from '@/components/teams/TeamHistoryDrawer';
 import { TeamsTabContent } from '@/components/teams/TeamsTabContent';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TransferActivitiesDialog } from '@/components/users/TransferActivitiesDialog';
 import { UserCreateModal } from '@/components/users/UserCreateModal';
 import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserHistoryDrawer } from '@/components/users/UserHistoryDrawer';
-import { UserManagementFilters } from '@/components/users/UserManagementFilters';
+import { UsersTabContent } from '@/components/users/UsersTabContent';
 import { useAuth } from '@/hooks/useAuth';
-
-function displayName(user: UserListItem): string {
-  return user.adDisplayName || user.adUsername || `User ${user.id}`;
-}
-
-function formatLastUpdated(iso: string | null | undefined): string {
-  if (!iso) return '-';
-  try {
-    const d = new Date(iso);
-    return Number.isNaN(d.getTime())
-      ? '-'
-      : d.toLocaleDateString(undefined, {
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-        });
-  } catch {
-    return '-';
-  }
-}
-
-function statusBadge(isActive: boolean) {
-  return (
-    <span
-      className={
-        isActive
-          ? 'rounded bg-green-100 px-2 py-0.5 text-xs text-green-800'
-          : 'rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600'
-      }
-    >
-      {isActive ? 'Active' : 'Inactive'}
-    </span>
-  );
-}
-
-const IDIR_PLACEHOLDER = 'MYIDIR';
-
-const DEFAULT_SORT_KEY = 'name';
-const DEFAULT_SORT_DIRECTION = 'asc' as const;
-
-type UserSortKey = 'name' | 'role' | 'lastUpdated';
-
-function compareUsers(
-  a: UserListItem,
-  b: UserListItem,
-  sortKey: UserSortKey,
-  direction: 'asc' | 'desc'
-): number {
-  const mult = direction === 'asc' ? 1 : -1;
-  switch (sortKey) {
-    case 'name': {
-      const na = (a.adDisplayName ?? a.adUsername ?? '').toLowerCase();
-      const nb = (b.adDisplayName ?? b.adUsername ?? '').toLowerCase();
-      return mult * na.localeCompare(nb);
-    }
-    case 'role': {
-      const ra = (a.roleName ?? '').toLowerCase();
-      const rb = (b.roleName ?? '').toLowerCase();
-      return mult * ra.localeCompare(rb);
-    }
-    case 'lastUpdated': {
-      const ta = new Date(
-        (a as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
-      ).getTime();
-      const tb = new Date(
-        (b as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
-      ).getTime();
-      return mult * (ta - tb);
-    }
-    default:
-      return 0;
-  }
-}
 
 export function Users() {
   const [activeTab, setActiveTab] = useState<'users' | 'teams'>('users');
-  const [keyword, setKeyword] = useState('');
-  const [teamIds, setTeamIds] = useState<number[]>([]);
-  const [roleIds, setRoleIds] = useState<number[]>([]);
-  const [sortKey, setSortKey] = useState<UserSortKey | null>(DEFAULT_SORT_KEY);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
-    DEFAULT_SORT_DIRECTION
-  );
   const [editUser, setEditUser] = useState<UserListItem | null>(null);
   const [transferSourceUser, setTransferSourceUser] =
     useState<UserListItem | null>(null);
   const [historyUser, setHistoryUser] = useState<UserListItem | null>(null);
   const [showCreateTeam, setShowCreateTeam] = useState(false);
   const [showCreateUser, setShowCreateUser] = useState(false);
-  const [showInactive, setShowInactive] = useState(false);
   const [teamToEdit, setTeamToEdit] = useState<TeamListItem | null>(null);
   const [teamHistoryTeam, setTeamHistoryTeam] = useState<TeamListItem | null>(
     null
@@ -145,50 +42,6 @@ export function Users() {
   const canCreateTeam = hasPermission(PERMISSIONS.TEAMS.CREATE);
   const canEditTeam = hasPermission(PERMISSIONS.TEAMS.EDIT);
   const canDeleteTeam = hasPermission(PERMISSIONS.TEAMS.DELETE);
-
-  const fetchUsersParams = useMemo(
-    () => ({
-      search: keyword || undefined,
-      teamIds: teamIds.length ? teamIds : undefined,
-      roleIds: roleIds.length ? roleIds : undefined,
-    }),
-    [keyword, teamIds, roleIds]
-  );
-
-  const { data: users = [], isLoading } = useQuery({
-    queryKey: ['users', fetchUsersParams],
-    queryFn: () => fetchUsers(fetchUsersParams),
-  });
-
-  const sortedUsers = useMemo(() => {
-    const key = sortKey ?? DEFAULT_SORT_KEY;
-    const dir = sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
-    return [...users].sort((a, b) => compareUsers(a, b, key, dir));
-  }, [users, sortKey, sortDirection]);
-
-  const { data: teamsForFilter = [] } = useQuery({
-    queryKey: ['teams'],
-    queryFn: fetchTeams,
-  });
-
-  const { data: rolesForFilter = [] } = useQuery({
-    queryKey: ['roles'],
-    queryFn: fetchRoles,
-  });
-
-  const teamOptions = useMemo(
-    () =>
-      teamsForFilter.map((t) => ({
-        value: String(t.id),
-        label: t.displayName || t.name,
-      })),
-    [teamsForFilter]
-  );
-
-  const roleOptions = useMemo(
-    () => rolesForFilter.map((r) => ({ value: String(r.id), label: r.name })),
-    [rolesForFilter]
-  );
 
   const updateMutation = useMutation({
     mutationFn: ({
@@ -251,14 +104,6 @@ export function Users() {
     [updateMutation]
   );
 
-  const handleSortChange = useCallback(
-    (key: string | null, direction: 'asc' | 'desc') => {
-      setSortKey(key as UserSortKey | null);
-      setSortDirection(direction);
-    },
-    []
-  );
-
   return (
     <div className="mx-auto max-w-7xl px-6 py-6">
       <PageHeader
@@ -279,234 +124,22 @@ export function Users() {
         onValueChange={(v) => setActiveTab(v as 'users' | 'teams')}
       >
         <div className="mb-0">
-          <TabsList className="mb-0" variant="line">
+          <TabsList className="mb-0" variant="line" size="med">
             <TabsTrigger value="users">Users</TabsTrigger>
             {canViewTeams && <TabsTrigger value="teams">Teams</TabsTrigger>}
           </TabsList>
         </div>
 
         <TabsContent value="users" className="mt-0">
-          <UserManagementFilters
-            keyword={keyword}
-            teamIds={teamIds}
-            roleIds={roleIds}
-            onKeywordChange={setKeyword}
-            onTeamIdsChange={setTeamIds}
-            onRoleIdsChange={setRoleIds}
-            teamOptions={teamOptions}
-            roleOptions={roleOptions}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            defaultSortKey={DEFAULT_SORT_KEY}
-            defaultSortDirection={DEFAULT_SORT_DIRECTION}
-            className="mb-4"
+          <UsersTabContent
+            canEdit={canEdit}
+            canTransfer={canTransfer}
+            onEditUser={setEditUser}
+            onTransfer={setTransferSourceUser}
+            onViewHistory={setHistoryUser}
+            onDeactivate={handleDeactivate}
+            onReactivate={handleReactivate}
           />
-
-          <TableSummaryBar
-            count={sortedUsers.length}
-            singularLabel="user"
-            pluralLabel="users"
-            filters={[
-              {
-                id: 'show-inactive',
-                label: 'Show inactive',
-                checked: showInactive,
-                onCheckedChange: setShowInactive,
-              },
-            ]}
-          />
-          {isLoading ? (
-            <div className="flex justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-            </div>
-          ) : (
-            <div className="rounded-lg border border-slate-200 bg-white">
-              <table className="w-full table-auto border-collapse">
-                <thead>
-                  <tr className="border-b border-slate-200 bg-slate-50">
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      <span className="inline-flex items-center gap-1">
-                        Name
-                        <SortIndicator
-                          columnId="name"
-                          sortKey={sortKey}
-                          sortDirection={
-                            sortKey !== null
-                              ? sortDirection
-                              : DEFAULT_SORT_DIRECTION
-                          }
-                          className="h-4 w-4"
-                        />
-                      </span>
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Email
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      IDIR
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      <span className="inline-flex items-center gap-1">
-                        Role
-                        <SortIndicator
-                          columnId="role"
-                          sortKey={sortKey}
-                          sortDirection={
-                            sortKey !== null
-                              ? sortDirection
-                              : DEFAULT_SORT_DIRECTION
-                          }
-                          className="h-4 w-4"
-                        />
-                      </span>
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Teams
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Status
-                    </th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      <span className="inline-flex items-center gap-1">
-                        Last updated
-                        <SortIndicator
-                          columnId="lastUpdated"
-                          sortKey={sortKey}
-                          sortDirection={
-                            sortKey !== null
-                              ? sortDirection
-                              : DEFAULT_SORT_DIRECTION
-                          }
-                          className="h-4 w-4"
-                        />
-                      </span>
-                    </th>
-                    <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedUsers.map((user) => (
-                    <tr
-                      key={user.id}
-                      className="border-b border-slate-100 hover:bg-slate-50/50"
-                    >
-                      <td className="px-4 py-3 font-medium text-slate-900">
-                        {displayName(user)}
-                      </td>
-                      <td className="px-4 py-3 text-slate-600">
-                        {user.adEmail ?? '-'}
-                      </td>
-                      <td className="px-4 py-3 text-slate-600">
-                        {IDIR_PLACEHOLDER}
-                      </td>
-                      <td className="px-4 py-3">
-                        <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
-                          {user.roleName}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-1">
-                          {user.teams.length === 0 ? (
-                            <span className="text-slate-400">-</span>
-                          ) : (
-                            user.teams.map((t) => (
-                              <span
-                                key={t.teamId}
-                                className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
-                              >
-                                {t.teamName}
-                                {t.role !== 'member' ? ` (${t.role})` : ''}
-                              </span>
-                            ))
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3">
-                        {statusBadge(user.isActive)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-slate-600">
-                        {formatLastUpdated(
-                          (user as { lastUpdatedDateTime?: string | null })
-                            .lastUpdatedDateTime
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8"
-                              aria-label="Actions"
-                            >
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {canEdit && (
-                              <DropdownMenuItem
-                                onClick={() => setEditUser(user)}
-                              >
-                                <Pencil className="h-4 w-4" />
-                                Edit
-                              </DropdownMenuItem>
-                            )}
-                            {canEdit && (
-                              <DropdownMenuItem
-                                onClick={() => setEditUser(user)}
-                              >
-                                <UsersRound className="h-4 w-4" />
-                                Add to team / Edit teams
-                              </DropdownMenuItem>
-                            )}
-                            {canTransfer && (
-                              <DropdownMenuItem
-                                onClick={() => setTransferSourceUser(user)}
-                              >
-                                <ArrowLeftRight className="h-4 w-4" />
-                                Transfer activities
-                              </DropdownMenuItem>
-                            )}
-                            <DropdownMenuItem
-                              onClick={() => setHistoryUser(user)}
-                            >
-                              <History className="h-4 w-4" />
-                              View history
-                            </DropdownMenuItem>
-                            {canEdit && user.isActive && (
-                              <DropdownMenuItem
-                                onClick={() => handleDeactivate(user)}
-                                variant="destructive"
-                              >
-                                Deactivate
-                              </DropdownMenuItem>
-                            )}
-                            {canEdit && !user.isActive && (
-                              <DropdownMenuItem
-                                onClick={() => handleReactivate(user)}
-                              >
-                                Reactivate
-                              </DropdownMenuItem>
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {sortedUsers.length === 0 && (
-                <div className="py-12 text-center text-slate-500">
-                  {keyword || teamIds.length > 0 || roleIds.length > 0
-                    ? 'No users match your filters'
-                    : 'No users found'}
-                </div>
-              )}
-            </div>
-          )}
 
           {editUser && (
             <UserEditModal

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -5,6 +5,7 @@ import {
   Loader2,
   MoreHorizontal,
   Pencil,
+  Plus,
   UsersRound,
 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -20,6 +21,9 @@ import {
   removeUserFromTeam,
   updateUser,
 } from '@/api/usersApi';
+import { PageHeader } from '@/components/PageHeader';
+import { SortIndicator } from '@/components/Table/SortIndicator';
+import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { TeamEditModal } from '@/components/teams/TeamEditModal';
 import { TeamHistoryDrawer } from '@/components/teams/TeamHistoryDrawer';
 import { TeamsTabContent } from '@/components/teams/TeamsTabContent';
@@ -32,6 +36,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TransferActivitiesDialog } from '@/components/users/TransferActivitiesDialog';
+import { UserCreateModal } from '@/components/users/UserCreateModal';
 import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserHistoryDrawer } from '@/components/users/UserHistoryDrawer';
 import { UserManagementFilters } from '@/components/users/UserManagementFilters';
@@ -73,16 +78,59 @@ function statusBadge(isActive: boolean) {
 
 const IDIR_PLACEHOLDER = 'MYIDIR';
 
+const DEFAULT_SORT_KEY = 'name';
+const DEFAULT_SORT_DIRECTION = 'asc' as const;
+
+type UserSortKey = 'name' | 'role' | 'lastUpdated';
+
+function compareUsers(
+  a: UserListItem,
+  b: UserListItem,
+  sortKey: UserSortKey,
+  direction: 'asc' | 'desc'
+): number {
+  const mult = direction === 'asc' ? 1 : -1;
+  switch (sortKey) {
+    case 'name': {
+      const na = (a.adDisplayName ?? a.adUsername ?? '').toLowerCase();
+      const nb = (b.adDisplayName ?? b.adUsername ?? '').toLowerCase();
+      return mult * na.localeCompare(nb);
+    }
+    case 'role': {
+      const ra = (a.roleName ?? '').toLowerCase();
+      const rb = (b.roleName ?? '').toLowerCase();
+      return mult * ra.localeCompare(rb);
+    }
+    case 'lastUpdated': {
+      const ta = new Date(
+        (a as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
+      ).getTime();
+      const tb = new Date(
+        (b as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ?? 0
+      ).getTime();
+      return mult * (ta - tb);
+    }
+    default:
+      return 0;
+  }
+}
+
 export function Users() {
   const [activeTab, setActiveTab] = useState<'users' | 'teams'>('users');
   const [keyword, setKeyword] = useState('');
   const [teamIds, setTeamIds] = useState<number[]>([]);
   const [roleIds, setRoleIds] = useState<number[]>([]);
+  const [sortKey, setSortKey] = useState<UserSortKey | null>(DEFAULT_SORT_KEY);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
+    DEFAULT_SORT_DIRECTION
+  );
   const [editUser, setEditUser] = useState<UserListItem | null>(null);
   const [transferSourceUser, setTransferSourceUser] =
     useState<UserListItem | null>(null);
   const [historyUser, setHistoryUser] = useState<UserListItem | null>(null);
   const [showCreateTeam, setShowCreateTeam] = useState(false);
+  const [showCreateUser, setShowCreateUser] = useState(false);
+  const [showInactive, setShowInactive] = useState(false);
   const [teamToEdit, setTeamToEdit] = useState<TeamListItem | null>(null);
   const [teamHistoryTeam, setTeamHistoryTeam] = useState<TeamListItem | null>(
     null
@@ -91,6 +139,7 @@ export function Users() {
   const queryClient = useQueryClient();
   const { hasPermission } = useAuth();
   const canEdit = hasPermission(PERMISSIONS.USERS.EDIT);
+  const canCreateUser = hasPermission(PERMISSIONS.USERS.CREATE);
   const canTransfer = hasPermission(PERMISSIONS.USERS.TRANSFER_ACTIVITIES);
   const canViewTeams = hasPermission(PERMISSIONS.TEAMS.VIEW);
   const canCreateTeam = hasPermission(PERMISSIONS.TEAMS.CREATE);
@@ -110,6 +159,12 @@ export function Users() {
     queryKey: ['users', fetchUsersParams],
     queryFn: () => fetchUsers(fetchUsersParams),
   });
+
+  const sortedUsers = useMemo(() => {
+    const key = sortKey ?? DEFAULT_SORT_KEY;
+    const dir = sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
+    return [...users].sort((a, b) => compareUsers(a, b, key, dir));
+  }, [users, sortKey, sortDirection]);
 
   const { data: teamsForFilter = [] } = useQuery({
     queryKey: ['teams'],
@@ -196,27 +251,39 @@ export function Users() {
     [updateMutation]
   );
 
+  const handleSortChange = useCallback(
+    (key: string | null, direction: 'asc' | 'desc') => {
+      setSortKey(key as UserSortKey | null);
+      setSortDirection(direction);
+    },
+    []
+  );
+
   return (
     <div className="mx-auto max-w-7xl px-6 py-6">
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-900">
-            User & Team Management
-          </h1>
-          <p className="text-sm text-slate-600">
-            Manage user accounts, teams, and roles
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="User & Team Management"
+        description="Manage user accounts, teams, and roles"
+        action={
+          canCreateUser && (
+            <Button onClick={() => setShowCreateUser(true)}>
+              <Plus className="h-4 w-4" />
+              Add user
+            </Button>
+          )
+        }
+      />
 
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as 'users' | 'teams')}
       >
-        <TabsList className="mb-4">
-          <TabsTrigger value="users">Users</TabsTrigger>
-          {canViewTeams && <TabsTrigger value="teams">Teams</TabsTrigger>}
-        </TabsList>
+        <div className="mb-0">
+          <TabsList className="mb-0" variant="line">
+            <TabsTrigger value="users">Users</TabsTrigger>
+            {canViewTeams && <TabsTrigger value="teams">Teams</TabsTrigger>}
+          </TabsList>
+        </div>
 
         <TabsContent value="users" className="mt-0">
           <UserManagementFilters
@@ -228,11 +295,27 @@ export function Users() {
             onRoleIdsChange={setRoleIds}
             teamOptions={teamOptions}
             roleOptions={roleOptions}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={handleSortChange}
+            defaultSortKey={DEFAULT_SORT_KEY}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
             className="mb-4"
           />
-          <div className="mb-2 text-sm text-slate-500">
-            {users.length} {users.length === 1 ? 'user' : 'users'}
-          </div>
+
+          <TableSummaryBar
+            count={sortedUsers.length}
+            singularLabel="user"
+            pluralLabel="users"
+            filters={[
+              {
+                id: 'show-inactive',
+                label: 'Show inactive',
+                checked: showInactive,
+                onCheckedChange: setShowInactive,
+              },
+            ]}
+          />
           {isLoading ? (
             <div className="flex justify-center py-12">
               <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
@@ -243,7 +326,19 @@ export function Users() {
                 <thead>
                   <tr className="border-b border-slate-200 bg-slate-50">
                     <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Name
+                      <span className="inline-flex items-center gap-1">
+                        Name
+                        <SortIndicator
+                          columnId="name"
+                          sortKey={sortKey}
+                          sortDirection={
+                            sortKey !== null
+                              ? sortDirection
+                              : DEFAULT_SORT_DIRECTION
+                          }
+                          className="h-4 w-4"
+                        />
+                      </span>
                     </th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                       Email
@@ -252,7 +347,19 @@ export function Users() {
                       IDIR
                     </th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Role
+                      <span className="inline-flex items-center gap-1">
+                        Role
+                        <SortIndicator
+                          columnId="role"
+                          sortKey={sortKey}
+                          sortDirection={
+                            sortKey !== null
+                              ? sortDirection
+                              : DEFAULT_SORT_DIRECTION
+                          }
+                          className="h-4 w-4"
+                        />
+                      </span>
                     </th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                       Teams
@@ -261,7 +368,19 @@ export function Users() {
                       Status
                     </th>
                     <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                      Last updated
+                      <span className="inline-flex items-center gap-1">
+                        Last updated
+                        <SortIndicator
+                          columnId="lastUpdated"
+                          sortKey={sortKey}
+                          sortDirection={
+                            sortKey !== null
+                              ? sortDirection
+                              : DEFAULT_SORT_DIRECTION
+                          }
+                          className="h-4 w-4"
+                        />
+                      </span>
                     </th>
                     <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
                       Actions
@@ -269,7 +388,7 @@ export function Users() {
                   </tr>
                 </thead>
                 <tbody>
-                  {users.map((user) => (
+                  {sortedUsers.map((user) => (
                     <tr
                       key={user.id}
                       className="border-b border-slate-100 hover:bg-slate-50/50"
@@ -379,7 +498,7 @@ export function Users() {
                   ))}
                 </tbody>
               </table>
-              {users.length === 0 && (
+              {sortedUsers.length === 0 && (
                 <div className="py-12 text-center text-slate-500">
                   {keyword || teamIds.length > 0 || roleIds.length > 0
                     ? 'No users match your filters'
@@ -421,6 +540,11 @@ export function Users() {
               onClose={() => setHistoryUser(null)}
             />
           )}
+
+          <UserCreateModal
+            open={showCreateUser}
+            onClose={() => setShowCreateUser(false)}
+          />
         </TabsContent>
 
         <TabsContent value="teams" className="mt-0">

--- a/calendar-ui/src/pages/Users.tsx
+++ b/calendar-ui/src/pages/Users.tsx
@@ -8,11 +8,21 @@ import {
   UsersRound,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
-import type { UserListItem } from '@corpcal/shared/api/types';
-import { fetchUsers, removeUserFromTeam, updateUser } from '@/api/usersApi';
+import type { TeamListItem, UserListItem } from '@corpcal/shared/api/types';
+import { updateTeam } from '@/api/teamsApi';
+import {
+  fetchRoles,
+  fetchTeams,
+  fetchUsers,
+  removeUserFromTeam,
+  updateUser,
+} from '@/api/usersApi';
+import { TeamEditModal } from '@/components/teams/TeamEditModal';
+import { TeamHistoryDrawer } from '@/components/teams/TeamHistoryDrawer';
+import { TeamsTabContent } from '@/components/teams/TeamsTabContent';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -20,17 +30,33 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TransferActivitiesDialog } from '@/components/users/TransferActivitiesDialog';
 import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserHistoryDrawer } from '@/components/users/UserHistoryDrawer';
+import { UserManagementFilters } from '@/components/users/UserManagementFilters';
 import { useAuth } from '@/hooks/useAuth';
 
 function displayName(user: UserListItem): string {
   return user.adDisplayName || user.adUsername || `User ${user.id}`;
 }
 
-// TODO: review inline styling and move to centralized semantic colours/styles
+function formatLastUpdated(iso: string | null | undefined): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? '-'
+      : d.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        });
+  } catch {
+    return '-';
+  }
+}
+
 function statusBadge(isActive: boolean) {
   return (
     <span
@@ -45,22 +71,69 @@ function statusBadge(isActive: boolean) {
   );
 }
 
+const IDIR_PLACEHOLDER = 'MYIDIR';
+
 export function Users() {
-  const [search, setSearch] = useState('');
+  const [activeTab, setActiveTab] = useState<'users' | 'teams'>('users');
+  const [keyword, setKeyword] = useState('');
+  const [teamIds, setTeamIds] = useState<number[]>([]);
+  const [roleIds, setRoleIds] = useState<number[]>([]);
   const [editUser, setEditUser] = useState<UserListItem | null>(null);
   const [transferSourceUser, setTransferSourceUser] =
     useState<UserListItem | null>(null);
   const [historyUser, setHistoryUser] = useState<UserListItem | null>(null);
+  const [showCreateTeam, setShowCreateTeam] = useState(false);
+  const [teamToEdit, setTeamToEdit] = useState<TeamListItem | null>(null);
+  const [teamHistoryTeam, setTeamHistoryTeam] = useState<TeamListItem | null>(
+    null
+  );
 
   const queryClient = useQueryClient();
   const { hasPermission } = useAuth();
   const canEdit = hasPermission(PERMISSIONS.USERS.EDIT);
   const canTransfer = hasPermission(PERMISSIONS.USERS.TRANSFER_ACTIVITIES);
+  const canViewTeams = hasPermission(PERMISSIONS.TEAMS.VIEW);
+  const canCreateTeam = hasPermission(PERMISSIONS.TEAMS.CREATE);
+  const canEditTeam = hasPermission(PERMISSIONS.TEAMS.EDIT);
+  const canDeleteTeam = hasPermission(PERMISSIONS.TEAMS.DELETE);
+
+  const fetchUsersParams = useMemo(
+    () => ({
+      search: keyword || undefined,
+      teamIds: teamIds.length ? teamIds : undefined,
+      roleIds: roleIds.length ? roleIds : undefined,
+    }),
+    [keyword, teamIds, roleIds]
+  );
 
   const { data: users = [], isLoading } = useQuery({
-    queryKey: ['users', search],
-    queryFn: () => fetchUsers(search || undefined),
+    queryKey: ['users', fetchUsersParams],
+    queryFn: () => fetchUsers(fetchUsersParams),
   });
+
+  const { data: teamsForFilter = [] } = useQuery({
+    queryKey: ['teams'],
+    queryFn: fetchTeams,
+  });
+
+  const { data: rolesForFilter = [] } = useQuery({
+    queryKey: ['roles'],
+    queryFn: fetchRoles,
+  });
+
+  const teamOptions = useMemo(
+    () =>
+      teamsForFilter.map((t) => ({
+        value: String(t.id),
+        label: t.displayName || t.name,
+      })),
+    [teamsForFilter]
+  );
+
+  const roleOptions = useMemo(
+    () => rolesForFilter.map((r) => ({ value: String(r.id), label: r.name })),
+    [rolesForFilter]
+  );
 
   const updateMutation = useMutation({
     mutationFn: ({
@@ -92,6 +165,17 @@ export function Users() {
     },
   });
 
+  const deactivateTeamMutation = useMutation({
+    mutationFn: (teamId: number) => updateTeam(teamId, { isActive: false }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      toast.success('Team deactivated');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Deactivate failed');
+    },
+  });
+
   const handleDeactivate = useCallback(
     (user: UserListItem) => {
       updateMutation.mutate({
@@ -117,7 +201,7 @@ export function Users() {
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-slate-900">
-            User Management
+            User & Team Management
           </h1>
           <p className="text-sm text-slate-600">
             Manage user accounts, teams, and roles
@@ -125,181 +209,254 @@ export function Users() {
         </div>
       </div>
 
-      <div className="mb-4 flex items-center gap-4">
-        <Input
-          placeholder="Search by name, email, or username..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-sm"
-        />
-        <span className="text-sm text-slate-500">
-          {users.length} {users.length === 1 ? 'user' : 'users'}
-        </span>
-      </div>
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as 'users' | 'teams')}
+      >
+        <TabsList className="mb-4">
+          <TabsTrigger value="users">Users</TabsTrigger>
+          {canViewTeams && <TabsTrigger value="teams">Teams</TabsTrigger>}
+        </TabsList>
 
-      {isLoading ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-        </div>
-      ) : (
-        <div className="rounded-lg border border-slate-200 bg-white">
-          <table className="w-full table-auto border-collapse">
-            <thead>
-              <tr className="border-b border-slate-200 bg-slate-50">
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Name
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Email
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Role
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Teams
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Status
-                </th>
-                <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {users.map((user) => (
-                <tr
-                  key={user.id}
-                  className="border-b border-slate-100 hover:bg-slate-50/50"
-                >
-                  <td className="px-4 py-3 font-medium text-slate-900">
-                    {displayName(user)}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {user.adEmail ?? '-'}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
-                      {user.roleName}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {user.teams.length === 0 ? (
-                        <span className="text-slate-400">-</span>
-                      ) : (
-                        user.teams.map((t) => (
-                          <span
-                            key={t.teamId}
-                            className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
-                          >
-                            {t.teamName}
-                            {t.role !== 'member' ? ` (${t.role})` : ''}
-                          </span>
-                        ))
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">{statusBadge(user.isActive)}</td>
-                  <td className="px-4 py-3">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8"
-                          aria-label="Actions"
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        {canEdit && (
-                          <DropdownMenuItem onClick={() => setEditUser(user)}>
-                            <Pencil className="h-4 w-4" />
-                            Edit
-                          </DropdownMenuItem>
+        <TabsContent value="users" className="mt-0">
+          <UserManagementFilters
+            keyword={keyword}
+            teamIds={teamIds}
+            roleIds={roleIds}
+            onKeywordChange={setKeyword}
+            onTeamIdsChange={setTeamIds}
+            onRoleIdsChange={setRoleIds}
+            teamOptions={teamOptions}
+            roleOptions={roleOptions}
+            className="mb-4"
+          />
+          <div className="mb-2 text-sm text-slate-500">
+            {users.length} {users.length === 1 ? 'user' : 'users'}
+          </div>
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+            </div>
+          ) : (
+            <div className="rounded-lg border border-slate-200 bg-white">
+              <table className="w-full table-auto border-collapse">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Name
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Email
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      IDIR
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Role
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Teams
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Last updated
+                    </th>
+                    <th className="w-[60px] px-4 py-3 text-left text-sm font-medium text-slate-700">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map((user) => (
+                    <tr
+                      key={user.id}
+                      className="border-b border-slate-100 hover:bg-slate-50/50"
+                    >
+                      <td className="px-4 py-3 font-medium text-slate-900">
+                        {displayName(user)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-600">
+                        {user.adEmail ?? '-'}
+                      </td>
+                      <td className="px-4 py-3 text-slate-600">
+                        {IDIR_PLACEHOLDER}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="rounded border border-slate-200 px-2 py-0.5 text-xs">
+                          {user.roleName}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {user.teams.length === 0 ? (
+                            <span className="text-slate-400">-</span>
+                          ) : (
+                            user.teams.map((t) => (
+                              <span
+                                key={t.teamId}
+                                className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
+                              >
+                                {t.teamName}
+                                {t.role !== 'member' ? ` (${t.role})` : ''}
+                              </span>
+                            ))
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        {statusBadge(user.isActive)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-slate-600">
+                        {formatLastUpdated(
+                          (user as { lastUpdatedDateTime?: string | null })
+                            .lastUpdatedDateTime
                         )}
-                        {canEdit && (
-                          <DropdownMenuItem onClick={() => setEditUser(user)}>
-                            <UsersRound className="h-4 w-4" />
-                            Add to team / Edit teams
-                          </DropdownMenuItem>
-                        )}
-                        {canTransfer && (
-                          <DropdownMenuItem
-                            onClick={() => setTransferSourceUser(user)}
-                          >
-                            <ArrowLeftRight className="h-4 w-4" />
-                            Transfer activities
-                          </DropdownMenuItem>
-                        )}
-                        <DropdownMenuItem onClick={() => setHistoryUser(user)}>
-                          <History className="h-4 w-4" />
-                          View history
-                        </DropdownMenuItem>
-                        {canEdit && user.isActive && (
-                          <DropdownMenuItem
-                            onClick={() => handleDeactivate(user)}
-                            variant="destructive"
-                          >
-                            Deactivate
-                          </DropdownMenuItem>
-                        )}
-                        {canEdit && !user.isActive && (
-                          <DropdownMenuItem
-                            onClick={() => handleReactivate(user)}
-                          >
-                            Reactivate
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          {users.length === 0 && (
-            <div className="py-12 text-center text-slate-500">
-              {search ? 'No users match your search' : 'No users found'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              aria-label="Actions"
+                            >
+                              <MoreHorizontal className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {canEdit && (
+                              <DropdownMenuItem
+                                onClick={() => setEditUser(user)}
+                              >
+                                <Pencil className="h-4 w-4" />
+                                Edit
+                              </DropdownMenuItem>
+                            )}
+                            {canEdit && (
+                              <DropdownMenuItem
+                                onClick={() => setEditUser(user)}
+                              >
+                                <UsersRound className="h-4 w-4" />
+                                Add to team / Edit teams
+                              </DropdownMenuItem>
+                            )}
+                            {canTransfer && (
+                              <DropdownMenuItem
+                                onClick={() => setTransferSourceUser(user)}
+                              >
+                                <ArrowLeftRight className="h-4 w-4" />
+                                Transfer activities
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuItem
+                              onClick={() => setHistoryUser(user)}
+                            >
+                              <History className="h-4 w-4" />
+                              View history
+                            </DropdownMenuItem>
+                            {canEdit && user.isActive && (
+                              <DropdownMenuItem
+                                onClick={() => handleDeactivate(user)}
+                                variant="destructive"
+                              >
+                                Deactivate
+                              </DropdownMenuItem>
+                            )}
+                            {canEdit && !user.isActive && (
+                              <DropdownMenuItem
+                                onClick={() => handleReactivate(user)}
+                              >
+                                Reactivate
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {users.length === 0 && (
+                <div className="py-12 text-center text-slate-500">
+                  {keyword || teamIds.length > 0 || roleIds.length > 0
+                    ? 'No users match your filters'
+                    : 'No users found'}
+                </div>
+              )}
             </div>
           )}
-        </div>
-      )}
 
-      {editUser && (
-        <UserEditModal
-          user={editUser}
-          onClose={() => setEditUser(null)}
-          onSaved={() => {
-            void queryClient.invalidateQueries({ queryKey: ['users'] });
-            setEditUser(null);
-          }}
-          onRemoveFromTeam={(userId, teamId) =>
-            removeTeamMutation.mutate({ userId, teamId })
-          }
-        />
-      )}
+          {editUser && (
+            <UserEditModal
+              user={editUser}
+              onClose={() => setEditUser(null)}
+              onSaved={() => {
+                void queryClient.invalidateQueries({ queryKey: ['users'] });
+                setEditUser(null);
+              }}
+              onRemoveFromTeam={(userId, teamId) =>
+                removeTeamMutation.mutate({ userId, teamId })
+              }
+            />
+          )}
 
-      {transferSourceUser && (
-        <TransferActivitiesDialog
-          sourceUser={transferSourceUser}
-          onClose={() => setTransferSourceUser(null)}
-          onTransferred={() => {
-            void queryClient.invalidateQueries({ queryKey: ['users'] });
-            setTransferSourceUser(null);
-          }}
-        />
-      )}
+          {transferSourceUser && (
+            <TransferActivitiesDialog
+              sourceUser={transferSourceUser}
+              onClose={() => setTransferSourceUser(null)}
+              onTransferred={() => {
+                void queryClient.invalidateQueries({ queryKey: ['users'] });
+                setTransferSourceUser(null);
+              }}
+            />
+          )}
 
-      {historyUser && (
-        <UserHistoryDrawer
-          user={historyUser}
-          open={!!historyUser}
-          onClose={() => setHistoryUser(null)}
-        />
-      )}
+          {historyUser && (
+            <UserHistoryDrawer
+              user={historyUser}
+              open={!!historyUser}
+              onClose={() => setHistoryUser(null)}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="teams" className="mt-0">
+          {canViewTeams && (
+            <TeamsTabContent
+              canCreate={canCreateTeam}
+              canEdit={canEditTeam}
+              canDelete={canDeleteTeam}
+              onAddTeam={() => setShowCreateTeam(true)}
+              onEditTeam={setTeamToEdit}
+              onViewHistory={setTeamHistoryTeam}
+              onDeactivate={(team) => deactivateTeamMutation.mutate(team.id)}
+            />
+          )}
+        </TabsContent>
+      </Tabs>
+
+      <TeamEditModal
+        team={showCreateTeam ? null : (teamToEdit ?? null)}
+        open={showCreateTeam || !!teamToEdit}
+        onClose={() => {
+          setShowCreateTeam(false);
+          setTeamToEdit(null);
+        }}
+        onSaved={() => {
+          void queryClient.invalidateQueries({ queryKey: ['teams'] });
+          setShowCreateTeam(false);
+          setTeamToEdit(null);
+        }}
+      />
+
+      <TeamHistoryDrawer
+        team={teamHistoryTeam}
+        open={!!teamHistoryTeam}
+        onClose={() => setTeamHistoryTeam(null)}
+      />
     </div>
   );
 }

--- a/calendar-ui/src/styles/globals.css
+++ b/calendar-ui/src/styles/globals.css
@@ -95,6 +95,79 @@
     --bc-gold: #fcba19;
     --bc-gold-dark: #e8a317;
 
+    /* BCSDS color primitives */
+    /* Simplified from BC Design System tokens */
+    /* https://www2.gov.bc.ca/gov/content/digital/design-system/foundations/design-tokens/glossary */
+    --bcsds-gold-10: #fff8e9;
+    --bcsds-gold-15: #fef1d8;
+    --bcsds-gold-20: #feebc2;
+    --bcsds-gold-30: #fddf9d;
+    --bcsds-gold-40: #fdd47b;
+    --bcsds-gold-50: #fcc85d;
+    --bcsds-gold-60: #f8ba47;
+    --bcsds-gold-65: #e3a82b;
+    --bcsds-gold-70: #ce9737;
+    --bcsds-gold-80: #a5792b;
+    --bcsds-gold-90: #7e5d21;
+    --bcsds-gold-100: #584215;
+    --bcsds-bc-blue-5: #f7f9fc;
+    --bcsds-bc-blue-10: #f1f8fe;
+    --bcsds-bc-blue-20: #d8eafd;
+    --bcsds-bc-blue-30: #c1ddfc;
+    --bcsds-bc-blue-40: #a8d0fb;
+    --bcsds-bc-blue-50: #91c4fa;
+    --bcsds-bc-blue-60: #7ab8f9;
+    --bcsds-bc-blue-70: #5595d9;
+    --bcsds-bc-blue-80: #3470b1;
+    --bcsds-bc-blue-90: #1e5189;
+    --bcsds-bc-blue-95: #234075;
+    --bcsds-bc-blue-99: #013366;
+    --bcsds-bc-blue-100: #053662;
+    --bcsds-bc-blue-110: #083155;
+    --bcsds-link-blue-60: #2e5dd7;
+    --bcsds-aqua-blue-70: #2378c7;
+    --bcsds-aqua-blue-90: #255a90;
+    --bcsds-warm-grey-10: #faf9f8;
+    --bcsds-warm-grey-20: #f3f2f1;
+    --bcsds-warm-grey-30: #eceae8;
+    --bcsds-warm-grey-40: #e0dedc;
+    --bcsds-warm-grey-50: #d1cfcd;
+    --bcsds-warm-grey-60: #c6c5c3;
+    --bcsds-warm-grey-70: #9f9d9c;
+    --bcsds-warm-grey-75: #898785;
+    --bcsds-warm-grey-80: #605e5c;
+    --bcsds-warm-grey-85: #474543;
+    --bcsds-warm-grey-90: #3d3c3b;
+    --bcsds-warm-grey-100: #353433;
+    --bcsds-warm-grey-110: #252423;
+    --bcsds-neutral-grey-50: #d8d8d8;
+    --bcsds-neutral-grey-105: #2d2d2d;
+    --bcsds-red-15: #f4e1e2;
+    --bcsds-red-60: #ce3e39;
+    --bcsds-red-80: #a2312d;
+    --bcsds-red-90: #902b28;
+    --bcsds-green-5: #f6fff8;
+    --bcsds-green-60: #42814a;
+    --bcsds-green-80: #35673b;
+    --bcsds-green-90: #2e5a34;
+    --bcsds-white-00: #ffffff;
+    --bcsds-white-opacity-00-15: #ffffff15;
+    --bcsds-white-opacity-00-05: #ffffff05;
+    --bcsds-white-opacity-00-45: #ffffff45;
+    --bcsds-white-opacity-00-10: #ffffff10;
+    --bcsds-white-opacity-00-20: #ffffff20;
+    --bcsds-black-100: #000000;
+    --bcsds-black-opacity-100-00: #00000000;
+    --bcsds-black-opacity-100-45: #00000045;
+    --bcsds-black-opacity-100-15: #00000015;
+    --bcsds-black-opacity-100-05: #00000005;
+    --bcsds-black-opacity-100-10: #00000010;
+
+    /* BCSDS semantic tokens */
+    --bcsds-button-primary-background: var(--bcsds-bc-blue-95);
+    --bcsds-button-primary-foreground: var(--bcsds-white-00);
+    --bcsds-button-primary-hover-background: var(--bcsds-bc-blue-90);
+
     /* Tabs underline (#0F6CBD equivalent) */
     --tabs-underline: oklch(0.5263 0.1493 251.63);
 

--- a/calendar-ui/src/styles/globals.css
+++ b/calendar-ui/src/styles/globals.css
@@ -94,6 +94,12 @@
     --bc-blue-light: #1a4b82;
     --bc-gold: #fcba19;
     --bc-gold-dark: #e8a317;
+
+    /* Tabs underline (#0F6CBD equivalent) */
+    --tabs-underline: oklch(0.5263 0.1493 251.63);
+
+    /* Link / interactive blue (#0F6CBD equivalent) */
+    --link: oklch(0.5263 0.1493 251.63);
   }
 
   .dark {
@@ -130,6 +136,9 @@
     --sidebar-ring: oklch(0.439 0 0);
     --inverted-background: oklch(0.985 0 0);
     --inverted-foreground: oklch(0.145 0 0);
+
+    --tabs-underline: oklch(0.5263 0.1493 251.63);
+    --link: oklch(0.5263 0.1493 251.63);
   }
 }
 
@@ -155,6 +164,8 @@
   --color-card-foreground: var(--card-foreground);
   --color-inverted-background: var(--inverted-background);
   --color-inverted-foreground: var(--inverted-foreground);
+  --color-tabs-underline: var(--tabs-underline);
+  --color-link: var(--link);
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
@@ -224,6 +235,8 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-tabs-underline: var(--tabs-underline);
+  --color-link: var(--link);
 }
 
 :root {
@@ -259,6 +272,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --tabs-underline: oklch(0.5263 0.1493 251.63);
+  --link: oklch(0.5263 0.1493 251.63);
 }
 
 .dark {
@@ -293,6 +308,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --tabs-underline: oklch(0.5263 0.1493 251.63);
+  --link: oklch(0.5263 0.1493 251.63);
 }
 
 @layer base {

--- a/docs/AUTH_AND_RBAC.md
+++ b/docs/AUTH_AND_RBAC.md
@@ -118,7 +118,7 @@ The system includes 5 predefined roles with hierarchical capabilities:
 | lookups.view              | x         | x      | x        | x     | x            |
 | lookups.manage            |           |        |          | x     | x            |
 | users.view                |           |        |          | x     | x            |
-| users.create              |           |        |          |       | x            |
+| users.create              |           |        |          | x     | x            |
 | users.edit                |           |        |          | x     | x            |
 | users.delete              |           |        |          |       | x            |
 | users.manage_roles        |           |        |          |       | x            |

--- a/packages/database/seeds/0002_20250124_rbac_permissions_seed.sql
+++ b/packages/database/seeds/0002_20250124_rbac_permissions_seed.sql
@@ -74,7 +74,7 @@ WHERE r.name = 'Admin' AND p.key IN (
   'drafts.view','drafts.create','drafts.edit','drafts.delete','drafts.recover',
   'reports.view','reports.export','reports.create_custom',
   'lookups.view','lookups.manage',
-  'users.view','users.edit','users.transfer_activities',
+  'users.view','users.create','users.edit','users.transfer_activities',
   'teams.view','teams.create','teams.edit','teams.delete',
   'settings.view','settings.manage'
 )

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -44,6 +44,7 @@ export const userListItemSchema = z.object({
   roleName: z.string(),
   isActive: z.boolean(),
   teams: z.array(userTeamSchema),
+  lastUpdatedDateTime: z.string().nullable().optional(),
 });
 
 export type UserListItem = z.infer<typeof userListItemSchema>;


### PR DESCRIPTION
## Summary

Adds **team/role filtering** to the Users API, introduces a shared ID‑parsing utility, and UX and layout updates to **User & Team Management** UI (new tables, filters, modals, sorting, pagination). Also adds Teams CRUD support to the UI and adds styling with BCDS tokens.

**Still WIP, but at a good point to check-in**

## Changes

*   **Backend**
    *   Added shared `parseCommaSeparatedIds()` and applied across controllers.
    *   Expanded `UsersController.findAll` + `UsersService.findAll` to handle `teamIds`, `roleIds`, and return `lastUpdatedDateTime`.
    *   Updated RBAC docs + seed to include `users.create` and add to admin

*   **UI**
    *   New Teams API module + Teams CRUD (modal, history drawer, filters).
    *   Table UX: sticky headers, skeleton loading, fixed-height scroll, pagination, column widths.
    *   New filtering components: team/role filters, keyword search, unified SortDropdown.
    *   Updated `fetchUsers()` to support `teamIds`/`roleIds`.
    *   Added BCDS design tokens to `globals.css`.
    *   Added Skeleton component, PageHeader refresh, Tabs cleanup.

## Testing

*   Existing tests passing.
*   Confirm new Users/Teams tabs load and filters, sort, pagination behave correctly.
*   Modals still WIP (edit user, edit team, create team/user placeholder).
*   Confirm UI skeletons, sticky headers, and empty states work as expected.
