### PR TITLE
Feat/corpcal 165 toast ids

### DIFF
--- a/calendar-ui/docs/Toasts.md
+++ b/calendar-ui/docs/Toasts.md
@@ -1,0 +1,22 @@
+# Toast notifications (Sonner)
+
+The app uses [Sonner](https://sonner.emilkowal.ski/) for toasts. Helpers and conventions are documented here and in code.
+
+## Helpers vs direct toast
+
+- **Helpers** ([src/lib/error-toast.ts](../src/lib/error-toast.ts)): Use `showErrorToast()` for API/network errors so messaging and correlation IDs stay consistent. Use `showSuccessToast()` / `showInfoToast()` when you want the same default duration and shape as other app toasts.
+- **Direct** `toast.success()`, `toast.info()`, `toast.error()`: Use when you need custom copy, description, or duration (e.g. "Activity updated" with activity details).
+
+## Toast IDs and deduplication
+
+When the same logical event can trigger toasts from more than one place (e.g. form submit and a WebSocket event), pass the same `id` in the toast options so Sonner updates one toast instead of showing two.
+
+**ID convention:** `{domain}-{action}-{entityId?}`
+
+- Examples: `activity-updated-42`, `activity-created-123`, `user-updated-5`, `team-deactivated-3`, `team-created`.
+- Use a stable id so the same event always uses the same string across call sites.
+
+## Where things live
+
+- Helpers: [calendar-ui/src/lib/error-toast.ts](../src/lib/error-toast.ts)
+- Direct toast calls: search for `toast.` from `sonner` across the app.

--- a/calendar-ui/src/components/teams/TeamEditModal.test.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
+
+import { TeamEditModal } from './TeamEditModal';
+
+const { mockToast, mockCreateTeam, mockUpdateTeam, mockFetchTeamById } =
+  vi.hoisted(() => ({
+    mockToast: { success: vi.fn(), error: vi.fn() },
+    mockCreateTeam: vi.fn(),
+    mockUpdateTeam: vi.fn(),
+    mockFetchTeamById: vi.fn(),
+  }));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('@/api/teamsApi', () => ({
+  createTeam: (...args: unknown[]) => mockCreateTeam(...args),
+  fetchTeamById: (id: number) => mockFetchTeamById(id),
+  updateTeam: (...args: unknown[]) => mockUpdateTeam(...args),
+}));
+
+vi.mock('@/api/lookupsApi', () => ({
+  fetchMinistries: vi.fn().mockResolvedValue([]),
+}));
+
+function renderModal() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TeamEditModal
+        team={null}
+        open={true}
+        onSaved={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+}
+
+function renderEditModal(team: TeamListItem) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TeamEditModal
+        team={team}
+        open={true}
+        onSaved={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+}
+
+const mockTeamListItem: TeamListItem = {
+  id: 5,
+  name: 'Existing Team',
+  displayName: 'Existing',
+  description: 'Team description',
+  sortOrder: 0,
+  isActive: true,
+  memberCount: 0,
+  ministryCount: 0,
+};
+
+const mockTeamDetail: TeamDetail = {
+  ...mockTeamListItem,
+  ministries: [],
+  members: [],
+};
+
+describe('TeamEditModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateTeam.mockResolvedValue({ id: 1, name: 'New Team' });
+  });
+
+  describe('create success toast', () => {
+    it('calls toast.success with id team-created when create succeeds', async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.type(screen.getByLabelText(/name \*/i), 'Test Team');
+      await user.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(mockToast.success).toHaveBeenCalledWith('Team created', {
+          id: 'team-created',
+        });
+      });
+    });
+  });
+
+  describe('create error toast', () => {
+    it('calls toast.error with id team-created when create fails', async () => {
+      mockCreateTeam.mockRejectedValue(new Error('Failed to create'));
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.type(screen.getByLabelText(/name \*/i), 'Test Team');
+      await user.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith('Failed to create', {
+          id: 'team-created',
+        });
+      });
+    });
+  });
+
+  describe('update success toast', () => {
+    it('calls toast.success with id team-updated-{id} when update succeeds', async () => {
+      mockFetchTeamById.mockResolvedValue(mockTeamDetail);
+      mockUpdateTeam.mockResolvedValue({
+        ...mockTeamListItem,
+        name: 'Updated',
+      });
+      const user = userEvent.setup();
+      renderEditModal(mockTeamListItem);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing Team');
+      });
+
+      await user.clear(screen.getByLabelText(/name \*/i));
+      await user.type(screen.getByLabelText(/name \*/i), 'Updated Name');
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(mockToast.success).toHaveBeenCalledWith('Team updated', {
+          id: 'team-updated-5',
+        });
+      });
+    });
+  });
+
+  describe('update error toast', () => {
+    it('calls toast.error with id team-updated-{id} when update fails', async () => {
+      mockFetchTeamById.mockResolvedValue(mockTeamDetail);
+      mockUpdateTeam.mockRejectedValue(new Error('Server error'));
+      const user = userEvent.setup();
+      renderEditModal(mockTeamListItem);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing Team');
+      });
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith('Server error', {
+          id: 'team-updated-5',
+        });
+      });
+    });
+  });
+});

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -11,6 +11,7 @@ import { Combobox } from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -160,6 +161,11 @@ export function TeamEditModal({
       <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isCreate ? 'Create team' : 'Edit team'}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {isCreate
+              ? 'Enter details to create a new team.'
+              : 'Edit team name, display name, description, and settings.'}
+          </DialogDescription>
         </DialogHeader>
         {isLoading ? (
           <div className="flex justify-center py-8">

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -85,12 +85,14 @@ export function TeamEditModal({
     mutationFn: createTeam,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['teams'] });
-      toast.success('Team created');
+      toast.success('Team created', { id: 'team-created' });
       onSaved();
       onClose();
     },
     onError: (err: Error) => {
-      toast.error(err.message || 'Failed to create team');
+      toast.error(err.message || 'Failed to create team', {
+        id: 'team-created',
+      });
     },
   });
 
@@ -102,14 +104,16 @@ export function TeamEditModal({
       id: number;
       body: Parameters<typeof updateTeam>[1];
     }) => updateTeam(id, body),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['teams'] });
-      toast.success('Team updated');
+      toast.success('Team updated', { id: `team-updated-${variables.id}` });
       onSaved();
       onClose();
     },
-    onError: (err: Error) => {
-      toast.error(err.message || 'Failed to update team');
+    onError: (err: Error, variables) => {
+      toast.error(err.message || 'Failed to update team', {
+        id: variables ? `team-updated-${variables.id}` : undefined,
+      });
     },
   });
 
@@ -117,7 +121,7 @@ export function TeamEditModal({
     e.preventDefault();
     const trimmedName = name.trim();
     if (!trimmedName) {
-      toast.error('Name is required');
+      toast.error('Name is required', { id: 'team-edit-validation-name' });
       return;
     }
     if (isCreate) {

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -139,11 +139,21 @@ export function TransferActivitiesDialog({
       }),
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success(`Transferred ${data.transferredCount} assignment(s)`);
+      const toastId =
+        targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+          : 'activities-transferred';
+      toast.success(`Transferred ${data.transferredCount} assignment(s)`, {
+        id: toastId,
+      });
       onTransferred();
     },
     onError: (err: Error) => {
-      toast.error(err.message || 'Transfer failed');
+      const toastId =
+        targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+          : 'activities-transferred';
+      toast.error(err.message || 'Transfer failed', { id: toastId });
     },
   });
 

--- a/calendar-ui/src/components/users/UserEditModal.tsx
+++ b/calendar-ui/src/components/users/UserEditModal.tsx
@@ -85,11 +85,13 @@ export function UserEditModal({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['user', user.id] });
       void queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success('User updated');
+      toast.success('User updated', { id: `user-updated-${user.id}` });
       onSaved();
     },
     onError: (err: Error) => {
-      toast.error(err.message || 'Update failed');
+      toast.error(err.message || 'Update failed', {
+        id: `user-updated-${user.id}`,
+      });
     },
   });
 
@@ -100,15 +102,22 @@ export function UserEditModal({
         role: addTeamRole,
         ...(addTeamNotes.trim() && { notes: addTeamNotes.trim() }),
       }),
-    onSuccess: () => {
+    onSuccess: (_data, teamId) => {
       void queryClient.invalidateQueries({ queryKey: ['user', user.id] });
       void queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success('User added to team');
+      toast.success('User added to team', {
+        id: `user-added-to-team-${user.id}-${teamId}`,
+      });
       setAddTeamId('');
       setAddTeamNotes('');
     },
-    onError: (err: Error) => {
-      toast.error(err.message || 'Add to team failed');
+    onError: (err: Error, teamId) => {
+      toast.error(err.message || 'Add to team failed', {
+        id:
+          typeof teamId === 'number'
+            ? `user-added-to-team-${user.id}-${teamId}`
+            : undefined,
+      });
     },
   });
 

--- a/calendar-ui/src/hooks/useLookAheadWebSocket.test.tsx
+++ b/calendar-ui/src/hooks/useLookAheadWebSocket.test.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useLookAheadWebSocket } from './useLookAheadWebSocket';
+
+const { mockToast, getFakeSocket } = vi.hoisted(() => {
+  const listeners = new Map<string, (data: unknown) => void>();
+  const socket = {
+    on: vi.fn((event: string, cb: (data: unknown) => void) => {
+      listeners.set(event, cb);
+      return socket;
+    }),
+    emit: vi.fn(),
+    off: vi.fn(),
+    disconnect: vi.fn(),
+    emitEvent(event: string, data: unknown) {
+      const cb = listeners.get(event);
+      if (cb) cb(data);
+    },
+  };
+  return {
+    mockToast: { success: vi.fn(), info: vi.fn() },
+    getFakeSocket: () => socket,
+  };
+});
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => getFakeSocket()),
+}));
+
+function TestWrapper({ onActivityUpdate }: { onActivityUpdate?: () => void }) {
+  useLookAheadWebSocket({ onActivityUpdate });
+  return null;
+}
+
+describe('useLookAheadWebSocket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('activityCreated', () => {
+    it('calls toast.success with id activity-created-{id} and description', () => {
+      render(<TestWrapper />);
+      getFakeSocket().emitEvent('activityCreated', {
+        id: 1,
+        displayId: 'ACT-1',
+        title: 'Test Activity',
+      });
+
+      expect(mockToast.success).toHaveBeenCalledTimes(1);
+      expect(mockToast.success).toHaveBeenCalledWith('New activity created', {
+        id: 'activity-created-1',
+        description: 'ACT-1: Test Activity',
+        duration: 5000,
+      });
+      expect(mockToast.info).not.toHaveBeenCalled();
+    });
+
+    it('uses title only when displayId is missing', () => {
+      render(<TestWrapper />);
+      getFakeSocket().emitEvent('activityCreated', {
+        id: 42,
+        title: 'Only Title',
+      });
+
+      expect(mockToast.success).toHaveBeenCalledWith('New activity created', {
+        id: 'activity-created-42',
+        description: 'Only Title',
+        duration: 5000,
+      });
+    });
+
+    it('calls onActivityUpdate when activityCreated fires', () => {
+      const onActivityUpdate = vi.fn();
+      render(<TestWrapper onActivityUpdate={onActivityUpdate} />);
+      getFakeSocket().emitEvent('activityCreated', { id: 1, title: 'Test' });
+
+      expect(onActivityUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('activityUpdated', () => {
+    it('calls toast.info with id activity-updated-{id} and description', () => {
+      render(<TestWrapper />);
+      getFakeSocket().emitEvent('activityUpdated', {
+        id: 1,
+        displayId: 'ACT-1',
+        title: 'Updated Title',
+      });
+
+      expect(mockToast.info).toHaveBeenCalledTimes(1);
+      expect(mockToast.info).toHaveBeenCalledWith('Activity updated', {
+        id: 'activity-updated-1',
+        description: 'ACT-1: Updated Title',
+        duration: 5000,
+      });
+      expect(mockToast.success).not.toHaveBeenCalled();
+    });
+
+    it('uses ACT-{id} prefix when displayId is missing (shared utility format)', () => {
+      render(<TestWrapper />);
+      getFakeSocket().emitEvent('activityUpdated', {
+        id: 99,
+        title: 'No displayId',
+      });
+
+      expect(mockToast.info).toHaveBeenCalledWith('Activity updated', {
+        id: 'activity-updated-99',
+        description: 'ACT-99: No displayId',
+        duration: 5000,
+      });
+    });
+
+    it('calls onActivityUpdate when activityUpdated fires', () => {
+      const onActivityUpdate = vi.fn();
+      render(<TestWrapper onActivityUpdate={onActivityUpdate} />);
+      getFakeSocket().emitEvent('activityUpdated', { id: 1, title: 'Test' });
+
+      expect(onActivityUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('calls off and disconnect on unmount', () => {
+      const { unmount } = render(<TestWrapper />);
+      const socket = getFakeSocket();
+      unmount();
+
+      expect(socket.emit).toHaveBeenCalledWith('unsubscribeFromActivities');
+      expect(socket.off).toHaveBeenCalledWith('activityCreated');
+      expect(socket.off).toHaveBeenCalledWith('activityUpdated');
+      expect(socket.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/calendar-ui/src/hooks/useLookAheadWebSocket.test.tsx
+++ b/calendar-ui/src/hooks/useLookAheadWebSocket.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useLookAheadWebSocket } from './useLookAheadWebSocket';
 
-const { mockToast, getFakeSocket } = vi.hoisted(() => {
+const { getFakeSocket } = vi.hoisted(() => {
   const listeners = new Map<string, (data: unknown) => void>();
   const socket = {
     on: vi.fn((event: string, cb: (data: unknown) => void) => {
@@ -18,13 +18,8 @@ const { mockToast, getFakeSocket } = vi.hoisted(() => {
       if (cb) cb(data);
     },
   };
-  return {
-    mockToast: { success: vi.fn(), info: vi.fn() },
-    getFakeSocket: () => socket,
-  };
+  return { getFakeSocket: () => socket };
 });
-
-vi.mock('sonner', () => ({ toast: mockToast }));
 
 vi.mock('socket.io-client', () => ({
   io: vi.fn(() => getFakeSocket()),
@@ -41,37 +36,6 @@ describe('useLookAheadWebSocket', () => {
   });
 
   describe('activityCreated', () => {
-    it('calls toast.success with id activity-created-{id} and description', () => {
-      render(<TestWrapper />);
-      getFakeSocket().emitEvent('activityCreated', {
-        id: 1,
-        displayId: 'ACT-1',
-        title: 'Test Activity',
-      });
-
-      expect(mockToast.success).toHaveBeenCalledTimes(1);
-      expect(mockToast.success).toHaveBeenCalledWith('New activity created', {
-        id: 'activity-created-1',
-        description: 'ACT-1: Test Activity',
-        duration: 5000,
-      });
-      expect(mockToast.info).not.toHaveBeenCalled();
-    });
-
-    it('uses title only when displayId is missing', () => {
-      render(<TestWrapper />);
-      getFakeSocket().emitEvent('activityCreated', {
-        id: 42,
-        title: 'Only Title',
-      });
-
-      expect(mockToast.success).toHaveBeenCalledWith('New activity created', {
-        id: 'activity-created-42',
-        description: 'Only Title',
-        duration: 5000,
-      });
-    });
-
     it('calls onActivityUpdate when activityCreated fires', () => {
       const onActivityUpdate = vi.fn();
       render(<TestWrapper onActivityUpdate={onActivityUpdate} />);
@@ -82,37 +46,6 @@ describe('useLookAheadWebSocket', () => {
   });
 
   describe('activityUpdated', () => {
-    it('calls toast.info with id activity-updated-{id} and description', () => {
-      render(<TestWrapper />);
-      getFakeSocket().emitEvent('activityUpdated', {
-        id: 1,
-        displayId: 'ACT-1',
-        title: 'Updated Title',
-      });
-
-      expect(mockToast.info).toHaveBeenCalledTimes(1);
-      expect(mockToast.info).toHaveBeenCalledWith('Activity updated', {
-        id: 'activity-updated-1',
-        description: 'ACT-1: Updated Title',
-        duration: 5000,
-      });
-      expect(mockToast.success).not.toHaveBeenCalled();
-    });
-
-    it('uses ACT-{id} prefix when displayId is missing (shared utility format)', () => {
-      render(<TestWrapper />);
-      getFakeSocket().emitEvent('activityUpdated', {
-        id: 99,
-        title: 'No displayId',
-      });
-
-      expect(mockToast.info).toHaveBeenCalledWith('Activity updated', {
-        id: 'activity-updated-99',
-        description: 'ACT-99: No displayId',
-        duration: 5000,
-      });
-    });
-
     it('calls onActivityUpdate when activityUpdated fires', () => {
       const onActivityUpdate = vi.fn();
       render(<TestWrapper onActivityUpdate={onActivityUpdate} />);

--- a/calendar-ui/src/hooks/useLookAheadWebSocket.ts
+++ b/calendar-ui/src/hooks/useLookAheadWebSocket.ts
@@ -26,6 +26,7 @@ export function useLookAheadWebSocket({
       (data: { id: number; title?: string; displayId?: string }) => {
         onActivityUpdate?.();
         toast.success('New activity created', {
+          id: `activity-created-${data.id}`,
           description: data.displayId
             ? `${data.displayId}: ${data.title ?? ''}`
             : data.title,
@@ -39,6 +40,7 @@ export function useLookAheadWebSocket({
       (data: { id: number; title?: string; displayId?: string }) => {
         onActivityUpdate?.();
         toast.info('Activity updated', {
+          id: `activity-updated-${data.id}`,
           description: data.displayId
             ? `${data.displayId}: ${data.title ?? ''}`
             : data.title,

--- a/calendar-ui/src/hooks/useLookAheadWebSocket.ts
+++ b/calendar-ui/src/hooks/useLookAheadWebSocket.ts
@@ -1,16 +1,14 @@
 import { io } from 'socket.io-client';
-import { toast } from 'sonner';
 import { useEffect } from 'react';
-
-import { getActivityUpdatedToastOptions } from '@/lib/activity-toast-options';
 
 interface UseLookAheadWebSocketOptions {
   onActivityUpdate?: () => void;
 }
 
 /**
- * Subscribes to activity table WebSocket events and refetches Look Ahead data
- * when any activity is created or updated (relevant activities are filtered server-side).
+ * Subscribes to activity table WebSocket events and invokes the callback when
+ * any activity is created or updated, so Look Ahead (or other consumers) can
+ * refetch.
  */
 export function useLookAheadWebSocket({
   onActivityUpdate,
@@ -23,34 +21,13 @@ export function useLookAheadWebSocket({
       socket.emit('subscribeToActivities');
     });
 
-    socket.on(
-      'activityCreated',
-      (data: { id: number; title?: string; displayId?: string }) => {
-        onActivityUpdate?.();
-        toast.success('New activity created', {
-          id: `activity-created-${data.id}`,
-          description: data.displayId
-            ? `${data.displayId}: ${data.title ?? ''}`
-            : data.title,
-          duration: 5000,
-        });
-      }
-    );
+    socket.on('activityCreated', () => {
+      onActivityUpdate?.();
+    });
 
-    socket.on(
-      'activityUpdated',
-      (data: { id: number; title?: string; displayId?: string }) => {
-        onActivityUpdate?.();
-        toast.info(
-          'Activity updated',
-          getActivityUpdatedToastOptions({
-            id: String(data.id),
-            title: data.title,
-            displayId: data.displayId,
-          })
-        );
-      }
-    );
+    socket.on('activityUpdated', () => {
+      onActivityUpdate?.();
+    });
 
     return () => {
       socket.emit('unsubscribeFromActivities');

--- a/calendar-ui/src/hooks/useLookAheadWebSocket.ts
+++ b/calendar-ui/src/hooks/useLookAheadWebSocket.ts
@@ -2,6 +2,8 @@ import { io } from 'socket.io-client';
 import { toast } from 'sonner';
 import { useEffect } from 'react';
 
+import { getActivityUpdatedToastOptions } from '@/lib/activity-toast-options';
+
 interface UseLookAheadWebSocketOptions {
   onActivityUpdate?: () => void;
 }
@@ -39,13 +41,14 @@ export function useLookAheadWebSocket({
       'activityUpdated',
       (data: { id: number; title?: string; displayId?: string }) => {
         onActivityUpdate?.();
-        toast.info('Activity updated', {
-          id: `activity-updated-${data.id}`,
-          description: data.displayId
-            ? `${data.displayId}: ${data.title ?? ''}`
-            : data.title,
-          duration: 5000,
-        });
+        toast.info(
+          'Activity updated',
+          getActivityUpdatedToastOptions({
+            id: String(data.id),
+            title: data.title,
+            displayId: data.displayId,
+          })
+        );
       }
     );
 

--- a/calendar-ui/src/lib/activity-toast-options.test.ts
+++ b/calendar-ui/src/lib/activity-toast-options.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { getActivityUpdatedToastOptions } from './activity-toast-options';
+
+describe('getActivityUpdatedToastOptions', () => {
+  it('returns id activity-updated-{id} and description with displayId and title', () => {
+    const result = getActivityUpdatedToastOptions({
+      id: '42',
+      title: 'My Activity',
+      displayId: 'ACT-42',
+    });
+    expect(result).toEqual({
+      id: 'activity-updated-42',
+      description: 'ACT-42: My Activity',
+      duration: 5000,
+    });
+  });
+
+  it('falls back to ACT-{id} when displayId is missing', () => {
+    const result = getActivityUpdatedToastOptions({
+      id: '7',
+      title: 'No displayId',
+    });
+    expect(result).toEqual({
+      id: 'activity-updated-7',
+      description: 'ACT-7: No displayId',
+      duration: 5000,
+    });
+  });
+
+  it('falls back to ACT-{id} when displayId is null', () => {
+    const result = getActivityUpdatedToastOptions({
+      id: '99',
+      title: 'Test',
+      displayId: null,
+    });
+    expect(result.id).toBe('activity-updated-99');
+    expect(result.description).toBe('ACT-99: Test');
+    expect(result.duration).toBe(5000);
+  });
+
+  it('omits colon when title is empty', () => {
+    const result = getActivityUpdatedToastOptions({
+      id: '1',
+      displayId: 'ACT-1',
+    });
+    expect(result.description).toBe('ACT-1');
+  });
+});

--- a/calendar-ui/src/lib/activity-toast-options.ts
+++ b/calendar-ui/src/lib/activity-toast-options.ts
@@ -1,6 +1,6 @@
 /**
- * Builds toast options for activity-updated toasts so the same id is used
- * by EditActivityForm and useLookAheadWebSocket (Sonner deduplication).
+ * Builds toast options for activity-updated toasts (e.g. used by EditActivityForm
+ * for consistent id and description; stable ids enable Sonner deduplication).
  */
 export interface ActivityUpdatedToastParams {
   id: string;

--- a/calendar-ui/src/lib/activity-toast-options.ts
+++ b/calendar-ui/src/lib/activity-toast-options.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds toast options for activity-updated toasts so the same id is used
+ * by EditActivityForm and useLookAheadWebSocket (Sonner deduplication).
+ */
+export interface ActivityUpdatedToastParams {
+  id: string;
+  title?: string;
+  displayId?: string | null;
+}
+
+const DURATION_MS = 5000;
+
+export function getActivityUpdatedToastOptions(
+  params: ActivityUpdatedToastParams
+): { id: string; description: string; duration: number } {
+  const { id, title = '', displayId } = params;
+  const prefix = displayId ?? `ACT-${id}`;
+  return {
+    id: `activity-updated-${id}`,
+    description: title ? `${prefix}: ${title}` : prefix,
+    duration: DURATION_MS,
+  };
+}

--- a/calendar-ui/src/lib/error-toast.test.ts
+++ b/calendar-ui/src/lib/error-toast.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError, NetworkError } from '../api/errors';
+import {
+  getFriendlyErrorMessage,
+  showErrorToast,
+  showInfoToast,
+  showSuccessToast,
+} from './error-toast';
+
+const mockToast = vi.hoisted(() => ({
+  error: vi.fn(),
+  warning: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+function createApiError(
+  overrides: Partial<{
+    status: number;
+    detail: string;
+    type: string;
+    title: string;
+    instance: string;
+    correlationId: string;
+  }> = {}
+) {
+  return new ApiError({
+    type: 'https://example.com/error',
+    title: 'Error',
+    status: 500,
+    detail: 'Server error',
+    instance: '/api/foo',
+    correlationId: '',
+    ...overrides,
+  });
+}
+
+describe('showErrorToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls toast.error with title and detail for ApiError (e.g. 404)', () => {
+    showErrorToast(createApiError({ status: 404, detail: 'Not found' }));
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.error).toHaveBeenCalledWith('Not Found', {
+      description: 'Not found',
+      duration: 5000,
+    });
+    expect(mockToast.warning).not.toHaveBeenCalled();
+  });
+
+  it('calls toast.warning for ApiError 409 (Conflict)', () => {
+    showErrorToast(createApiError({ status: 409, detail: 'Conflict' }));
+
+    expect(mockToast.warning).toHaveBeenCalledTimes(1);
+    expect(mockToast.warning).toHaveBeenCalledWith('Conflict', {
+      description: 'Conflict',
+      duration: 7000,
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it('calls toast.error with server message for ApiError 500', () => {
+    showErrorToast(createApiError({ status: 500, detail: 'Internal error' }));
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.error).toHaveBeenCalledWith('Server Error', {
+      description: 'Server error. Please try again later.',
+      duration: 8000,
+    });
+  });
+
+  it('calls toast.warning for NetworkError with correct title and message', () => {
+    showErrorToast(new NetworkError('Connection failed'));
+
+    expect(mockToast.warning).toHaveBeenCalledTimes(1);
+    expect(mockToast.warning).toHaveBeenCalledWith('Connection Error', {
+      description:
+        'Unable to connect to server. Please check your connection and try again.',
+      duration: 6000,
+    });
+  });
+
+  it('calls toast.error for generic Error with message', () => {
+    showErrorToast(new Error('Something broke'));
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.error).toHaveBeenCalledWith('Error', {
+      description: 'Something broke',
+      duration: 5000,
+    });
+  });
+
+  it('uses customMessage when provided', () => {
+    showErrorToast(
+      createApiError({ status: 404, detail: 'Not found' }),
+      'Custom'
+    );
+
+    expect(mockToast.error).toHaveBeenCalledWith('Not Found', {
+      description: 'Custom',
+      duration: 5000,
+    });
+  });
+
+  it('calls toast.warning for ApiError 429 (Too Many Requests)', () => {
+    showErrorToast(createApiError({ status: 429, detail: 'Rate limited' }));
+
+    expect(mockToast.warning).toHaveBeenCalledTimes(1);
+    expect(mockToast.warning).toHaveBeenCalledWith('Too Many Requests', {
+      description: 'Too many requests. Please wait a moment and try again.',
+      duration: 6000,
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it('calls toast.error for string error input', () => {
+    showErrorToast('raw string');
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.error).toHaveBeenCalledWith('Error', {
+      description: 'raw string',
+      duration: 5000,
+    });
+  });
+});
+
+describe('showSuccessToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls toast.success with title and description and duration 3000', () => {
+    showSuccessToast('Saved successfully');
+
+    expect(mockToast.success).toHaveBeenCalledTimes(1);
+    expect(mockToast.success).toHaveBeenCalledWith('Success', {
+      description: 'Saved successfully',
+      duration: 3000,
+    });
+  });
+
+  it('accepts custom title', () => {
+    showSuccessToast('Done', 'All good');
+
+    expect(mockToast.success).toHaveBeenCalledWith('All good', {
+      description: 'Done',
+      duration: 3000,
+    });
+  });
+});
+
+describe('showInfoToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls toast.info with title and description and duration 4000', () => {
+    showInfoToast('Processing...');
+
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    expect(mockToast.info).toHaveBeenCalledWith('Info', {
+      description: 'Processing...',
+      duration: 4000,
+    });
+  });
+
+  it('accepts custom title', () => {
+    showInfoToast('Details here', 'Notice');
+
+    expect(mockToast.info).toHaveBeenCalledWith('Notice', {
+      description: 'Details here',
+      duration: 4000,
+    });
+  });
+});
+
+describe('getFriendlyErrorMessage', () => {
+  it('returns error.detail for ApiError', () => {
+    expect(
+      getFriendlyErrorMessage(
+        createApiError({ status: 404, detail: 'Not found' })
+      )
+    ).toBe('Not found');
+  });
+
+  it('returns rate limit message for ApiError 429', () => {
+    expect(
+      getFriendlyErrorMessage(
+        createApiError({ status: 429, detail: 'Rate limited' })
+      )
+    ).toBe('Too many requests. Please wait a moment and try again.');
+  });
+
+  it('returns server error message for ApiError 500+', () => {
+    expect(
+      getFriendlyErrorMessage(
+        createApiError({ status: 500, detail: 'Internal error' })
+      )
+    ).toBe('Server error. Please try again later.');
+  });
+
+  it('returns customMessage when provided for ApiError', () => {
+    expect(
+      getFriendlyErrorMessage(
+        createApiError({ status: 404, detail: 'Not found' }),
+        'Custom'
+      )
+    ).toBe('Custom');
+  });
+
+  it('returns connection message for NetworkError', () => {
+    expect(getFriendlyErrorMessage(new NetworkError('Connection failed'))).toBe(
+      'Unable to connect. Please check your connection and try again.'
+    );
+  });
+
+  it('returns error.message for generic Error', () => {
+    expect(getFriendlyErrorMessage(new Error('Something broke'))).toBe(
+      'Something broke'
+    );
+  });
+
+  it('returns the string for string input', () => {
+    expect(getFriendlyErrorMessage('raw string')).toBe('raw string');
+  });
+
+  it('returns fallback for unknown input', () => {
+    expect(getFriendlyErrorMessage(null)).toBe(
+      'Something went wrong. Please try again.'
+    );
+  });
+});

--- a/calendar-ui/src/lib/error-toast.ts
+++ b/calendar-ui/src/lib/error-toast.ts
@@ -9,6 +9,26 @@ import { ApiError, NetworkError } from '../api/errors';
  * that don't require full-page error displays.
  *
  * Uses Sonner for toast notifications - no dispatch function needed.
+ *
+ * ---
+ * Toast usage across the app
+ *
+ * When to use helpers vs direct toast:
+ * - Use showErrorToast() for API/network errors so messaging and correlation IDs
+ *   stay consistent. Use showSuccessToast / showInfoToast when you want the
+ *   same default duration and shape as other app toasts.
+ * - Use direct toast.success(), toast.info(), toast.error() from 'sonner' when
+ *   you need custom copy, description, or duration (e.g. "Activity updated" with
+ *   activity details).
+ *
+ * Toast IDs (deduplication):
+ * - When the same logical event can trigger toasts from more than one place
+ *   (e.g. form submit + WebSocket), pass the same `id` in the options so Sonner
+ *   updates one toast instead of showing two. Example: form and WebSocket both
+ *   use id: `activity-updated-${id}`.
+ * - ID convention: `{domain}-{action}-{entityId?}` (e.g. activity-updated-42,
+ *   user-updated-5, team-created). Use a stable id so the same event always
+ *   uses the same string.
  */
 
 /**

--- a/calendar-ui/src/pages/EditActivityForm.tsx
+++ b/calendar-ui/src/pages/EditActivityForm.tsx
@@ -33,6 +33,7 @@ import { Button } from '../components/ui/button';
 import { Form } from '../components/ui/form';
 import { useFormLookups, type FormLookupData } from '../hooks/useFormLookups';
 import { useDateStatuses, useTimeStatuses } from '../hooks/useLookups';
+import { getActivityUpdatedToastOptions } from '../lib/activity-toast-options';
 import {
   ERROR_DETAILS_LABEL,
   LOAD_ACTIVITY_NO_ID,
@@ -289,12 +290,14 @@ export function EditActivityForm(): React.ReactElement {
       };
 
       await updateActivity(Number(id), submitData);
-      // Show success toast
-      toast.success('Activity updated', {
-        id: `activity-updated-${id}`,
-        description: `${loadedActivity?.displayId || `ACT-${id}`}: ${data.title || ''}`,
-        duration: 5000,
-      });
+      toast.success(
+        'Activity updated',
+        getActivityUpdatedToastOptions({
+          id,
+          title: data.title ?? '',
+          displayId: loadedActivity?.displayId ?? undefined,
+        })
+      );
       // Navigate back to the entries list view
       void navigate('/');
     } catch (err) {

--- a/calendar-ui/src/pages/EditActivityForm.tsx
+++ b/calendar-ui/src/pages/EditActivityForm.tsx
@@ -291,6 +291,7 @@ export function EditActivityForm(): React.ReactElement {
       await updateActivity(Number(id), submitData);
       // Show success toast
       toast.success('Activity updated', {
+        id: `activity-updated-${id}`,
         description: `${loadedActivity?.displayId || `ACT-${id}`}: ${data.title || ''}`,
         duration: 5000,
       });

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -51,36 +51,45 @@ export function Users() {
       id: number;
       body: Parameters<typeof updateUser>[1];
     }) => updateUser(id, body),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success('User updated');
+      toast.success('User updated', { id: `user-updated-${variables.id}` });
       setEditUser(null);
     },
-    onError: (err: Error) => {
-      toast.error(err.message || 'Update failed');
+    onError: (err: Error, variables) => {
+      toast.error(err.message || 'Update failed', {
+        id: variables ? `user-updated-${variables.id}` : undefined,
+      });
     },
   });
 
   const removeTeamMutation = useMutation({
     mutationFn: ({ userId, teamId }: { userId: number; teamId: number }) =>
       removeUserFromTeam(userId, teamId),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['users'] });
-      toast.success('User removed from team');
+      toast.success('User removed from team', {
+        id: `user-removed-from-team-${variables.userId}-${variables.teamId}`,
+      });
     },
-    onError: (err: Error) => {
-      toast.error(err.message || 'Remove from team failed');
+    onError: (err: Error, variables) => {
+      toast.error(err.message || 'Remove from team failed', {
+        id: `user-removed-from-team-${variables.userId}-${variables.teamId}`,
+      });
     },
   });
 
   const deactivateTeamMutation = useMutation({
     mutationFn: (teamId: number) => updateTeam(teamId, { isActive: false }),
-    onSuccess: () => {
+    onSuccess: (_data, teamId) => {
       void queryClient.invalidateQueries({ queryKey: ['teams'] });
-      toast.success('Team deactivated');
+      toast.success('Team deactivated', { id: `team-deactivated-${teamId}` });
     },
-    onError: (err: Error) => {
-      toast.error(err.message || 'Deactivate failed');
+    onError: (err: Error, teamId) => {
+      toast.error(err.message || 'Deactivate failed', {
+        id:
+          typeof teamId === 'number' ? `team-deactivated-${teamId}` : undefined,
+      });
     },
   });
 


### PR DESCRIPTION
## Summary

This PR fixes the potential for duplicate toasts when updating an activity via the edit page.

- adds Sonner toast ids so toasts can be deduped across the application
- removes a toast trigger from useLookAheadWebSocket hook, which was the cause of this potential duplication; the hook now has a single responsibility of fetching for the Look Ahead

## Changes

- Removed toast and getActivityUpdatedToastOptions; the hook no longer shows any toasts.
activityCreated and activityUpdated handlers now only call onActivityUpdate?.() so Look Ahead can refetch.
- Event handlers no longer use the payload (no toast content), so the listener signatures were simplified.

## Testing

- Added test files: TestEditModal.test.tsx, useLookAheadWebSocket.test.tsx, activity-toast-options.test.ts
- All tests passing
- Sanity check: UI toasts showing as expected