### PR TITLE
build(cicd): update github actions to npm install

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -21,7 +21,9 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        # 2026-02-23: updated to npm install from npm ci to fix build errors
+        # run: npm ci
+        run: npm install
 
       - name: Check formatting
         run: npm run format:check


### PR DESCRIPTION
- changed from npm ci to npm install to fix pipeline
- attempt to resolve optional dep issues
- npm ci failure may be linked to override added for minimatch
- needs more permanent resolution in the future