### PR TITLE
Feat/corpcal 172 polish activity sort

### DIFF
--- a/calendar-ui/docs/ACTIVITY_TABLE_PREFERENCES_PERSISTENCE.md
+++ b/calendar-ui/docs/ACTIVITY_TABLE_PREFERENCES_PERSISTENCE.md
@@ -1,0 +1,121 @@
+# Activity table sort and filter persistence
+
+The activity list persists sort and filter state so it survives navigation and can be shared via URL. This doc describes how the implementation works and how to add new filters.
+
+## Overview
+
+- **URL search params** (via `useSearchParams` from React Router): When the user lands on the list with query params (e.g. `/?sort=lastUpdated&dir=desc`), state is restored from the URL. Links with params are shareable and bookmarkable.
+- **sessionStorage**: When the user lands on `/` with no relevant params (e.g. after clicking "Activities" in the sidebar or before any preferences exist), state is restored from sessionStorage for the current tab. This covers "navigate away and back" within the same session.
+- **Write path**: Whenever the user changes sort or a filter, the hook updates React state, then a `useEffect` syncs the same values to both the URL (`setSearchParams`) and sessionStorage. URL updates use `replace: true` so each change does not push a new history entry.
+
+So URL and sessionStorage always hold the same preference shape; the only difference is **when** we read from which source (URL wins when it has any of our known params).
+
+## How URL and sessionStorage work together
+
+### Read path (initial state)
+
+On mount, the hook decides initial preferences in this order:
+
+1. **URL has any known param?** (`sort`, `dir`, `completed`, `deleted`, `pageSize`)  
+   If **yes**: Parse all preferences from the URL (with validation and defaults for missing/invalid values). Ignore sessionStorage for this load.
+2. **Otherwise**: Read from sessionStorage key `activityTablePreferences`. Parse and validate. If invalid or missing, use `DEFAULT_PREFERENCES`.
+
+So: **URL is the source of truth when it contains any of our params.** An empty or unrelated query string triggers a sessionStorage restore.
+
+### Write path (user changes something)
+
+When the user changes sort or a filter:
+
+1. `setPreferences(partial)` updates React state (merge with current preferences).
+2. A `useEffect` runs because `preferences` changed. It only syncs if the change came from the user (a ref guards the initial mount).
+3. Sync step: call `setSearchParams(preferencesToParams(preferences), { replace: true })` and `sessionStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))`.
+
+So URL and sessionStorage are updated together; they are not sources of truth for each other, they are two outputs from the same state.
+
+### Summary
+
+| Scenario                                                                  | Source used                                                 |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| User opens `/?sort=lastUpdated&dir=desc` (e.g. shared link or breadcrumb) | URL                                                         |
+| User opens `/` with no params (e.g. sidebar "Activities")                 | sessionStorage, or defaults if empty                        |
+| User changes sort/filter on the list                                      | State updates, then URL and sessionStorage are both written |
+
+## Data shape and URL param names
+
+Defined in [calendar-ui/src/hooks/useActivityTablePreferences.ts](../src/hooks/useActivityTablePreferences.ts):
+
+| Preference    | URL param   | Type                                | Default     |
+| ------------- | ----------- | ----------------------------------- | ----------- |
+| sortKey       | `sort`      | string (must be in VALID_SORT_KEYS) | `startDate` |
+| sortDirection | `dir`       | `asc` \| `desc`                     | `desc`      |
+| showCompleted | `completed` | boolean                             | `false`     |
+| showDeleted   | `deleted`   | boolean                             | `false`     |
+| pageSize      | `pageSize`  | number (1–100)                      | `10`        |
+
+- **sessionStorage key**: `activityTablePreferences`. Stored value is a single JSON object with these keys.
+- **pageIndex** is not persisted; it is local component state and resets when filters change.
+
+## Adding a new filter (or preference)
+
+To add a new persisted filter (or any new field in the preferences object), update the hook in one place and the consumer (e.g. ActivityTable) in another.
+
+### 1. Hook: [useActivityTablePreferences.ts](../src/hooks/useActivityTablePreferences.ts)
+
+Do all of the following so the new field is read from URL, read from sessionStorage, validated, and written back to both.
+
+1. **URL param constant**  
+   Add a constant, e.g. `const URL_PARAM_MY_FILTER = 'myFilter';`
+
+2. **Type and defaults**
+   - Add the field to `ActivityTablePreferences` (e.g. `myFilter: boolean`).
+   - Add it to `DEFAULT_PREFERENCES` with the default value.
+
+3. **Parsing from URL**  
+   In `parseFromSearchParams`, read the param (e.g. `searchParams.get(URL_PARAM_MY_FILTER)`), parse/validate, and add the field to the returned object. Use the same pattern as existing fields (e.g. `parseBool` for booleans, or a small validator for numbers/enums).
+
+4. **"Known param" check**  
+   In `hasAnyKnownParam`, add `searchParams.has(URL_PARAM_MY_FILTER)` so that when this param is present we treat the URL as source of truth.
+
+5. **Parsing from sessionStorage**  
+   In `parseFromStorage`, read `parsed.myFilter`, validate type and bounds, and add the field to the returned object. If invalid, use the default from `DEFAULT_PREFERENCES`. Apply any permission gating here if needed (e.g. like `showDeleted` and `canSeeDeleted`).
+
+6. **Serialization to URL and storage**  
+   In `preferencesToParams`, add a line so the new field is included in the object passed to `URLSearchParams` and thus to the URL. sessionStorage already stores the full `preferences` object as JSON, so no extra step there.
+
+7. **Optional: permission gating**  
+   If the filter should be hidden or forced off for some users (e.g. `showDeleted` and `canSeeDeleted`):
+   - In `parseFromSearchParams` and `parseFromStorage`, when the user cannot use the feature, set the field to the safe default (e.g. `false`).
+   - In `setPreferences`, when merging `partial`, if the field is in `partial` and the user cannot use it, ignore or override it (same pattern as `showDeleted`).
+
+### 2. Consumer: [ActivityTable.tsx](../src/components/ActivityTable/ActivityTable.tsx)
+
+1. Read the value from `preferences` (e.g. `preferences.myFilter`).
+2. When the user changes the filter, call `setPreferences({ myFilter: newValue })`.
+3. Use the value where needed (e.g. in `activityFilters` or in the filter UI). Keep the existing “reset to first page when filters change” behavior if this filter affects the list.
+
+### 3. Breadcrumb (if the list is linked from elsewhere)
+
+The breadcrumb “Activities list” link uses `getStoredActivityListSearch(canSeeDeleted)` to build the list URL. That function reads from sessionStorage and builds a query string from the same `preferencesToParams` shape. So once the new field is in `ActivityTablePreferences` and `preferencesToParams`, the breadcrumb will include it automatically. No change needed in [ActivityBreadcrumb.tsx](../src/components/ActivityBreadcrumb.tsx) unless the new filter is permission-gated (then ensure `canSeeDeleted` or an equivalent is passed where needed; the breadcrumb already passes `canSeeDeleted` for `showDeleted`).
+
+### Checklist for a new filter
+
+- [ ] `ActivityTablePreferences` and `DEFAULT_PREFERENCES`
+- [ ] URL param constant and `hasAnyKnownParam`
+- [ ] `parseFromSearchParams` (read + validate + default)
+- [ ] `parseFromStorage` (read + validate + default; permission override if needed)
+- [ ] `preferencesToParams` (so URL and breadcrumb include the new param)
+- [ ] ActivityTable: read from `preferences`, call `setPreferences` on change, use value in filters / UI
+
+## Key files
+
+| File                                                                                                            | Purpose                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [calendar-ui/src/hooks/useActivityTablePreferences.ts](../src/hooks/useActivityTablePreferences.ts)             | Hook that holds preferences state, reads from URL or sessionStorage on mount, and syncs writes to both. Exports `useActivityTablePreferences`, `getStoredActivityListSearch`, and `ActivityTablePreferences`. |
+| [calendar-ui/src/components/ActivityTable/ActivityTable.tsx](../src/components/ActivityTable/ActivityTable.tsx) | Uses `useActivityTablePreferences(canSeeDeleted)` and passes `preferences` / `setPreferences` into sort and filter UI.                                                                                        |
+| [calendar-ui/src/components/ActivityBreadcrumb.tsx](../src/components/ActivityBreadcrumb.tsx)                   | “Activities list” link uses `getStoredActivityListSearch(canSeeDeleted)` so View/Edit/Create breadcrumbs return to the list with stored sort/filters in the URL.                                              |
+
+## Edge cases
+
+- **Invalid or missing stored data**: Parsers fall back to defaults; the table always renders.
+- **canSeeDeleted**: When the user cannot see deleted activities, `showDeleted` is forced to `false` when reading (URL or storage) and when applying updates in `setPreferences`. The breadcrumb passes `canSeeDeleted` into `getStoredActivityListSearch` so the link never includes `deleted=true` for those users.
+- **Replace vs push**: `setSearchParams(..., { replace: true })` avoids one history entry per sort/filter change.

--- a/calendar-ui/src/components/ActivityBreadcrumb.tsx
+++ b/calendar-ui/src/components/ActivityBreadcrumb.tsx
@@ -2,24 +2,37 @@ import { ChevronRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { ReactElement } from 'react';
 
+import { SYSTEM_ROLES } from '@corpcal/shared/auth';
+import { getStoredActivityListSearch } from '@/hooks/useActivityTablePreferences';
+import { useAuth } from '@/hooks/useAuth';
+
 type ActivityBreadcrumbProps = {
   /** Label for the current page (e.g. displayId "ACT-123" or "New activity") */
   currentLabel: string;
 };
 
 /**
- * Breadcrumb above the activity form: Activities list > currentLabel
+ * Breadcrumb above the activity form: Activities list > currentLabel.
+ * The "Activities list" link includes stored sort/filter params so returning
+ * from View/Edit/Create restores the previous list state.
  */
 export function ActivityBreadcrumb({
   currentLabel,
 }: ActivityBreadcrumbProps): ReactElement {
+  const { user } = useAuth();
+  const canSeeDeleted =
+    user?.roleName === SYSTEM_ROLES.ADMIN ||
+    user?.roleName === SYSTEM_ROLES.SYSTEM_ADMIN;
+  const listSearch = getStoredActivityListSearch(canSeeDeleted);
+  const listPath = `/${listSearch}`;
+
   return (
     <nav
       aria-label="Breadcrumb"
       className="mb-4 flex items-center gap-1 text-sm"
     >
       <Link
-        to="/"
+        to={listPath}
         className="text-muted-foreground hover:text-foreground focus:ring-ring rounded focus:ring-2 focus:outline-none"
       >
         Activities list

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -59,6 +59,7 @@ import {
   getLookAheadSectionLabel,
   getLookAheadStatusLabel,
 } from '@/constants/form-options';
+import { useActivityTablePreferences } from '@/hooks/useActivityTablePreferences';
 import { useAuth } from '@/hooks/useAuth';
 import { useActivityList } from '@/hooks/useCalendar';
 import { useUsers } from '@/hooks/useLookups';
@@ -591,19 +592,20 @@ export function ActivityTable() {
     user?.roleName === SYSTEM_ROLES.SYSTEM_ADMIN;
 
   const tableScrollRef = useRef<HTMLDivElement>(null);
-  const [sortKey, setSortKey] = useState<string | null>(DEFAULT_SORT_KEY);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
-    DEFAULT_SORT_DIRECTION
+  const { preferences, setPreferences } =
+    useActivityTablePreferences(canSeeDeleted);
+  const sortKey = preferences.sortKey;
+  const sortDirection = preferences.sortDirection;
+  const showCompleted = preferences.showCompleted;
+  const showDeleted = preferences.showDeleted;
+  const [pageIndex, setPageIndex] = useState(0);
+  const pagination = useMemo(
+    () => ({ pageIndex, pageSize: preferences.pageSize }),
+    [pageIndex, preferences.pageSize]
   );
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
-  });
   const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({
     left: ['overview'],
   });
-  const [showCompleted, setShowCompleted] = useState(false);
-  const [showDeleted, setShowDeleted] = useState(false);
 
   const activityFilters = useMemo(
     () => ({
@@ -622,7 +624,7 @@ export function ActivityTable() {
       prev.includeDeleted === activityFilters.includeDeleted;
     if (!same) {
       prevFiltersRef.current = activityFilters;
-      setPagination((p) => ({ ...p, pageIndex: 0 }));
+      setPageIndex(0);
     }
   }, [activityFilters]);
 
@@ -639,22 +641,21 @@ export function ActivityTable() {
         | ((prev: typeof pagination) => typeof pagination)
         | typeof pagination
     ) => {
-      setPagination((prev) => {
-        const next =
-          typeof updaterOrValue === 'function'
-            ? updaterOrValue(prev)
-            : updaterOrValue;
-        if (
-          next.pageIndex === prev.pageIndex &&
-          next.pageSize === prev.pageSize
-        ) {
-          return prev;
-        }
-        return next;
-      });
+      const prev = pagination;
+      const next =
+        typeof updaterOrValue === 'function'
+          ? updaterOrValue(prev)
+          : updaterOrValue;
+      if (next.pageSize !== prev.pageSize) {
+        setPreferences({ pageSize: next.pageSize });
+        setPageIndex(0);
+      } else {
+        setPageIndex(next.pageIndex);
+      }
     },
-    []
+    [pagination, setPreferences]
   );
+  const setPagination = onPaginationChangeStable;
 
   const userMap = useMemo(() => {
     const map = new Map<string, { name: string; jobTitle?: string | null }>();
@@ -706,10 +707,12 @@ export function ActivityTable() {
 
   const handleSortChange = useCallback(
     (key: string | null, direction: 'asc' | 'desc') => {
-      setSortKey(key);
-      setSortDirection(direction);
+      setPreferences({
+        sortKey: key ?? DEFAULT_SORT_KEY,
+        sortDirection: direction,
+      });
     },
-    []
+    [setPreferences]
   );
 
   const handleHeaderSort = useCallback(
@@ -871,7 +874,8 @@ export function ActivityTable() {
         id: 'show-completed',
         label: 'Show completed',
         checked: showCompleted,
-        onCheckedChange: setShowCompleted,
+        onCheckedChange: (checked: boolean) =>
+          setPreferences({ showCompleted: checked }),
       },
     ];
     if (canSeeDeleted) {
@@ -879,11 +883,12 @@ export function ActivityTable() {
         id: 'show-deleted',
         label: 'Show deleted',
         checked: showDeleted,
-        onCheckedChange: setShowDeleted,
+        onCheckedChange: (checked: boolean) =>
+          setPreferences({ showDeleted: checked }),
       });
     }
     return filters;
-  }, [showCompleted, showDeleted, canSeeDeleted]);
+  }, [showCompleted, showDeleted, canSeeDeleted, setPreferences]);
 
   // Loading state
   if (loading) {

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -33,13 +33,11 @@ import {
   COLUMN_SORT_DROPDOWN_DATA_ATTR,
   ColumnSortDropdown,
 } from '@/components/Table/ColumnSortDropdown';
-import {
-  SortDropdown,
-  type SortColumnConfig,
-} from '@/components/Table/SortDropdown';
+import { SortableColumnHeader } from '@/components/Table/SortableColumnHeader';
+import type { SortColumnConfig } from '@/components/Table/SortDropdown';
 import { SortIndicator } from '@/components/Table/SortIndicator';
 import {
-  ACTIVITY_TABLE_COLUMN_WIDTHS,
+  getActivityColumnSizes,
   tableBodyRow,
   tableTable,
   tableTd,
@@ -47,8 +45,6 @@ import {
   tableThead,
 } from '@/components/Table/tableConstants';
 import { TablePagination } from '@/components/Table/TablePagination';
-import { TableScrollContainer } from '@/components/Table/TableScrollContainer';
-import { TableSummaryBar } from '@/components/Table/TableSummaryBar';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge, getActivityStatusBadgeVariant } from '@/components/ui/badge';
 import { BadgeGroup, type BadgeGroupItem } from '@/components/ui/badge-group';
@@ -75,10 +71,12 @@ import {
 import { getFriendlyErrorMessage } from '@/lib/error-toast';
 import { cn } from '@/lib/utils';
 
+import { ActivityTableLayout } from './ActivityTableLayout';
 import {
   mapActivityResponseToTableRow,
   type ActivityTableRow,
 } from './activityTableRow';
+import { compareActivityRows } from './activityTableSort';
 
 /**
  * Table width: The table uses table-fixed layout; its width is the sum of column
@@ -92,20 +90,6 @@ import {
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SORT_KEY = 'startDate';
 const DEFAULT_SORT_DIRECTION = 'desc' as const;
-
-/** Plan order: New, Changed, Delete requested, Reviewed, Completed, Deleted (on_hold last). */
-const ACTIVITY_STATUS_SORT_ORDER = [
-  'new',
-  'changed',
-  'delete_requested',
-  'reviewed',
-  'completed',
-  'deleted',
-  'on_hold',
-] as const;
-
-/** Plan order: New, Changed, None. */
-const LOOK_AHEAD_SORT_ORDER = ['new', 'changed', 'none'] as const;
 
 const ACTIVITY_SORT_COLUMNS: SortColumnConfig[] = [
   { id: 'activityId', label: 'Activity ID', defaultDirection: 'asc' },
@@ -126,57 +110,6 @@ const STATUS_COLUMN_SORT_KEYS = [
   'lastUpdated',
   'createdDateTime',
 ] as const;
-
-function indexOfOrder<T extends string>(
-  order: readonly T[],
-  value: string | null
-): number {
-  if (!value) return order.length;
-  const i = order.indexOf(value.toLowerCase() as T);
-  return i === -1 ? order.length : i;
-}
-
-function compareActivityRows(
-  a: ActivityTableRow,
-  b: ActivityTableRow,
-  sortKey: string,
-  direction: 'asc' | 'desc'
-): number {
-  const mult = direction === 'asc' ? 1 : -1;
-  switch (sortKey) {
-    case 'activityId':
-      return mult * (a.id - b.id);
-    case 'activityStatus': {
-      const ia = indexOfOrder(ACTIVITY_STATUS_SORT_ORDER, a.activityStatus);
-      const ib = indexOfOrder(ACTIVITY_STATUS_SORT_ORDER, b.activityStatus);
-      return mult * (ia - ib);
-    }
-    case 'lookAheadStatus': {
-      const ia = indexOfOrder(LOOK_AHEAD_SORT_ORDER, a.lookAheadStatus);
-      const ib = indexOfOrder(LOOK_AHEAD_SORT_ORDER, b.lookAheadStatus);
-      return mult * (ia - ib);
-    }
-    case 'startDate': {
-      const ta = a.startDate ? new Date(a.startDate).getTime() : 0;
-      const tb = b.startDate ? new Date(b.startDate).getTime() : 0;
-      return mult * (ta - tb);
-    }
-    case 'lastUpdated':
-      return (
-        mult *
-        (new Date(a.lastUpdatedDateTime).getTime() -
-          new Date(b.lastUpdatedDateTime).getTime())
-      );
-    case 'createdDateTime':
-      return (
-        mult *
-        (new Date(a.createdDateTime).getTime() -
-          new Date(b.createdDateTime).getTime())
-      );
-    default:
-      return 0;
-  }
-}
 
 function getCommonPinningStyles<T>(column: Column<T, unknown>): CSSProperties {
   const isPinned = column.getIsPinned();
@@ -805,128 +738,61 @@ export function ActivityTable() {
     () => [
       columnHelper.display({
         id: 'overview',
-        header: () => {
-          const label =
-            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'activityId')?.label ??
-            'Activity ID';
-          const indicator = (
-            <SortIndicator
-              columnId="activityId"
-              sortKey={effectiveSortKey}
-              sortDirection={effectiveSortDirection}
-              className="h-4 w-4"
-            />
-          );
-          return (
-            <span className="inline-flex items-center gap-1">
-              Overview
-              {effectiveSortKey === 'activityId' ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex">{indicator}</span>
-                  </TooltipTrigger>
-                  <TooltipContent>Sorted by {label}</TooltipContent>
-                </Tooltip>
-              ) : (
-                indicator
-              )}
-            </span>
-          );
-        },
+        header: () => (
+          <SortableColumnHeader
+            title="Overview"
+            sortColumnId="activityId"
+            sortColumns={ACTIVITY_SORT_COLUMNS}
+            effectiveSortKey={effectiveSortKey}
+            effectiveSortDirection={effectiveSortDirection}
+          />
+        ),
         meta: { sortKey: 'activityId' as const },
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.maxSize,
+        ...getActivityColumnSizes('overview'),
         cell: ({ row }) => <OverviewCell row={row.original} />,
       }),
 
       columnHelper.accessor('summary', {
-        header: () => {
-          const label =
-            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'lookAheadStatus')
-              ?.label ?? 'Look Ahead Status';
-          const indicator = (
-            <SortIndicator
-              columnId="lookAheadStatus"
-              sortKey={effectiveSortKey}
-              sortDirection={effectiveSortDirection}
-              className="h-4 w-4"
-            />
-          );
-          return (
-            <span className="inline-flex items-center gap-1">
-              Summary
-              {effectiveSortKey === 'lookAheadStatus' ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex">{indicator}</span>
-                  </TooltipTrigger>
-                  <TooltipContent>Sorted by {label}</TooltipContent>
-                </Tooltip>
-              ) : (
-                indicator
-              )}
-            </span>
-          );
-        },
+        header: () => (
+          <SortableColumnHeader
+            title="Summary"
+            sortColumnId="lookAheadStatus"
+            sortColumns={ACTIVITY_SORT_COLUMNS}
+            effectiveSortKey={effectiveSortKey}
+            effectiveSortDirection={effectiveSortDirection}
+          />
+        ),
         meta: { sortKey: 'lookAheadStatus' as const },
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.maxSize,
+        ...getActivityColumnSizes('summary'),
         cell: ({ row }) => <SummaryCell row={row.original} />,
       }),
 
       columnHelper.accessor('startDate', {
-        header: () => {
-          const label =
-            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'startDate')?.label ??
-            'Scheduled date';
-          const indicator = (
-            <SortIndicator
-              columnId="startDate"
-              sortKey={effectiveSortKey}
-              sortDirection={effectiveSortDirection}
-              className="h-4 w-4"
-            />
-          );
-          return (
-            <span className="inline-flex items-center gap-1">
-              Scheduling
-              {effectiveSortKey === 'startDate' ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex">{indicator}</span>
-                  </TooltipTrigger>
-                  <TooltipContent>Sorted by {label}</TooltipContent>
-                </Tooltip>
-              ) : (
-                indicator
-              )}
-            </span>
-          );
-        },
+        header: () => (
+          <SortableColumnHeader
+            title="Scheduling"
+            sortColumnId="startDate"
+            sortColumns={ACTIVITY_SORT_COLUMNS}
+            effectiveSortKey={effectiveSortKey}
+            effectiveSortDirection={effectiveSortDirection}
+          />
+        ),
         meta: { sortKey: 'startDate' as const },
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.maxSize,
+        ...getActivityColumnSizes('scheduling'),
         cell: ({ row }) => <SchedulingCell row={row.original} />,
       }),
 
       columnHelper.display({
         id: 'leads',
         header: 'Leads',
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.leads.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.leads.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.leads.maxSize,
+        ...getActivityColumnSizes('leads'),
         cell: ({ row }) => <LeadsCell row={row.original} />,
       }),
 
       columnHelper.display({
         id: 'materials',
         header: 'Materials',
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.materials.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.materials.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.materials.maxSize,
+        ...getActivityColumnSizes('materials'),
         cell: ({ row }) => <MaterialsCell row={row.original} />,
       }),
 
@@ -975,9 +841,7 @@ export function ActivityTable() {
           );
         },
         meta: { sortKeys: [...STATUS_COLUMN_SORT_KEYS] },
-        size: ACTIVITY_TABLE_COLUMN_WIDTHS.status.size,
-        minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.minSize,
-        maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.maxSize,
+        ...getActivityColumnSizes('status'),
         cell: ({ row }) => <StatusCell row={row.original} userMap={userMap} />,
       }),
     ],
@@ -1024,34 +888,24 @@ export function ActivityTable() {
   // Loading state
   if (loading) {
     return (
-      <div className="min-w-0 space-y-4">
-        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
-          <SortDropdown
-            hideDirectionLabel
-            columns={ACTIVITY_SORT_COLUMNS}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            defaultSortKey={DEFAULT_SORT_KEY}
-            defaultSortDirection={DEFAULT_SORT_DIRECTION}
-            ariaLabel="Sort by"
-          />
+      <ActivityTableLayout
+        scrollRef={tableScrollRef}
+        sortColumns={ACTIVITY_SORT_COLUMNS}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
+        defaultSortKey={DEFAULT_SORT_KEY}
+        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        count={0}
+        singularLabel="entry"
+        pluralLabel="entries"
+        filters={eventTableFilters}
+      >
+        <div className="flex flex-col items-center justify-center gap-3 py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+          <span className="text-sm text-slate-600">Loading activities...</span>
         </div>
-        <TableSummaryBar
-          count={0}
-          singularLabel="entry"
-          pluralLabel="entries"
-          filters={eventTableFilters}
-        />
-        <TableScrollContainer ref={tableScrollRef}>
-          <div className="flex flex-col items-center justify-center gap-3 py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-            <span className="text-sm text-slate-600">
-              Loading activities...
-            </span>
-          </div>
-        </TableScrollContainer>
-      </div>
+      </ActivityTableLayout>
     );
   }
 
@@ -1071,34 +925,26 @@ export function ActivityTable() {
   // Empty state
   if (data.length === 0) {
     return (
-      <div className="min-w-0 space-y-4">
-        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
-          <SortDropdown
-            hideDirectionLabel
-            columns={ACTIVITY_SORT_COLUMNS}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            defaultSortKey={DEFAULT_SORT_KEY}
-            defaultSortDirection={DEFAULT_SORT_DIRECTION}
-            ariaLabel="Sort by"
-          />
-        </div>
-        <TableSummaryBar
-          count={0}
-          singularLabel="entry"
-          pluralLabel="entries"
-          filters={eventTableFilters}
-        />
-        <TableScrollContainer ref={tableScrollRef}>
-          <div className="py-12 text-center text-sm text-slate-600">
-            <div className="mb-2 font-semibold">No activities found</div>
-            <div>
-              Create a new entry or adjust filters to see activities here.
-            </div>
+      <ActivityTableLayout
+        scrollRef={tableScrollRef}
+        sortColumns={ACTIVITY_SORT_COLUMNS}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
+        defaultSortKey={DEFAULT_SORT_KEY}
+        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        count={0}
+        singularLabel="entry"
+        pluralLabel="entries"
+        filters={eventTableFilters}
+      >
+        <div className="py-12 text-center text-sm text-slate-600">
+          <div className="mb-2 font-semibold">No activities found</div>
+          <div>
+            Create a new entry or adjust filters to see activities here.
           </div>
-        </TableScrollContainer>
-      </div>
+        </div>
+      </ActivityTableLayout>
     );
   }
 
@@ -1107,25 +953,19 @@ export function ActivityTable() {
   return (
     <TooltipProvider delayDuration={400}>
       <div className="min-w-0 space-y-4">
-        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
-          <SortDropdown
-            hideDirectionLabel
-            columns={ACTIVITY_SORT_COLUMNS}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            defaultSortKey={DEFAULT_SORT_KEY}
-            defaultSortDirection={DEFAULT_SORT_DIRECTION}
-            ariaLabel="Sort by"
-          />
-        </div>
-        <TableSummaryBar
+        <ActivityTableLayout
+          scrollRef={tableScrollRef}
+          sortColumns={ACTIVITY_SORT_COLUMNS}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSortChange={handleSortChange}
+          defaultSortKey={DEFAULT_SORT_KEY}
+          defaultSortDirection={DEFAULT_SORT_DIRECTION}
           count={sortedData.length}
           singularLabel="entry"
           pluralLabel="entries"
           filters={eventTableFilters}
-        />
-        <TableScrollContainer ref={tableScrollRef}>
+        >
           <table
             className={`${tableTable} min-w-[640px] border-separate border-spacing-0`}
             role="grid"
@@ -1255,7 +1095,7 @@ export function ActivityTable() {
               })}
             </tbody>
           </table>
-        </TableScrollContainer>
+        </ActivityTableLayout>
 
         <TablePagination
           totalItems={sortedData.length}

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -30,6 +30,10 @@ import {
 import { SYSTEM_ROLES } from '@corpcal/shared/auth';
 import { ErrorState } from '@/components/ErrorState';
 import {
+  COLUMN_SORT_DROPDOWN_DATA_ATTR,
+  ColumnSortDropdown,
+} from '@/components/Table/ColumnSortDropdown';
+import {
   SortDropdown,
   type SortColumnConfig,
 } from '@/components/Table/SortDropdown';
@@ -50,6 +54,12 @@ import { Badge, getActivityStatusBadgeVariant } from '@/components/ui/badge';
 import { BadgeGroup, type BadgeGroupItem } from '@/components/ui/badge-group';
 import { CopyableText } from '@/components/ui/copyable-text';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
   getLookAheadSectionLabel,
   getLookAheadStatusLabel,
 } from '@/constants/form-options';
@@ -63,6 +73,7 @@ import {
   formatTime12h,
 } from '@/lib/datetime-utils';
 import { getFriendlyErrorMessage } from '@/lib/error-toast';
+import { cn } from '@/lib/utils';
 
 import {
   mapActivityResponseToTableRow,
@@ -108,6 +119,13 @@ const ACTIVITY_SORT_COLUMNS: SortColumnConfig[] = [
   { id: 'lastUpdated', label: 'Last updated', defaultDirection: 'desc' },
   { id: 'createdDateTime', label: 'Date created', defaultDirection: 'desc' },
 ];
+
+/** Status column can be sorted by activity status, last updated, or date created. */
+const STATUS_COLUMN_SORT_KEYS = [
+  'activityStatus',
+  'lastUpdated',
+  'createdDateTime',
+] as const;
 
 function indexOfOrder<T extends string>(
   order: readonly T[],
@@ -762,16 +780,20 @@ export function ActivityTable() {
   );
 
   const handleHeaderSort = useCallback(
-    (columnSortKey: string) => {
-      const isActive = effectiveSortKey === columnSortKey;
+    (columnSortKeyOrKeys: string | string[]) => {
+      const keys = Array.isArray(columnSortKeyOrKeys)
+        ? columnSortKeyOrKeys
+        : [columnSortKeyOrKeys];
+      const isActive = keys.includes(effectiveSortKey);
       if (isActive) {
         handleSortChange(
-          columnSortKey,
+          effectiveSortKey,
           effectiveSortDirection === 'asc' ? 'desc' : 'asc'
         );
       } else {
-        const col = ACTIVITY_SORT_COLUMNS.find((c) => c.id === columnSortKey);
-        handleSortChange(columnSortKey, col?.defaultDirection ?? 'asc');
+        const primaryKey = keys[0];
+        const col = ACTIVITY_SORT_COLUMNS.find((c) => c.id === primaryKey);
+        handleSortChange(primaryKey, col?.defaultDirection ?? 'asc');
       }
     },
     [effectiveSortKey, effectiveSortDirection, handleSortChange]
@@ -783,17 +805,34 @@ export function ActivityTable() {
     () => [
       columnHelper.display({
         id: 'overview',
-        header: () => (
-          <span className="inline-flex items-center gap-1">
-            Overview
+        header: () => {
+          const label =
+            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'activityId')?.label ??
+            'Activity ID';
+          const indicator = (
             <SortIndicator
               columnId="activityId"
               sortKey={effectiveSortKey}
               sortDirection={effectiveSortDirection}
               className="h-4 w-4"
             />
-          </span>
-        ),
+          );
+          return (
+            <span className="inline-flex items-center gap-1">
+              Overview
+              {effectiveSortKey === 'activityId' ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">{indicator}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>Sorted by {label}</TooltipContent>
+                </Tooltip>
+              ) : (
+                indicator
+              )}
+            </span>
+          );
+        },
         meta: { sortKey: 'activityId' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.minSize,
@@ -802,17 +841,34 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('summary', {
-        header: () => (
-          <span className="inline-flex items-center gap-1">
-            Summary
+        header: () => {
+          const label =
+            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'lookAheadStatus')
+              ?.label ?? 'Look Ahead Status';
+          const indicator = (
             <SortIndicator
               columnId="lookAheadStatus"
               sortKey={effectiveSortKey}
               sortDirection={effectiveSortDirection}
               className="h-4 w-4"
             />
-          </span>
-        ),
+          );
+          return (
+            <span className="inline-flex items-center gap-1">
+              Summary
+              {effectiveSortKey === 'lookAheadStatus' ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">{indicator}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>Sorted by {label}</TooltipContent>
+                </Tooltip>
+              ) : (
+                indicator
+              )}
+            </span>
+          );
+        },
         meta: { sortKey: 'lookAheadStatus' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.minSize,
@@ -821,17 +877,34 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('startDate', {
-        header: () => (
-          <span className="inline-flex items-center gap-1">
-            Scheduling
+        header: () => {
+          const label =
+            ACTIVITY_SORT_COLUMNS.find((c) => c.id === 'startDate')?.label ??
+            'Scheduled date';
+          const indicator = (
             <SortIndicator
               columnId="startDate"
               sortKey={effectiveSortKey}
               sortDirection={effectiveSortDirection}
               className="h-4 w-4"
             />
-          </span>
-        ),
+          );
+          return (
+            <span className="inline-flex items-center gap-1">
+              Scheduling
+              {effectiveSortKey === 'startDate' ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">{indicator}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>Sorted by {label}</TooltipContent>
+                </Tooltip>
+              ) : (
+                indicator
+              )}
+            </span>
+          );
+        },
         meta: { sortKey: 'startDate' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.minSize,
@@ -858,18 +931,50 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('activityStatus', {
-        header: () => (
-          <span className="inline-flex items-center gap-1">
-            Status
+        header: () => {
+          const statusSortKeys: string[] = [...STATUS_COLUMN_SORT_KEYS];
+          const isStatusSortActive = statusSortKeys.includes(effectiveSortKey);
+          const statusLabel = isStatusSortActive
+            ? (ACTIVITY_SORT_COLUMNS.find((c) => c.id === effectiveSortKey)
+                ?.label ?? effectiveSortKey)
+            : null;
+          const sortIndicator = (
             <SortIndicator
-              columnId="activityStatus"
+              columnId={statusSortKeys}
               sortKey={effectiveSortKey}
               sortDirection={effectiveSortDirection}
               className="h-4 w-4"
             />
-          </span>
-        ),
-        meta: { sortKey: 'activityStatus' as const },
+          );
+          return (
+            <span className="inline-flex items-center gap-1">
+              Status
+              <span className="inline-flex items-center gap-0.5">
+                {isStatusSortActive && statusLabel ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">{sortIndicator}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>Sorted by {statusLabel}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  sortIndicator
+                )}
+                <ColumnSortDropdown
+                  sortKeys={statusSortKeys}
+                  columns={ACTIVITY_SORT_COLUMNS}
+                  effectiveSortKey={effectiveSortKey}
+                  effectiveSortDirection={effectiveSortDirection}
+                  onSortChange={handleSortChange}
+                  triggerClassName="opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100"
+                  iconClassName="text-slate-400"
+                  ariaLabel="Sort Status column by"
+                />
+              </span>
+            </span>
+          );
+        },
+        meta: { sortKeys: [...STATUS_COLUMN_SORT_KEYS] },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.status.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.minSize,
         maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.maxSize,
@@ -998,156 +1103,170 @@ export function ActivityTable() {
   const pageRows = table.getRowModel().rows;
 
   return (
-    <div className="min-w-0 space-y-4">
-      <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
-        <SortDropdown
-          columns={ACTIVITY_SORT_COLUMNS}
-          sortKey={sortKey}
-          sortDirection={sortDirection}
-          onSortChange={handleSortChange}
-          defaultSortKey={DEFAULT_SORT_KEY}
-          defaultSortDirection={DEFAULT_SORT_DIRECTION}
-          ariaLabel="Sort by"
+    <TooltipProvider delayDuration={400}>
+      <div className="min-w-0 space-y-4">
+        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+          <SortDropdown
+            columns={ACTIVITY_SORT_COLUMNS}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={handleSortChange}
+            defaultSortKey={DEFAULT_SORT_KEY}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            ariaLabel="Sort by"
+          />
+        </div>
+        <TableSummaryBar
+          count={sortedData.length}
+          singularLabel="entry"
+          pluralLabel="entries"
+          filters={eventTableFilters}
         />
-      </div>
-      <TableSummaryBar
-        count={sortedData.length}
-        singularLabel="entry"
-        pluralLabel="entries"
-        filters={eventTableFilters}
-      />
-      <TableScrollContainer ref={tableScrollRef}>
-        <table
-          className={`${tableTable} min-w-[640px] border-separate border-spacing-0`}
-          role="grid"
-          aria-colcount={columns.length}
-        >
-          <thead className={tableThead}>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  const pinStyles = getCommonPinningStyles(header.column);
-                  return (
-                    <th
-                      key={header.id}
-                      className={tableTh}
-                      style={{
-                        width: header.getSize(),
-                        minWidth:
-                          header.column.columnDef.minSize ?? header.getSize(),
-                        maxWidth:
-                          header.column.columnDef.maxSize ?? header.getSize(),
-                        cursor: (
-                          header.column.columnDef.meta as
-                            | { sortKey?: string }
-                            | undefined
-                        )?.sortKey
-                          ? 'pointer'
-                          : 'default',
-                        ...pinStyles,
-                        ...(pinStyles.position === 'sticky'
-                          ? { backgroundColor: 'rgb(248 250 252)' }
-                          : {}),
-                      }}
-                      onClick={() => {
-                        const sortKeyMeta = (
-                          header.column.columnDef.meta as
-                            | { sortKey?: string }
-                            | undefined
-                        )?.sortKey;
-                        const onHeaderSort = (
-                          table.options.meta as
-                            | { handleHeaderSort?: (key: string) => void }
-                            | undefined
-                        )?.handleHeaderSort;
-                        if (sortKeyMeta && onHeaderSort)
-                          onHeaderSort(sortKeyMeta);
-                      }}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                    </th>
-                  );
-                })}
-              </tr>
-            ))}
-          </thead>
-          <tbody>
-            {pageRows.map((row) => {
-              const isNewRow = newRowIds.has(row.original.id);
-              return (
-                <tr
-                  key={row.id}
-                  className={`group/row ${tableBodyRow} cursor-pointer ${
-                    isNewRow ? 'animate-in fade-in-0 duration-300' : ''
-                  }`}
-                  tabIndex={0}
-                  onClick={(e) => {
-                    if ((e.target as HTMLElement).closest('[data-no-row-nav]'))
-                      return;
-                    if (window.getSelection()?.toString().trim()) return;
-                    void navigate(`/activity/${row.original.id}`);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key !== 'Enter' && e.key !== ' ') return;
-                    if ((e.target as HTMLElement).closest('[data-no-row-nav]'))
-                      return;
-                    e.preventDefault();
-                    void navigate(`/activity/${row.original.id}`);
-                  }}
-                >
-                  {row.getVisibleCells().map((cell) => {
-                    const pinStyles = getCommonPinningStyles(cell.column);
-                    const isOverview = cell.column.id === 'overview';
+        <TableScrollContainer ref={tableScrollRef}>
+          <table
+            className={`${tableTable} min-w-[640px] border-separate border-spacing-0`}
+            role="grid"
+            aria-colcount={columns.length}
+          >
+            <thead className={tableThead}>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    const pinStyles = getCommonPinningStyles(header.column);
+                    const meta = header.column.columnDef.meta as
+                      | { sortKey?: string; sortKeys?: string[] }
+                      | undefined;
+                    const isSortable =
+                      meta?.sortKey != null ||
+                      (meta?.sortKeys?.length ?? 0) > 0;
+                    const sortPayload = meta?.sortKeys ?? meta?.sortKey;
+                    const hasMultiSort = (meta?.sortKeys?.length ?? 0) > 0;
                     return (
-                      <td
-                        key={cell.id}
-                        className={`${tableTd} border-b border-slate-100 ${
-                          isOverview
-                            ? 'bg-white/95 group-hover/row:bg-slate-50/50 supports-backdrop-filter:bg-white/80'
-                            : ''
-                        }`}
+                      <th
+                        key={header.id}
+                        className={cn(tableTh, hasMultiSort && 'group')}
                         style={{
-                          width: cell.column.getSize(),
+                          width: header.getSize(),
                           minWidth:
-                            cell.column.columnDef.minSize ??
-                            cell.column.getSize(),
+                            header.column.columnDef.minSize ?? header.getSize(),
                           maxWidth:
-                            cell.column.columnDef.maxSize ??
-                            cell.column.getSize(),
+                            header.column.columnDef.maxSize ?? header.getSize(),
+                          cursor: isSortable ? 'pointer' : 'default',
                           ...pinStyles,
+                          ...(pinStyles.position === 'sticky'
+                            ? { backgroundColor: 'rgb(248 250 252)' }
+                            : {}),
+                        }}
+                        onClick={(e) => {
+                          if (
+                            (e.target as HTMLElement).closest(
+                              `[${COLUMN_SORT_DROPDOWN_DATA_ATTR}]`
+                            )
+                          ) {
+                            return;
+                          }
+                          const onHeaderSort = (
+                            table.options.meta as
+                              | {
+                                  handleHeaderSort?: (
+                                    key: string | string[]
+                                  ) => void;
+                                }
+                              | undefined
+                          )?.handleHeaderSort;
+                          if (sortPayload != null && onHeaderSort)
+                            onHeaderSort(sortPayload);
                         }}
                       >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </td>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                      </th>
                     );
                   })}
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </TableScrollContainer>
+              ))}
+            </thead>
+            <tbody>
+              {pageRows.map((row) => {
+                const isNewRow = newRowIds.has(row.original.id);
+                return (
+                  <tr
+                    key={row.id}
+                    className={`group/row ${tableBodyRow} cursor-pointer ${
+                      isNewRow ? 'animate-in fade-in-0 duration-300' : ''
+                    }`}
+                    tabIndex={0}
+                    onClick={(e) => {
+                      if (
+                        (e.target as HTMLElement).closest('[data-no-row-nav]')
+                      )
+                        return;
+                      if (window.getSelection()?.toString().trim()) return;
+                      void navigate(`/activity/${row.original.id}`);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Enter' && e.key !== ' ') return;
+                      if (
+                        (e.target as HTMLElement).closest('[data-no-row-nav]')
+                      )
+                        return;
+                      e.preventDefault();
+                      void navigate(`/activity/${row.original.id}`);
+                    }}
+                  >
+                    {row.getVisibleCells().map((cell) => {
+                      const pinStyles = getCommonPinningStyles(cell.column);
+                      const isOverview = cell.column.id === 'overview';
+                      return (
+                        <td
+                          key={cell.id}
+                          className={`${tableTd} border-b border-slate-100 ${
+                            isOverview
+                              ? 'bg-white/95 group-hover/row:bg-slate-50/50 supports-backdrop-filter:bg-white/80'
+                              : ''
+                          }`}
+                          style={{
+                            width: cell.column.getSize(),
+                            minWidth:
+                              cell.column.columnDef.minSize ??
+                              cell.column.getSize(),
+                            maxWidth:
+                              cell.column.columnDef.maxSize ??
+                              cell.column.getSize(),
+                            ...pinStyles,
+                          }}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </TableScrollContainer>
 
-      <TablePagination
-        totalItems={sortedData.length}
-        page={pagination.pageIndex + 1}
-        pageSize={pagination.pageSize}
-        onPageChange={(page) =>
-          setPagination((prev) => ({ ...prev, pageIndex: page - 1 }))
-        }
-        onPageSizeChange={(pageSize) =>
-          setPagination((prev) => ({ ...prev, pageSize, pageIndex: 0 }))
-        }
-        scrollContainerRef={tableScrollRef}
-      />
-    </div>
+        <TablePagination
+          totalItems={sortedData.length}
+          page={pagination.pageIndex + 1}
+          pageSize={pagination.pageSize}
+          onPageChange={(page) =>
+            setPagination((prev) => ({ ...prev, pageIndex: page - 1 }))
+          }
+          onPageSizeChange={(pageSize) =>
+            setPagination((prev) => ({ ...prev, pageSize, pageIndex: 0 }))
+          }
+          scrollContainerRef={tableScrollRef}
+        />
+      </div>
+    </TooltipProvider>
   );
 }

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -1027,6 +1027,7 @@ export function ActivityTable() {
       <div className="min-w-0 space-y-4">
         <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
           <SortDropdown
+            hideDirectionLabel
             columns={ACTIVITY_SORT_COLUMNS}
             sortKey={sortKey}
             sortDirection={sortDirection}
@@ -1073,6 +1074,7 @@ export function ActivityTable() {
       <div className="min-w-0 space-y-4">
         <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
           <SortDropdown
+            hideDirectionLabel
             columns={ACTIVITY_SORT_COLUMNS}
             sortKey={sortKey}
             sortDirection={sortDirection}
@@ -1107,6 +1109,7 @@ export function ActivityTable() {
       <div className="min-w-0 space-y-4">
         <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
           <SortDropdown
+            hideDirectionLabel
             columns={ACTIVITY_SORT_COLUMNS}
             sortKey={sortKey}
             sortDirection={sortDirection}

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -4,8 +4,6 @@ import {
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
-  getSortedRowModel,
-  SortingState,
   useReactTable,
   type Column,
   type ColumnPinningState,
@@ -31,6 +29,11 @@ import {
 
 import { SYSTEM_ROLES } from '@corpcal/shared/auth';
 import { ErrorState } from '@/components/ErrorState';
+import {
+  SortDropdown,
+  type SortColumnConfig,
+} from '@/components/Table/SortDropdown';
+import { SortIndicator } from '@/components/Table/SortIndicator';
 import {
   ACTIVITY_TABLE_COLUMN_WIDTHS,
   tableBodyRow,
@@ -76,6 +79,86 @@ import {
  */
 
 const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_SORT_KEY = 'startDate';
+const DEFAULT_SORT_DIRECTION = 'desc' as const;
+
+/** Plan order: New, Changed, Delete requested, Reviewed, Completed, Deleted (on_hold last). */
+const ACTIVITY_STATUS_SORT_ORDER = [
+  'new',
+  'changed',
+  'delete_requested',
+  'reviewed',
+  'completed',
+  'deleted',
+  'on_hold',
+] as const;
+
+/** Plan order: New, Changed, None. */
+const LOOK_AHEAD_SORT_ORDER = ['new', 'changed', 'none'] as const;
+
+const ACTIVITY_SORT_COLUMNS: SortColumnConfig[] = [
+  { id: 'activityId', label: 'Activity ID', defaultDirection: 'asc' },
+  { id: 'activityStatus', label: 'Status', defaultDirection: 'asc' },
+  {
+    id: 'lookAheadStatus',
+    label: 'Look Ahead Status',
+    defaultDirection: 'asc',
+  },
+  { id: 'startDate', label: 'Scheduled date', defaultDirection: 'desc' },
+  { id: 'lastUpdated', label: 'Last updated', defaultDirection: 'desc' },
+  { id: 'createdDateTime', label: 'Date created', defaultDirection: 'desc' },
+];
+
+function indexOfOrder<T extends string>(
+  order: readonly T[],
+  value: string | null
+): number {
+  if (!value) return order.length;
+  const i = order.indexOf(value.toLowerCase() as T);
+  return i === -1 ? order.length : i;
+}
+
+function compareActivityRows(
+  a: ActivityTableRow,
+  b: ActivityTableRow,
+  sortKey: string,
+  direction: 'asc' | 'desc'
+): number {
+  const mult = direction === 'asc' ? 1 : -1;
+  switch (sortKey) {
+    case 'activityId':
+      return mult * (a.id - b.id);
+    case 'activityStatus': {
+      const ia = indexOfOrder(ACTIVITY_STATUS_SORT_ORDER, a.activityStatus);
+      const ib = indexOfOrder(ACTIVITY_STATUS_SORT_ORDER, b.activityStatus);
+      return mult * (ia - ib);
+    }
+    case 'lookAheadStatus': {
+      const ia = indexOfOrder(LOOK_AHEAD_SORT_ORDER, a.lookAheadStatus);
+      const ib = indexOfOrder(LOOK_AHEAD_SORT_ORDER, b.lookAheadStatus);
+      return mult * (ia - ib);
+    }
+    case 'startDate': {
+      const ta = a.startDate ? new Date(a.startDate).getTime() : 0;
+      const tb = b.startDate ? new Date(b.startDate).getTime() : 0;
+      return mult * (ta - tb);
+    }
+    case 'lastUpdated':
+      return (
+        mult *
+        (new Date(a.lastUpdatedDateTime).getTime() -
+          new Date(b.lastUpdatedDateTime).getTime())
+      );
+    case 'createdDateTime':
+      return (
+        mult *
+        (new Date(a.createdDateTime).getTime() -
+          new Date(b.createdDateTime).getTime())
+      );
+    default:
+      return 0;
+  }
+}
 
 function getCommonPinningStyles<T>(column: Column<T, unknown>): CSSProperties {
   const isPinned = column.getIsPinned();
@@ -557,7 +640,10 @@ export function ActivityTable() {
     user?.roleName === SYSTEM_ROLES.SYSTEM_ADMIN;
 
   const tableScrollRef = useRef<HTMLDivElement>(null);
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sortKey, setSortKey] = useState<string | null>(DEFAULT_SORT_KEY);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(
+    DEFAULT_SORT_DIRECTION
+  );
   const [pagination, setPagination] = useState({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -636,6 +722,15 @@ export function ActivityTable() {
     [activities]
   );
 
+  const effectiveSortKey = sortKey ?? DEFAULT_SORT_KEY;
+  const effectiveSortDirection =
+    sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
+  const sortedData = useMemo(() => {
+    return [...data].sort((a, b) =>
+      compareActivityRows(a, b, effectiveSortKey, effectiveSortDirection)
+    );
+  }, [data, effectiveSortKey, effectiveSortDirection]);
+
   // Track which row ids we have seen so we can animate only newly arrived rows on refetch
   const seenIdsRef = useRef<Set<number>>(new Set());
   const [newRowIds, setNewRowIds] = useState<Set<number>>(new Set());
@@ -658,13 +753,48 @@ export function ActivityTable() {
     }
   }, [data]);
 
+  const handleSortChange = useCallback(
+    (key: string | null, direction: 'asc' | 'desc') => {
+      setSortKey(key);
+      setSortDirection(direction);
+    },
+    []
+  );
+
+  const handleHeaderSort = useCallback(
+    (columnSortKey: string) => {
+      const isActive = effectiveSortKey === columnSortKey;
+      if (isActive) {
+        handleSortChange(
+          columnSortKey,
+          effectiveSortDirection === 'asc' ? 'desc' : 'asc'
+        );
+      } else {
+        const col = ACTIVITY_SORT_COLUMNS.find((c) => c.id === columnSortKey);
+        handleSortChange(columnSortKey, col?.defaultDirection ?? 'asc');
+      }
+    },
+    [effectiveSortKey, effectiveSortDirection, handleSortChange]
+  );
+
   const columnHelper = createColumnHelper<ActivityTableRow>();
 
   const columns = useMemo(
     () => [
       columnHelper.display({
         id: 'overview',
-        header: 'Overview',
+        header: () => (
+          <span className="inline-flex items-center gap-1">
+            Overview
+            <SortIndicator
+              columnId="activityId"
+              sortKey={effectiveSortKey}
+              sortDirection={effectiveSortDirection}
+              className="h-4 w-4"
+            />
+          </span>
+        ),
+        meta: { sortKey: 'activityId' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.minSize,
         maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.overview.maxSize,
@@ -672,7 +802,18 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('summary', {
-        header: 'Summary',
+        header: () => (
+          <span className="inline-flex items-center gap-1">
+            Summary
+            <SortIndicator
+              columnId="lookAheadStatus"
+              sortKey={effectiveSortKey}
+              sortDirection={effectiveSortDirection}
+              className="h-4 w-4"
+            />
+          </span>
+        ),
+        meta: { sortKey: 'lookAheadStatus' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.minSize,
         maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.summary.maxSize,
@@ -680,7 +821,18 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('startDate', {
-        header: 'Scheduling',
+        header: () => (
+          <span className="inline-flex items-center gap-1">
+            Scheduling
+            <SortIndicator
+              columnId="startDate"
+              sortKey={effectiveSortKey}
+              sortDirection={effectiveSortDirection}
+              className="h-4 w-4"
+            />
+          </span>
+        ),
+        meta: { sortKey: 'startDate' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.minSize,
         maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.scheduling.maxSize,
@@ -706,33 +858,42 @@ export function ActivityTable() {
       }),
 
       columnHelper.accessor('activityStatus', {
-        header: 'Status',
+        header: () => (
+          <span className="inline-flex items-center gap-1">
+            Status
+            <SortIndicator
+              columnId="activityStatus"
+              sortKey={effectiveSortKey}
+              sortDirection={effectiveSortDirection}
+              className="h-4 w-4"
+            />
+          </span>
+        ),
+        meta: { sortKey: 'activityStatus' as const },
         size: ACTIVITY_TABLE_COLUMN_WIDTHS.status.size,
         minSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.minSize,
         maxSize: ACTIVITY_TABLE_COLUMN_WIDTHS.status.maxSize,
         cell: ({ row }) => <StatusCell row={row.original} userMap={userMap} />,
       }),
     ],
-    [columnHelper, userMap]
+    [columnHelper, userMap, effectiveSortKey, effectiveSortDirection]
   );
 
   const table = useReactTable({
-    data,
+    data: sortedData,
     columns,
-    state: { sorting, pagination, columnPinning },
-    onSortingChange: setSorting,
+    state: { pagination, columnPinning },
     onPaginationChange: onPaginationChangeStable,
     onColumnPinningChange: (updater) =>
       setColumnPinning((prev) =>
         typeof updater === 'function' ? updater(prev) : updater
       ),
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     autoResetPageIndex: false,
     getRowId: (row) => String(row.id),
-    meta: { userMap },
+    meta: { userMap, handleHeaderSort },
   });
 
   const eventTableFilters = useMemo(() => {
@@ -759,6 +920,17 @@ export function ActivityTable() {
   if (loading) {
     return (
       <div className="min-w-0 space-y-4">
+        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+          <SortDropdown
+            columns={ACTIVITY_SORT_COLUMNS}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={handleSortChange}
+            defaultSortKey={DEFAULT_SORT_KEY}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            ariaLabel="Sort by"
+          />
+        </div>
         <TableSummaryBar
           count={0}
           singularLabel="entry"
@@ -794,6 +966,17 @@ export function ActivityTable() {
   if (data.length === 0) {
     return (
       <div className="min-w-0 space-y-4">
+        <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+          <SortDropdown
+            columns={ACTIVITY_SORT_COLUMNS}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSortChange={handleSortChange}
+            defaultSortKey={DEFAULT_SORT_KEY}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            ariaLabel="Sort by"
+          />
+        </div>
         <TableSummaryBar
           count={0}
           singularLabel="entry"
@@ -816,8 +999,19 @@ export function ActivityTable() {
 
   return (
     <div className="min-w-0 space-y-4">
+      <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+        <SortDropdown
+          columns={ACTIVITY_SORT_COLUMNS}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSortChange={handleSortChange}
+          defaultSortKey={DEFAULT_SORT_KEY}
+          defaultSortDirection={DEFAULT_SORT_DIRECTION}
+          ariaLabel="Sort by"
+        />
+      </div>
       <TableSummaryBar
-        count={data.length}
+        count={sortedData.length}
         singularLabel="entry"
         pluralLabel="entries"
         filters={eventTableFilters}
@@ -843,7 +1037,11 @@ export function ActivityTable() {
                           header.column.columnDef.minSize ?? header.getSize(),
                         maxWidth:
                           header.column.columnDef.maxSize ?? header.getSize(),
-                        cursor: header.column.getCanSort()
+                        cursor: (
+                          header.column.columnDef.meta as
+                            | { sortKey?: string }
+                            | undefined
+                        )?.sortKey
                           ? 'pointer'
                           : 'default',
                         ...pinStyles,
@@ -851,11 +1049,20 @@ export function ActivityTable() {
                           ? { backgroundColor: 'rgb(248 250 252)' }
                           : {}),
                       }}
-                      onClick={
-                        header.column.getCanSort()
-                          ? header.column.getToggleSortingHandler()
-                          : undefined
-                      }
+                      onClick={() => {
+                        const sortKeyMeta = (
+                          header.column.columnDef.meta as
+                            | { sortKey?: string }
+                            | undefined
+                        )?.sortKey;
+                        const onHeaderSort = (
+                          table.options.meta as
+                            | { handleHeaderSort?: (key: string) => void }
+                            | undefined
+                        )?.handleHeaderSort;
+                        if (sortKeyMeta && onHeaderSort)
+                          onHeaderSort(sortKeyMeta);
+                      }}
                     >
                       {header.isPlaceholder
                         ? null
@@ -930,7 +1137,7 @@ export function ActivityTable() {
       </TableScrollContainer>
 
       <TablePagination
-        totalItems={table.getFilteredRowModel().rows.length}
+        totalItems={sortedData.length}
         page={pagination.pageIndex + 1}
         pageSize={pagination.pageSize}
         onPageChange={(page) =>

--- a/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode, RefObject } from 'react';
+
+import {
+  SortDropdown,
+  type SortColumnConfig,
+} from '@/components/Table/SortDropdown';
+import { TableScrollContainer } from '@/components/Table/TableScrollContainer';
+import {
+  TableSummaryBar,
+  type BooleanFilter,
+} from '@/components/Table/TableSummaryBar';
+
+export interface ActivityTableLayoutProps {
+  /** Ref forwarded to the scroll container for scroll-to-top on pagination. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Sort dropdown config and state. */
+  sortColumns: SortColumnConfig[];
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  defaultSortKey: string;
+  defaultSortDirection: 'asc' | 'desc';
+  /** Summary bar. */
+  count: number;
+  singularLabel: string;
+  pluralLabel: string;
+  filters?: BooleanFilter[];
+  /** Content inside the scroll area (table, loading spinner, or empty state). */
+  children: ReactNode;
+}
+
+/**
+ * Shared layout shell for ActivityTable: toolbar (sort dropdown + summary bar with filters)
+ * and scroll container. Used for loading, empty, and success states so the toolbar and
+ * container structure are defined in one place.
+ */
+export function ActivityTableLayout({
+  scrollRef,
+  sortColumns,
+  sortKey,
+  sortDirection,
+  onSortChange,
+  defaultSortKey,
+  defaultSortDirection,
+  count,
+  singularLabel,
+  pluralLabel,
+  filters = [],
+  children,
+}: ActivityTableLayoutProps) {
+  return (
+    <div className="min-w-0 space-y-4">
+      <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+        <SortDropdown
+          hideDirectionLabel
+          columns={sortColumns}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSortChange={onSortChange}
+          defaultSortKey={defaultSortKey}
+          defaultSortDirection={defaultSortDirection}
+          ariaLabel="Sort by"
+        />
+      </div>
+      <TableSummaryBar
+        count={count}
+        singularLabel={singularLabel}
+        pluralLabel={pluralLabel}
+        filters={filters}
+      />
+      <TableScrollContainer ref={scrollRef}>{children}</TableScrollContainer>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/activityTableSort.ts
+++ b/calendar-ui/src/components/ActivityTable/activityTableSort.ts
@@ -1,0 +1,85 @@
+import type { ActivityTableRow } from './activityTableRow';
+
+/** Plan order: New, Changed, Delete requested, Reviewed, Completed, Deleted (on_hold last). */
+export const ACTIVITY_STATUS_SORT_ORDER = [
+  'new',
+  'changed',
+  'delete_requested',
+  'reviewed',
+  'completed',
+  'deleted',
+  'on_hold',
+] as const;
+
+/** Plan order: New, Changed, None. */
+export const LOOK_AHEAD_SORT_ORDER = ['new', 'changed', 'none'] as const;
+
+function indexOfOrder<T extends string>(
+  order: readonly T[],
+  value: string | null
+): number {
+  if (!value) return order.length;
+  const i = order.indexOf(value.toLowerCase() as T);
+  return i === -1 ? order.length : i;
+}
+
+/** Compare two values by their index in a fixed order array (unknown values sort last). */
+function compareByOrder(
+  order: readonly string[],
+  aVal: string | null,
+  bVal: string | null
+): number {
+  return indexOfOrder(order, aVal) - indexOfOrder(order, bVal);
+}
+
+type RowComparator = (a: ActivityTableRow, b: ActivityTableRow) => number;
+
+const byActivityId: RowComparator = (a, b) => a.id - b.id;
+
+const byActivityStatus: RowComparator = (a, b) =>
+  compareByOrder(
+    ACTIVITY_STATUS_SORT_ORDER,
+    a.activityStatus,
+    b.activityStatus
+  );
+
+const byLookAheadStatus: RowComparator = (a, b) =>
+  compareByOrder(LOOK_AHEAD_SORT_ORDER, a.lookAheadStatus, b.lookAheadStatus);
+
+const byStartDate: RowComparator = (a, b) => {
+  const ta = a.startDate ? new Date(a.startDate).getTime() : 0;
+  const tb = b.startDate ? new Date(b.startDate).getTime() : 0;
+  return ta - tb;
+};
+
+const byLastUpdated: RowComparator = (a, b) =>
+  new Date(a.lastUpdatedDateTime).getTime() -
+  new Date(b.lastUpdatedDateTime).getTime();
+
+const byCreatedDateTime: RowComparator = (a, b) =>
+  new Date(a.createdDateTime).getTime() - new Date(b.createdDateTime).getTime();
+
+const ACTIVITY_SORT_COMPARATORS: Record<string, RowComparator> = {
+  activityId: byActivityId,
+  activityStatus: byActivityStatus,
+  lookAheadStatus: byLookAheadStatus,
+  startDate: byStartDate,
+  lastUpdated: byLastUpdated,
+  createdDateTime: byCreatedDateTime,
+};
+
+/**
+ * Compare two activity table rows for sorting. Uses a map of comparators keyed by sortKey;
+ * applies direction (asc/desc) to the result.
+ */
+export function compareActivityRows(
+  a: ActivityTableRow,
+  b: ActivityTableRow,
+  sortKey: string,
+  direction: 'asc' | 'desc'
+): number {
+  const comparator = ACTIVITY_SORT_COMPARATORS[sortKey];
+  if (!comparator) return 0;
+  const mult = direction === 'asc' ? 1 : -1;
+  return mult * comparator(a, b);
+}

--- a/calendar-ui/src/components/Table/ColumnSortDropdown.tsx
+++ b/calendar-ui/src/components/Table/ColumnSortDropdown.tsx
@@ -1,0 +1,104 @@
+import { ArrowDown, ArrowUp, ChevronDown } from 'lucide-react';
+
+import type { SortColumnConfig } from '@/components/Table/SortDropdown';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+/** Stops the table header click from firing when interacting with this control. */
+export const COLUMN_SORT_DROPDOWN_DATA_ATTR = 'data-no-header-sort';
+
+interface ColumnSortDropdownProps {
+  /** Sort key ids that this column can be sorted by (subset of columns). */
+  sortKeys: string[];
+  /** Full column config to resolve labels and default directions. */
+  columns: SortColumnConfig[];
+  effectiveSortKey: string;
+  effectiveSortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  /** Applied to the trigger button (e.g. opacity-0 group-hover:opacity-100 for hover-reveal). */
+  triggerClassName?: string;
+  /** Applied to the ChevronDown icon (e.g. text-slate-400 for lighter fill). */
+  iconClassName?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Dropdown shown next to the sort arrow for columns with multiple sort keys.
+ * Lists only the options for this column; selecting one sets sort to that key (with its default direction).
+ */
+export function ColumnSortDropdown({
+  sortKeys,
+  columns,
+  effectiveSortKey,
+  effectiveSortDirection,
+  onSortChange,
+  triggerClassName,
+  iconClassName,
+  ariaLabel = 'Sort this column by',
+}: ColumnSortDropdownProps) {
+  const options = sortKeys
+    .map((id) => columns.find((c) => c.id === id))
+    .filter((c): c is SortColumnConfig => c != null);
+
+  if (options.length === 0) return null;
+
+  const handleSelect = (col: SortColumnConfig) => {
+    const isActive = effectiveSortKey === col.id;
+    if (isActive) {
+      onSortChange(col.id, effectiveSortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      onSortChange(col.id, col.defaultDirection ?? 'asc');
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'h-6 w-6 shrink-0 transition-opacity',
+            triggerClassName
+          )}
+          aria-label={ariaLabel}
+          {...{ [COLUMN_SORT_DROPDOWN_DATA_ATTR]: true }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ChevronDown className={cn('h-4 w-4', iconClassName)} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        {options.map((col) => {
+          const isActive = effectiveSortKey === col.id;
+          const direction = isActive
+            ? effectiveSortDirection
+            : (col.defaultDirection ?? 'asc');
+          const SortIcon = direction === 'asc' ? ArrowUp : ArrowDown;
+          return (
+            <DropdownMenuItem
+              key={col.id}
+              onSelect={(e) => {
+                e.preventDefault();
+                handleSelect(col);
+              }}
+            >
+              {isActive ? (
+                <SortIcon className="h-4 w-4 shrink-0" aria-hidden />
+              ) : (
+                <span className="w-4 shrink-0" aria-hidden />
+              )}
+              {col.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/Table/SortDropdown.tsx
+++ b/calendar-ui/src/components/Table/SortDropdown.tsx
@@ -23,6 +23,10 @@ interface SortDropdownProps {
   /** Default sort when none selected (used for initial display). */
   defaultSortKey: string;
   defaultSortDirection: 'asc' | 'desc';
+  /** When set, use this string as the trigger button label instead of the dynamic column + direction. */
+  triggerLabel?: string;
+  /** When true, do not append direction (e.g. "Newest", "A–Z") to the trigger label. */
+  hideDirectionLabel?: boolean;
   triggerClassName?: string;
   ariaLabel?: string;
 }
@@ -45,6 +49,8 @@ export function SortDropdown({
   onSortChange,
   defaultSortKey,
   defaultSortDirection,
+  triggerLabel: triggerLabelProp,
+  hideDirectionLabel = false,
   triggerClassName,
   ariaLabel = 'Sort by',
 }: SortDropdownProps) {
@@ -52,9 +58,14 @@ export function SortDropdown({
   const effectiveDirection =
     sortKey !== null ? sortDirection : defaultSortDirection;
   const activeColumn = columns.find((c) => c.id === effectiveKey);
-  const triggerLabel = activeColumn
-    ? `${activeColumn.label} ${directionLabel(activeColumn, effectiveDirection)}`
-    : 'Sort by';
+  const triggerLabel =
+    triggerLabelProp != null
+      ? triggerLabelProp
+      : activeColumn
+        ? hideDirectionLabel
+          ? activeColumn.label
+          : `${activeColumn.label} ${directionLabel(activeColumn, effectiveDirection)}`
+        : 'Sort by';
 
   const handleSelect = (col: SortColumnConfig) => {
     const isActive = effectiveKey === col.id;

--- a/calendar-ui/src/components/Table/SortIndicator.tsx
+++ b/calendar-ui/src/components/Table/SortIndicator.tsx
@@ -1,15 +1,27 @@
 import { ArrowDown, ArrowUp } from 'lucide-react';
 
 interface SortIndicatorProps {
-  columnId: string;
+  /** Single column id, or array of ids for columns that map multiple sort keys (arrow shows when sortKey matches any). */
+  columnId: string | string[];
   sortKey: string | null;
   sortDirection: 'asc' | 'desc';
   className?: string;
 }
 
+function isSortKeyActive(
+  sortKey: string | null,
+  columnId: string | string[]
+): boolean {
+  if (!sortKey) return false;
+  return Array.isArray(columnId)
+    ? columnId.includes(sortKey)
+    : sortKey === columnId;
+}
+
 /**
  * Renders an up or down arrow when this column is the active sort column; otherwise returns null.
  * Use next to table header content to show current sort state.
+ * For columns with multiple sort keys, pass columnId as an array so the arrow shows when any of those keys is active.
  */
 export function SortIndicator({
   columnId,
@@ -17,7 +29,7 @@ export function SortIndicator({
   sortDirection,
   className,
 }: SortIndicatorProps) {
-  if (sortKey !== columnId) return null;
+  if (!isSortKeyActive(sortKey, columnId)) return null;
   const Icon = sortDirection === 'asc' ? ArrowUp : ArrowDown;
   return (
     <Icon

--- a/calendar-ui/src/components/Table/SortableColumnHeader.tsx
+++ b/calendar-ui/src/components/Table/SortableColumnHeader.tsx
@@ -1,0 +1,61 @@
+import type { SortColumnConfig } from '@/components/Table/SortDropdown';
+import { SortIndicator } from '@/components/Table/SortIndicator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface SortableColumnHeaderProps {
+  /** Column title shown in the header (e.g. "Overview", "Scheduling"). */
+  title: string;
+  /** Sort key id for this column (e.g. "activityId", "startDate"). */
+  sortColumnId: string;
+  /** Column configs used to resolve the tooltip label when this column is active. */
+  sortColumns: SortColumnConfig[];
+  effectiveSortKey: string;
+  effectiveSortDirection: 'asc' | 'desc';
+  /** Optional class for the sort indicator icon. */
+  indicatorClassName?: string;
+}
+
+/**
+ * Renders a table header with a title and sort indicator. When this column is
+ * the active sort, the indicator is wrapped in a tooltip showing "Sorted by {label}".
+ */
+export function SortableColumnHeader({
+  title,
+  sortColumnId,
+  sortColumns,
+  effectiveSortKey,
+  effectiveSortDirection,
+  indicatorClassName = 'h-4 w-4',
+}: SortableColumnHeaderProps) {
+  const label =
+    sortColumns.find((c) => c.id === sortColumnId)?.label ?? sortColumnId;
+  const indicator = (
+    <SortIndicator
+      columnId={sortColumnId}
+      sortKey={effectiveSortKey}
+      sortDirection={effectiveSortDirection}
+      className={indicatorClassName}
+    />
+  );
+  const isActive = effectiveSortKey === sortColumnId;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      {title}
+      {isActive ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">{indicator}</span>
+          </TooltipTrigger>
+          <TooltipContent>Sorted by {label}</TooltipContent>
+        </Tooltip>
+      ) : (
+        indicator
+      )}
+    </span>
+  );
+}

--- a/calendar-ui/src/components/Table/tableConstants.ts
+++ b/calendar-ui/src/components/Table/tableConstants.ts
@@ -41,3 +41,15 @@ export const ACTIVITY_TABLE_COLUMN_WIDTHS = {
   materials: { size: 200, minSize: 200, maxSize: 240 },
   status: { size: 160, minSize: 160, maxSize: 240 },
 } as const;
+
+export type ActivityTableColumnKey = keyof typeof ACTIVITY_TABLE_COLUMN_WIDTHS;
+
+/** Returns size, minSize, maxSize for a given ActivityTable column (for spreading into column defs). */
+export function getActivityColumnSizes(key: ActivityTableColumnKey): {
+  size: number;
+  minSize: number;
+  maxSize: number;
+} {
+  const w = ACTIVITY_TABLE_COLUMN_WIDTHS[key];
+  return { size: w.size, minSize: w.minSize, maxSize: w.maxSize };
+}

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -1,0 +1,230 @@
+import { useSearchParams } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'activityTablePreferences';
+
+const URL_PARAM_SORT = 'sort';
+const URL_PARAM_DIR = 'dir';
+const URL_PARAM_COMPLETED = 'completed';
+const URL_PARAM_DELETED = 'deleted';
+const URL_PARAM_PAGE_SIZE = 'pageSize';
+
+const VALID_SORT_KEYS = new Set([
+  'activityId',
+  'activityStatus',
+  'lookAheadStatus',
+  'startDate',
+  'lastUpdated',
+  'createdDateTime',
+]);
+
+const DEFAULT_SORT_KEY = 'startDate';
+const DEFAULT_SORT_DIRECTION = 'desc' as const;
+const DEFAULT_PAGE_SIZE = 10;
+const MIN_PAGE_SIZE = 1;
+const MAX_PAGE_SIZE = 100;
+
+export interface ActivityTablePreferences {
+  sortKey: string;
+  sortDirection: 'asc' | 'desc';
+  showCompleted: boolean;
+  showDeleted: boolean;
+  pageSize: number;
+}
+
+const DEFAULT_PREFERENCES: ActivityTablePreferences = {
+  sortKey: DEFAULT_SORT_KEY,
+  sortDirection: DEFAULT_SORT_DIRECTION,
+  showCompleted: false,
+  showDeleted: false,
+  pageSize: DEFAULT_PAGE_SIZE,
+};
+
+function parseBool(value: string | null): boolean | null {
+  if (value === null || value === '') return null;
+  const lower = value.toLowerCase();
+  if (lower === 'true' || lower === '1') return true;
+  if (lower === 'false' || lower === '0') return false;
+  return null;
+}
+
+function parsePageSize(value: string | null): number | null {
+  if (value === null || value === '') return null;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n < MIN_PAGE_SIZE || n > MAX_PAGE_SIZE)
+    return null;
+  return n;
+}
+
+function parseFromSearchParams(
+  searchParams: URLSearchParams,
+  canSeeDeleted: boolean
+): ActivityTablePreferences {
+  const sort = searchParams.get(URL_PARAM_SORT)?.trim() || null;
+  const dir = searchParams.get(URL_PARAM_DIR)?.toLowerCase() || null;
+  const completed = parseBool(searchParams.get(URL_PARAM_COMPLETED));
+  const deleted = parseBool(searchParams.get(URL_PARAM_DELETED));
+  const pageSize = parsePageSize(searchParams.get(URL_PARAM_PAGE_SIZE));
+
+  return {
+    sortKey:
+      sort && VALID_SORT_KEYS.has(sort) ? sort : DEFAULT_PREFERENCES.sortKey,
+    sortDirection:
+      dir === 'asc' || dir === 'desc' ? dir : DEFAULT_PREFERENCES.sortDirection,
+    showCompleted:
+      completed !== null ? completed : DEFAULT_PREFERENCES.showCompleted,
+    showDeleted: !canSeeDeleted
+      ? false
+      : deleted !== null
+        ? deleted
+        : DEFAULT_PREFERENCES.showDeleted,
+    pageSize: pageSize ?? DEFAULT_PREFERENCES.pageSize,
+  };
+}
+
+function parseFromStorage(
+  canSeeDeleted: boolean
+): ActivityTablePreferences | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const sortKey =
+      typeof parsed.sortKey === 'string' && VALID_SORT_KEYS.has(parsed.sortKey)
+        ? parsed.sortKey
+        : DEFAULT_PREFERENCES.sortKey;
+    const sortDirection =
+      parsed.sortDirection === 'asc' || parsed.sortDirection === 'desc'
+        ? parsed.sortDirection
+        : DEFAULT_PREFERENCES.sortDirection;
+    const showCompleted =
+      typeof parsed.showCompleted === 'boolean'
+        ? parsed.showCompleted
+        : DEFAULT_PREFERENCES.showCompleted;
+    const showDeleted = !canSeeDeleted
+      ? false
+      : typeof parsed.showDeleted === 'boolean'
+        ? parsed.showDeleted
+        : DEFAULT_PREFERENCES.showDeleted;
+    const pageSize =
+      typeof parsed.pageSize === 'number' &&
+      Number.isFinite(parsed.pageSize) &&
+      parsed.pageSize >= MIN_PAGE_SIZE &&
+      parsed.pageSize <= MAX_PAGE_SIZE
+        ? parsed.pageSize
+        : DEFAULT_PREFERENCES.pageSize;
+
+    return {
+      sortKey,
+      sortDirection,
+      showCompleted,
+      showDeleted,
+      pageSize,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
+  return (
+    searchParams.has(URL_PARAM_SORT) ||
+    searchParams.has(URL_PARAM_DIR) ||
+    searchParams.has(URL_PARAM_COMPLETED) ||
+    searchParams.has(URL_PARAM_DELETED) ||
+    searchParams.has(URL_PARAM_PAGE_SIZE)
+  );
+}
+
+function getInitialPreferences(
+  searchParams: URLSearchParams,
+  canSeeDeleted: boolean
+): ActivityTablePreferences {
+  if (hasAnyKnownParam(searchParams)) {
+    return parseFromSearchParams(searchParams, canSeeDeleted);
+  }
+  const fromStorage = parseFromStorage(canSeeDeleted);
+  return (
+    fromStorage ?? {
+      ...DEFAULT_PREFERENCES,
+      showDeleted: canSeeDeleted ? DEFAULT_PREFERENCES.showDeleted : false,
+    }
+  );
+}
+
+function preferencesToParams(
+  prefs: ActivityTablePreferences
+): Record<string, string> {
+  return {
+    [URL_PARAM_SORT]: prefs.sortKey,
+    [URL_PARAM_DIR]: prefs.sortDirection,
+    [URL_PARAM_COMPLETED]: String(prefs.showCompleted),
+    [URL_PARAM_DELETED]: String(prefs.showDeleted),
+    [URL_PARAM_PAGE_SIZE]: String(prefs.pageSize),
+  };
+}
+
+/**
+ * Returns the activity list URL search string from sessionStorage (e.g. "?sort=lastUpdated&dir=desc")
+ * for use in breadcrumb or other links back to the list. Returns "" if no valid stored preferences.
+ */
+export function getStoredActivityListSearch(canSeeDeleted: boolean): string {
+  const prefs = parseFromStorage(canSeeDeleted);
+  if (!prefs) return '';
+  const params = new URLSearchParams(preferencesToParams(prefs));
+  const search = params.toString();
+  return search ? `?${search}` : '';
+}
+
+/**
+ * Persists activity table sort and filters using URL search params and sessionStorage.
+ * URL is source of truth when params are present (shareable links); when the user
+ * lands on the page with no params, state is restored from sessionStorage.
+ */
+export function useActivityTablePreferences(canSeeDeleted: boolean): {
+  preferences: ActivityTablePreferences;
+  setPreferences: (partial: Partial<ActivityTablePreferences>) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [preferences, setPreferencesState] = useState<ActivityTablePreferences>(
+    () => getInitialPreferences(searchParams, canSeeDeleted)
+  );
+  const hasUserChangedRef = useRef(false);
+
+  const setPreferences = useCallback(
+    (partial: Partial<ActivityTablePreferences>) => {
+      hasUserChangedRef.current = true;
+      setPreferencesState((prev) => {
+        const next: ActivityTablePreferences = {
+          ...prev,
+          ...partial,
+          showDeleted:
+            partial.showDeleted !== undefined
+              ? canSeeDeleted
+                ? partial.showDeleted
+                : false
+              : prev.showDeleted,
+        };
+        return next;
+      });
+    },
+    [canSeeDeleted]
+  );
+
+  useEffect(() => {
+    if (!hasUserChangedRef.current) return;
+    setSearchParams(preferencesToParams(preferences), { replace: true });
+    if (typeof window !== 'undefined') {
+      try {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+      } catch {
+        // ignore storage errors
+      }
+    }
+  }, [preferences, setSearchParams]);
+
+  return { preferences, setPreferences };
+}


### PR DESCRIPTION
## Summary
This PR updates sorting to the activity list and reconnects persisted sort and filter state across navigation. 
Users can sort by multiple columns (e.g. Start Date, Last updated), and their choices are kept in the URL and sessionStorage (updated from localStorage) so the list state is restored when they return from View/Edit/Create or when they open a shared/bookmarked URL. The activity table is refactored (layout, sortable headers, sort helpers) and documented in ACTIVITY_TABLE_PREFERENCES_PERSISTENCE.md.

## Changes

- **Activity list sort**
  - Sortable column headers with multi-option per column (e.g. Start Date: Date only / Date then Status).
  - `SortDropdown` and new `ColumnSortDropdown`; optional static label and `hideDirectionalLabel` for header use.
  - Sort state driven by `ActivityTablePreferences` (sortKey, sortDirection) and applied in `activityTableSort.ts`.
- **Persistence**
  - New hook `useActivityTablePreferences(canSeeDeleted)`: reads from URL search params (if present) or sessionStorage (previously used localStorage), merges with defaults, and on change writes to both URL (`setSearchParams` with `replace: true`) and sessionStorage key `activityTablePreferences`.
  - URL params: `sort`, `dir`, `completed`, `deleted`, `pageSize`; validation and safe defaults for invalid/missing values.
  - Breadcrumb “Activities list” link uses `getStoredActivityListSearch(canSeeDeleted)` so View/Edit/Create return to the list with current sort/filters in the URL.
- **ActivityTable refactor**
  - Extracted `ActivityTableLayout`, `SortableColumnHeader`, and sort helpers (`activityTableSort.ts`, `tableConstants.ts`) from `ActivityTable.tsx`.
  - `SortIndicator` and `SortDropdown` updated for new usage; new `ColumnSortDropdown` for header dropdowns.
- **Docs**
  - `ACTIVITY_TABLE_PREFERENCES_PERSISTENCE.md` added: read/write behavior, URL vs sessionStorage, data shape, and how to add new filters.

## Testing

- No new automated tests in this branch. Recommend: run lint, typecheck, and build (e.g. `npm run lint`, `npm run typecheck`, `npm run build` in `calendar-ui` / repo root as applicable).
- Manual: On activity list, change sort (column and direction), filters, and page size; navigate away (e.g. open an activity) and use “Activities list” in the breadcrumb — list should restore with the same sort/filters. 
- Open list with query params (e.g. `/?sort=lastUpdated&dir=desc`) and confirm state matches URL. 
- Open `/` with no params after setting preferences and confirm sessionStorage restore in the same tab. 
- Breadcrumbs back to `/` should persist sort state.