### PR TITLE
Feat/CORPCAL-192 activity tabs filters

### DIFF
--- a/calendar-service/src/activities/activities.controller.spec.ts
+++ b/calendar-service/src/activities/activities.controller.spec.ts
@@ -124,7 +124,8 @@ describe('ActivitiesController', () => {
         {
           page: 1,
           limit: 10,
-          excludeCompleted: undefined,
+          sharedWithTeamIds: undefined,
+          includeCompleted: undefined,
           includeDeleted: undefined,
         },
         {} as Parameters<ActivitiesController['findAll']>[1]
@@ -143,7 +144,8 @@ describe('ActivitiesController', () => {
         page: 1,
         limit: 10,
         title: 'Test',
-        excludeCompleted: undefined,
+        sharedWithTeamIds: undefined,
+        includeCompleted: undefined,
         includeDeleted: undefined,
       };
       mockActivitiesService.findAll.mockResolvedValue(activities);

--- a/calendar-service/src/activities/activities.controller.ts
+++ b/calendar-service/src/activities/activities.controller.ts
@@ -145,6 +145,9 @@ export class ActivitiesController {
       query.activityStatusId !== undefined ||
       query.leadMinistryId !== undefined ||
       query.leadTeamId !== undefined ||
+      query.commsContactLeadUserId !== undefined ||
+      query.sharedWithTeamId !== undefined ||
+      query.sharedWithTeamIds !== undefined ||
       query.lookAheadSection !== undefined ||
       query.city !== undefined ||
       query.isIssue !== undefined ||

--- a/calendar-service/src/activities/activities.controller.ts
+++ b/calendar-service/src/activities/activities.controller.ts
@@ -151,7 +151,7 @@ export class ActivitiesController {
       query.lookAheadSection !== undefined ||
       query.city !== undefined ||
       query.isIssue !== undefined ||
-      query.excludeCompleted !== undefined ||
+      query.includeCompleted !== undefined ||
       query.includeDeleted !== undefined;
     const filters = hasFilters ? query : undefined;
     const results = await this.activitiesService.findAll(filters, ctx);

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -713,7 +713,7 @@ export class ActivitiesService {
           conditions.push(ne(activities.activityStatusId, deletedStatusId));
         }
         if (
-          filters.excludeCompleted === true &&
+          filters.includeCompleted !== true &&
           completedStatusId !== undefined
         ) {
           conditions.push(ne(activities.activityStatusId, completedStatusId));
@@ -761,7 +761,7 @@ export class ActivitiesService {
           );
         }
         if (
-          filters.excludeCompleted === true &&
+          filters.includeCompleted !== true &&
           completedStatusId !== undefined
         ) {
           statusConditions.push(

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -808,6 +808,55 @@ export class ActivitiesService {
       );
     }
 
+    // Restrict to activities where this user is the comms contact lead
+    if (filters?.commsContactLeadUserId !== undefined) {
+      const commsLeadRows = await this.databaseService.db
+        .select({ activityId: activityCommsContacts.activityId })
+        .from(activityCommsContacts)
+        .where(
+          and(
+            eq(activityCommsContacts.userId, filters.commsContactLeadUserId),
+            eq(activityCommsContacts.isLead, true),
+            eq(activityCommsContacts.isActive, true)
+          )
+        );
+      const commsLeadIds = new Set(commsLeadRows.map((r) => r.activityId));
+      activityResults = activityResults.filter((a) => commsLeadIds.has(a.id));
+    }
+
+    // Restrict to activities shared with this team
+    if (filters?.sharedWithTeamId !== undefined) {
+      const sharedRows = await this.databaseService.db
+        .select({ activityId: activitySharedWithTeams.activityId })
+        .from(activitySharedWithTeams)
+        .where(
+          and(
+            eq(activitySharedWithTeams.teamId, filters.sharedWithTeamId),
+            eq(activitySharedWithTeams.isActive, true)
+          )
+        );
+      const sharedIds = new Set(sharedRows.map((r) => r.activityId));
+      activityResults = activityResults.filter((a) => sharedIds.has(a.id));
+    }
+
+    // Restrict to activities shared with any of these teams
+    if (
+      filters?.sharedWithTeamIds !== undefined &&
+      filters.sharedWithTeamIds.length > 0
+    ) {
+      const sharedRows = await this.databaseService.db
+        .select({ activityId: activitySharedWithTeams.activityId })
+        .from(activitySharedWithTeams)
+        .where(
+          and(
+            inArray(activitySharedWithTeams.teamId, filters.sharedWithTeamIds),
+            eq(activitySharedWithTeams.isActive, true)
+          )
+        );
+      const sharedIds = new Set(sharedRows.map((r) => r.activityId));
+      activityResults = activityResults.filter((a) => sharedIds.has(a.id));
+    }
+
     // Team-based data scoping: when bypass is false, restrict to activities visible by visibility rules
     // (global visibility for all; team visibility for lead team or shared-with teams only)
     const dataScope = ctx?.dataScope;

--- a/calendar-service/src/look-ahead/look-ahead.service.ts
+++ b/calendar-service/src/look-ahead/look-ahead.service.ts
@@ -57,7 +57,7 @@ export class LookAheadService {
         page: 1,
         limit: 500,
         sharedWithTeamIds: undefined,
-        excludeCompleted: undefined,
+        includeCompleted: undefined,
         includeDeleted: undefined,
       };
       if (options?.startDate) {

--- a/calendar-service/src/look-ahead/look-ahead.service.ts
+++ b/calendar-service/src/look-ahead/look-ahead.service.ts
@@ -56,6 +56,7 @@ export class LookAheadService {
         lookAheadSection: sectionId,
         page: 1,
         limit: 500,
+        sharedWithTeamIds: undefined,
         excludeCompleted: undefined,
         includeDeleted: undefined,
       };

--- a/calendar-ui/docs/ACTIVITY_FILTER_PERSIST.md
+++ b/calendar-ui/docs/ACTIVITY_FILTER_PERSIST.md
@@ -16,7 +16,7 @@ So URL and sessionStorage always hold the same preference shape; the only differ
 
 On mount, the hook decides initial preferences in this order:
 
-1. **URL has any known param?** (`sort`, `dir`, `completed`, `deleted`, `pageSize`)  
+1. **URL has any known param?** (`sort`, `dir`, `completed`, `deleted`, `pageSize`, `search`)  
    If **yes**: Parse all preferences from the URL (with validation and defaults for missing/invalid values). Ignore sessionStorage for this load.
 2. **Otherwise**: Read from sessionStorage key `activityTablePreferences`. Parse and validate. If invalid or missing, use `DEFAULT_PREFERENCES`.
 
@@ -44,13 +44,14 @@ So URL and sessionStorage are updated together; they are not sources of truth fo
 
 Defined in [calendar-ui/src/hooks/useActivityTablePreferences.ts](../src/hooks/useActivityTablePreferences.ts):
 
-| Preference    | URL param   | Type                                | Default     |
-| ------------- | ----------- | ----------------------------------- | ----------- |
-| sortKey       | `sort`      | string (must be in VALID_SORT_KEYS) | `startDate` |
-| sortDirection | `dir`       | `asc` \| `desc`                     | `desc`      |
-| showCompleted | `completed` | boolean                             | `false`     |
-| showDeleted   | `deleted`   | boolean                             | `false`     |
-| pageSize      | `pageSize`  | number (1–100)                      | `10`        |
+| Preference    | URL param   | Type                                    | Default     |
+| ------------- | ----------- | --------------------------------------- | ----------- |
+| sortKey       | `sort`      | string (must be in VALID_SORT_KEYS)     | `startDate` |
+| sortDirection | `dir`       | `asc` \| `desc`                         | `desc`      |
+| showCompleted | `completed` | boolean                                 | `false`     |
+| showDeleted   | `deleted`   | boolean                                 | `false`     |
+| pageSize      | `pageSize`  | number (1–100)                          | `10`        |
+| searchKeyword | `search`    | string (keyword; sync to URL debounced) | `''`        |
 
 - **sessionStorage key**: `activityTablePreferences`. Stored value is a single JSON object with these keys.
 - **pageIndex** is not persisted; it is local component state and resets when filters change.

--- a/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
+++ b/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
@@ -1,6 +1,15 @@
-# Activity list keyword search
+# Activity list keyword search and filtering strategy
 
-This document describes the activity list keyword search implementation and long-term suggestions for scaling.
+This document describes the activity list keyword search, the server vs client filtering split, and long-term suggestions for scaling.
+
+## Filtering strategy
+
+The activity list uses **server-side** filtering only for:
+
+- **Archive:** `includeCompleted` and `includeDeleted` (driven by "Show completed" / "Show deleted" and by the Status filter when it includes Completed or Deleted).
+- **Context:** `leadTeamId`, `commsContactLeadUserId`, `sharedWithTeamId`, `sharedWithTeamIds` when viewing a tab or shared list.
+
+All other filtering is **client-side** over the cached list: date range, status (dropdown), category, pitch, and keyword search. At expected scale (~1–1.5k active rows, up to ~10k with archive), client-side filtering is performant and keeps a single pipeline for adding new filters without API changes.
 
 ## Implemented approach
 
@@ -8,7 +17,7 @@ This document describes the activity list keyword search implementation and long
 
 Keyword search is implemented as **client-side filtering** over the cached activity list:
 
-- The list is already fetched for the current filter set (tab, exclude completed, include deleted) via TanStack Query. The query key does **not** include the search term.
+- The list is already fetched for the current filter set (tab, include completed, include deleted) via TanStack Query. The query key does **not** include the search term, date, status, category, or pitch.
 - When the user types a search term, the client filters the in-memory `ActivityTableRow[]` before sorting and pagination. No new network request is made for search.
 - When the cache is invalidated or refetched (e.g. refetch interval or after a mutation), the same search term is reapplied to the new data.
 
@@ -73,7 +82,7 @@ If the list is paginated, client-side search is no longer possible (the client o
 
 ### Summary
 
-| Scenario                                                | Current behavior                                                     | Possible evolution                                                                                     |
-| ------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Default list (exclude completed/deleted, &lt;1000 rows) | Full list fetched; client-side search; search in URL/sessionStorage. | No change needed.                                                                                      |
-| Include completed/deleted (10k+ rows)                   | Full list fetched once; client-side search over full set.            | Add server-side pagination (and then server-side search) to reduce payload and improve responsiveness. |
+| Scenario                                                   | Current behavior                                                           | Possible evolution                                                                          |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Default list (include completed/deleted off, ~1–1.5k rows) | Full list fetched (archive + context only); all other filters client-side. | No change needed.                                                                           |
+| Include completed/deleted on (~10k rows max)               | Full list fetched once; client-side date, status, category, pitch, search. | Add server-side pagination (and then server-side search) only if needed for responsiveness. |

--- a/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
+++ b/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
@@ -1,0 +1,79 @@
+# Activity list keyword search
+
+This document describes the activity list keyword search implementation and long-term suggestions for scaling.
+
+## Implemented approach
+
+### Client-side filtering
+
+Keyword search is implemented as **client-side filtering** over the cached activity list:
+
+- The list is already fetched for the current filter set (tab, exclude completed, include deleted) via TanStack Query. The query key does **not** include the search term.
+- When the user types a search term, the client filters the in-memory `ActivityTableRow[]` before sorting and pagination. No new network request is made for search.
+- When the cache is invalidated or refetched (e.g. refetch interval or after a mutation), the same search term is reapplied to the new data.
+
+### Persistence (URL and sessionStorage, debounced for search)
+
+Search is synced to the URL so links are shareable, but the URL is updated only **after** the user stops typing (debounced, 400ms). That keeps the search input from losing focus.
+
+- **Filtering**: The table filters on **every keystroke** (no debounce). The user sees results update immediately; only the **URL write** is debounced.
+- **sessionStorage**: Written on every preference change (including each keystroke) so the current search is never lost.
+- **URL (`search` param)**: When only the search keyword changes, the hook schedules a debounced sync. After 400ms with no further search changes, it calls `setSearchParams`. When sort/filter/pageSize change, the URL syncs immediately.
+- **Read**: On load, if the URL has any known params (including `search`), preferences are parsed from the URL; otherwise from sessionStorage.
+- **Breadcrumb**: The "Activities list" link includes the current search (from sessionStorage) once it has been synced.
+
+### Fields searched
+
+The filter matches the trimmed keyword (case-insensitive) against these fields on each activity row:
+
+- `title`, `displayId`, `summary`
+- `activityCategories` (joined), `tags[].text` (joined)
+- `lookAheadStatus`, `lookAheadSection`
+- `venue`, `leadOrg`, `leadMinistry`, `leadMinistryAbbreviation`
+- `commsLeadName`, `eventLead`
+- `activityStatus`
+- `activityRepresentatives` (joined)
+
+The filter is implemented in [calendar-ui/src/lib/activity-query-utils.ts](../src/lib/activity-query-utils.ts) as `filterActivityRowsByKeyword`.
+
+### Behavior details
+
+- **Page index**: When the user changes the search term, the table resets to the first page.
+- **Empty search**: If the term is empty or only whitespace, all rows are shown (no filtering).
+- **No matches**: When there are activities from the server but none match the keyword, the table shows the message "No activities match your search" with the same toolbar (search input and sort/filters) so the user can adjust or clear the search.
+
+### Key files
+
+| File                                                                               | Purpose                                                                                                                                                    |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [useActivityTablePreferences.ts](../src/hooks/useActivityTablePreferences.ts)      | Adds `searchKeyword` to preferences; debounces URL sync (400ms) when only search changes so the field keeps focus; sessionStorage written on every change. |
+| [activity-query-utils.ts](../src/lib/activity-query-utils.ts)                      | `filterActivityRowsByKeyword(rows, keyword)` used to filter table rows.                                                                                    |
+| [ActivityTable.tsx](../src/components/ActivityTable/ActivityTable.tsx)             | Applies filter to `data` -> `filteredData`, then sort -> `sortedData`; passes search props to layout; empty-search state.                                  |
+| [ActivityTableLayout.tsx](../src/components/ActivityTable/ActivityTableLayout.tsx) | Optional search input in toolbar when `searchKeyword` and `onSearchKeywordChange` are provided.                                                            |
+
+---
+
+## Long-term suggestions
+
+### Server-side pagination
+
+When "include completed" and/or "include deleted" is on, the list can grow to 10k+ activities. Loading the full list in one response may become slow and memory-heavy. Consider:
+
+- Adding `page` and `limit` (or cursor) query params to the activities API.
+- Using them in the TanStack Query key so each page is cached separately.
+- Optionally disabling or lengthening the 15s refetch interval when the full list is large.
+
+### Server-side search
+
+If the list is paginated, client-side search is no longer possible (the client only has the current page). Then:
+
+- Add a `search` (or `keyword`) query param to the activities API and filter on the server.
+- Include the search term in the query key (e.g. debounced) so results are cached per term.
+- For large tables, consider PostgreSQL trigram indexes (`pg_trgm`) so `ILIKE '%term%'` can use an index.
+
+### Summary
+
+| Scenario                                                | Current behavior                                                     | Possible evolution                                                                                     |
+| ------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Default list (exclude completed/deleted, &lt;1000 rows) | Full list fetched; client-side search; search in URL/sessionStorage. | No change needed.                                                                                      |
+| Include completed/deleted (10k+ rows)                   | Full list fetched once; client-side search over full set.            | Add server-side pagination (and then server-side search) to reduce payload and improve responsiveness. |

--- a/calendar-ui/src/api/activitiesApi.ts
+++ b/calendar-ui/src/api/activitiesApi.ts
@@ -21,10 +21,17 @@ const logger = createLogger('ActivitiesAPI');
 export async function fetchActivities(
   filters?: Partial<FilterActivitiesQueryParams>
 ): Promise<ActivityResponse[]> {
+  const params =
+    filters?.sharedWithTeamIds != null && filters.sharedWithTeamIds.length > 0
+      ? {
+          ...filters,
+          sharedWithTeamIds: filters.sharedWithTeamIds.join(','),
+        }
+      : filters;
   const res = await api.get<{ success: boolean; data: ActivityResponse[] }>(
     '/activities',
     {
-      params: filters,
+      params,
     }
   );
   // Handle different response structures

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -62,8 +62,17 @@ import {
 import { useActivityTablePreferences } from '@/hooks/useActivityTablePreferences';
 import { useAuth } from '@/hooks/useAuth';
 import { useActivityList } from '@/hooks/useCalendar';
-import { useUsers } from '@/hooks/useLookups';
-import { filterActivityRowsByKeyword } from '@/lib/activity-query-utils';
+import {
+  useActivityStatuses,
+  useCategories,
+  usePitchRequiredStatuses,
+  useUsers,
+} from '@/hooks/useLookups';
+import {
+  filterActivityRowsByFilters,
+  filterActivityRowsByKeyword,
+  type ActivityListQueryParams,
+} from '@/lib/activity-query-utils';
 import {
   formatDateRange,
   formatExactDate,
@@ -73,6 +82,7 @@ import {
 import { getFriendlyErrorMessage } from '@/lib/error-toast';
 import { cn } from '@/lib/utils';
 
+import { ActivityTableFilters } from './ActivityTableFilters';
 import { ActivityTableLayout } from './ActivityTableLayout';
 import {
   mapActivityResponseToTableRow,
@@ -610,7 +620,65 @@ export function ActivityTable({
   const showCompleted = preferences.showCompleted;
   const showDeleted = preferences.showDeleted;
   const searchKeyword = preferences.searchKeyword;
+  const filterState = preferences.filterState;
   const [pageIndex, setPageIndex] = useState(0);
+
+  const { data: categoriesForFilter = [] } = useCategories();
+  const { data: activityStatusesForFilter = [] } = useActivityStatuses();
+  const { data: pitchRequiredStatusesForFilter = [] } =
+    usePitchRequiredStatuses();
+  const categoryOptions = useMemo(
+    () =>
+      categoriesForFilter
+        .filter((c) => c.isActive)
+        .map((c) => ({ value: c.displayName, label: c.displayName })),
+    [categoriesForFilter]
+  );
+  const statusArchiveIds = useMemo(() => {
+    const completed = activityStatusesForFilter.find(
+      (s) => s.name === 'completed'
+    );
+    const deleted = activityStatusesForFilter.find((s) => s.name === 'deleted');
+    return {
+      completedStatusId: completed?.id,
+      deletedStatusId: deleted?.id,
+    };
+  }, [activityStatusesForFilter]);
+
+  const statusOptions = useMemo(
+    () =>
+      activityStatusesForFilter
+        .filter((s) => canSeeDeleted || s.name !== 'deleted')
+        .map((s) => ({
+          value: String(s.id),
+          label: s.displayName,
+        })),
+    [activityStatusesForFilter, canSeeDeleted]
+  );
+
+  const pitchRequiredStatusOptions = useMemo(
+    () =>
+      pitchRequiredStatusesForFilter.map((s) => ({
+        value: s.displayName,
+        label: s.displayName,
+      })),
+    [pitchRequiredStatusesForFilter]
+  );
+
+  const hasStatusFilter = filterState.activityStatusIds.length > 0;
+  const statusFilterIncludesCompleted =
+    statusArchiveIds.completedStatusId != null &&
+    filterState.activityStatusIds.includes(statusArchiveIds.completedStatusId);
+  const statusFilterIncludesDeleted =
+    statusArchiveIds.deletedStatusId != null &&
+    filterState.activityStatusIds.includes(statusArchiveIds.deletedStatusId);
+  const effectiveShowCompleted = hasStatusFilter
+    ? statusFilterIncludesCompleted
+    : showCompleted;
+  const effectiveShowDeleted = hasStatusFilter
+    ? statusFilterIncludesDeleted && canSeeDeleted
+    : showDeleted && canSeeDeleted;
+
   const pagination = useMemo(
     () => ({ pageIndex, pageSize: preferences.pageSize }),
     [pageIndex, preferences.pageSize]
@@ -619,10 +687,11 @@ export function ActivityTable({
     left: ['overview'],
   });
 
-  const activityFilters = useMemo(
-    () => ({
-      excludeCompleted: !showCompleted,
-      includeDeleted: showDeleted && canSeeDeleted,
+  const activityFilters = useMemo((): ActivityListQueryParams => {
+    const dr = filterState.dateRange;
+    const base: ActivityListQueryParams = {
+      excludeCompleted: !effectiveShowCompleted,
+      includeDeleted: effectiveShowDeleted,
       ...(leadTeamId !== undefined && { leadTeamId }),
       ...(commsContactLeadUserId !== undefined && {
         commsContactLeadUserId,
@@ -630,17 +699,29 @@ export function ActivityTable({
       ...(sharedWithTeamId !== undefined && { sharedWithTeamId }),
       ...(sharedWithTeamIds !== undefined &&
         sharedWithTeamIds.length > 0 && { sharedWithTeamIds }),
-    }),
-    [
-      showCompleted,
-      showDeleted,
-      canSeeDeleted,
-      leadTeamId,
-      commsContactLeadUserId,
-      sharedWithTeamId,
-      sharedWithTeamIds,
-    ]
-  );
+    };
+    if (dr.startDate && !dr.noStartDate) {
+      base.startDateFrom = dr.startDate;
+      base.endDateFrom = dr.startDate;
+    }
+    if (dr.endDate && !dr.noEndDate) {
+      base.startDateTo = dr.endDate;
+      base.endDateTo = dr.endDate;
+    }
+    if (filterState.activityStatusIds.length === 1) {
+      base.activityStatusId = filterState.activityStatusIds[0];
+    }
+    return base;
+  }, [
+    effectiveShowCompleted,
+    effectiveShowDeleted,
+    leadTeamId,
+    commsContactLeadUserId,
+    sharedWithTeamId,
+    sharedWithTeamIds,
+    filterState.dateRange,
+    filterState.activityStatusIds,
+  ]);
 
   // Reset to first page when user changes filters so results match expectations
   const prevFiltersRef = useRef(activityFilters);
@@ -669,14 +750,23 @@ export function ActivityTable({
     }
   }, [activityFilters]);
 
-  // Reset to first page when search keyword changes
+  // Reset to first page when search keyword or filter state changes
   const prevSearchKeywordRef = useRef(searchKeyword);
+  const prevFilterStateRef = useRef(filterState);
   useEffect(() => {
     if (prevSearchKeywordRef.current !== searchKeyword) {
       prevSearchKeywordRef.current = searchKeyword;
       setPageIndex(0);
     }
   }, [searchKeyword]);
+  useEffect(() => {
+    if (
+      JSON.stringify(prevFilterStateRef.current) !== JSON.stringify(filterState)
+    ) {
+      prevFilterStateRef.current = filterState;
+      setPageIndex(0);
+    }
+  }, [filterState]);
 
   const activitiesQuery = useActivityList(activityFilters);
   const usersQuery = useUsers();
@@ -723,10 +813,10 @@ export function ActivityTable({
     [activitiesQuery.data]
   );
 
-  const filteredData = useMemo(
-    () => filterActivityRowsByKeyword(data, searchKeyword),
-    [data, searchKeyword]
-  );
+  const filteredData = useMemo(() => {
+    const afterKeyword = filterActivityRowsByKeyword(data, searchKeyword);
+    return filterActivityRowsByFilters(afterKeyword, filterState);
+  }, [data, searchKeyword, filterState]);
 
   const effectiveSortKey = sortKey ?? DEFAULT_SORT_KEY;
   const effectiveSortDirection =
@@ -929,58 +1019,87 @@ export function ActivityTable({
   });
 
   const eventTableFilters = useMemo(() => {
+    const disabledTooltip = hasStatusFilter
+      ? 'Controlled by status filter'
+      : undefined;
     const filters = [
       {
         id: 'show-completed',
         label: 'Show completed',
-        checked: showCompleted,
+        checked: effectiveShowCompleted,
         onCheckedChange: (checked: boolean) =>
           setPreferences({ showCompleted: checked }),
+        disabled: hasStatusFilter,
+        disabledTooltip,
       },
     ];
     if (canSeeDeleted) {
       filters.push({
         id: 'show-deleted',
         label: 'Show deleted',
-        checked: showDeleted,
+        checked: effectiveShowDeleted,
         onCheckedChange: (checked: boolean) =>
           setPreferences({ showDeleted: checked }),
+        disabled: hasStatusFilter,
+        disabledTooltip,
       });
     }
     return filters;
-  }, [showCompleted, showDeleted, canSeeDeleted, setPreferences]);
+  }, [
+    hasStatusFilter,
+    effectiveShowCompleted,
+    effectiveShowDeleted,
+    canSeeDeleted,
+    setPreferences,
+  ]);
 
-  const searchLayoutProps = useMemo(
-    () => ({
-      searchKeyword,
-      onSearchKeywordChange: (value: string) =>
-        setPreferences({ searchKeyword: value }),
-    }),
-    [searchKeyword, setPreferences]
+  const handleFilterStateChange = useCallback(
+    (nextFilterState: typeof filterState) => {
+      setPreferences({ filterState: nextFilterState });
+    },
+    [setPreferences]
+  );
+
+  const filterBar = (
+    <ActivityTableFilters
+      filterState={filterState}
+      onFilterStateChange={handleFilterStateChange}
+      searchKeyword={searchKeyword}
+      onSearchKeywordChange={(value: string) =>
+        setPreferences({ searchKeyword: value })
+      }
+      sortKey={sortKey}
+      sortDirection={sortDirection}
+      onSortChange={handleSortChange}
+      defaultSortKey={DEFAULT_SORT_KEY}
+      defaultSortDirection={DEFAULT_SORT_DIRECTION}
+      sortColumns={ACTIVITY_SORT_COLUMNS}
+      categoryOptions={categoryOptions}
+      pitchRequiredStatusOptions={pitchRequiredStatusOptions}
+      statusOptions={statusOptions}
+    />
   );
 
   // Loading state
   if (loading) {
     return (
-      <ActivityTableLayout
-        scrollRef={tableScrollRef}
-        sortColumns={ACTIVITY_SORT_COLUMNS}
-        sortKey={sortKey}
-        sortDirection={sortDirection}
-        onSortChange={handleSortChange}
-        defaultSortKey={DEFAULT_SORT_KEY}
-        defaultSortDirection={DEFAULT_SORT_DIRECTION}
-        count={0}
-        singularLabel="entry"
-        pluralLabel="entries"
-        filters={eventTableFilters}
-        {...searchLayoutProps}
-      >
-        <div className="flex flex-col items-center justify-center gap-3 py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
-          <span className="text-sm text-slate-600">Loading activities...</span>
-        </div>
-      </ActivityTableLayout>
+      <div className="min-w-0 space-y-4">
+        {filterBar}
+        <ActivityTableLayout
+          scrollRef={tableScrollRef}
+          count={0}
+          singularLabel="entry"
+          pluralLabel="entries"
+          filters={eventTableFilters}
+        >
+          <div className="flex flex-col items-center justify-center gap-3 py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+            <span className="text-sm text-slate-600">
+              Loading activities...
+            </span>
+          </div>
+        </ActivityTableLayout>
+      </div>
     );
   }
 
@@ -1000,49 +1119,39 @@ export function ActivityTable({
   // Empty state (no activities from server)
   if (data.length === 0) {
     return (
-      <ActivityTableLayout
-        scrollRef={tableScrollRef}
-        sortColumns={ACTIVITY_SORT_COLUMNS}
-        sortKey={sortKey}
-        sortDirection={sortDirection}
-        onSortChange={handleSortChange}
-        defaultSortKey={DEFAULT_SORT_KEY}
-        defaultSortDirection={DEFAULT_SORT_DIRECTION}
-        count={0}
-        singularLabel="entry"
-        pluralLabel="entries"
-        filters={eventTableFilters}
-        {...searchLayoutProps}
-      >
-        <div className="py-12 text-center text-sm text-slate-600">
-          <div className="mb-2 font-semibold">No activities found</div>
-          <div>
-            Create a new entry or adjust filters to see activities here.
+      <div className="min-w-0 space-y-4">
+        {filterBar}
+        <ActivityTableLayout
+          scrollRef={tableScrollRef}
+          count={0}
+          singularLabel="entry"
+          pluralLabel="entries"
+          filters={eventTableFilters}
+        >
+          <div className="py-12 text-center text-sm text-slate-600">
+            <div className="mb-2 font-semibold">No activities found</div>
+            <div>
+              Create a new entry or adjust filters to see activities here.
+            </div>
           </div>
-        </div>
-      </ActivityTableLayout>
+        </ActivityTableLayout>
+      </div>
     );
   }
 
   const pageRows = table.getRowModel().rows;
 
-  // Single return so ActivityTableLayout (and search input) stay mounted when switching to empty-search state; preserves focus.
+  // Single return so ActivityTableLayout stays mounted when switching to empty-search state.
   return (
     <TooltipProvider delayDuration={400}>
       <div className="min-w-0 space-y-4">
+        {filterBar}
         <ActivityTableLayout
           scrollRef={tableScrollRef}
-          sortColumns={ACTIVITY_SORT_COLUMNS}
-          sortKey={sortKey}
-          sortDirection={sortDirection}
-          onSortChange={handleSortChange}
-          defaultSortKey={DEFAULT_SORT_KEY}
-          defaultSortDirection={DEFAULT_SORT_DIRECTION}
           count={sortedData.length}
           singularLabel="entry"
           pluralLabel="entries"
           filters={eventTableFilters}
-          {...searchLayoutProps}
         >
           {filteredData.length === 0 ? (
             <div className="py-12 text-center text-sm text-slate-600">

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -70,12 +70,15 @@ import {
   useOrganizations,
   usePitchRequiredStatuses,
   useTags,
+  useTranslationLanguages,
+  useTranslationRequiredStatuses,
   useUsers,
 } from '@/hooks/useLookups';
 import {
   filterActivityRowsByFilters,
   filterActivityRowsByKeyword,
   type ActivityListQueryParams,
+  type FilterActivityRowsContext,
 } from '@/lib/activity-query-utils';
 import {
   formatDateRange,
@@ -636,6 +639,10 @@ export function ActivityTable({
   const { data: organizationsForFilter = [] } = useOrganizations();
   const { data: usersForFilter = [] } = useUsers();
   const { data: eventPlannersForFilter = [] } = useEventPlanners();
+  const { data: translationLanguagesForFilter = [] } =
+    useTranslationLanguages();
+  const { data: translationRequiredStatusesForFilter = [] } =
+    useTranslationRequiredStatuses();
   const categoryOptions = useMemo(
     () =>
       categoriesForFilter
@@ -714,6 +721,40 @@ export function ActivityTable({
         label: ep.label ?? String(ep.id),
       })),
     [eventPlannersForFilter]
+  );
+  const translationOptions = useMemo(
+    () =>
+      translationLanguagesForFilter.map((l) => {
+        const displayLabel = l.shortcode
+          ? `${l.displayName} (${l.shortcode.toUpperCase()})`
+          : (l.displayName ?? String(l.id));
+        return { value: String(l.id), label: displayLabel };
+      }),
+    [translationLanguagesForFilter]
+  );
+  const translationLanguageOptionsForFilter = useMemo(
+    () =>
+      translationLanguagesForFilter.map((l) => ({
+        value: String(l.id),
+        label: l.shortcode ?? l.displayName ?? String(l.id),
+      })),
+    [translationLanguagesForFilter]
+  );
+  const translationStatusOptions = useMemo(
+    () =>
+      translationRequiredStatusesForFilter.map((s) => ({
+        value: String(s.id),
+        label: s.displayName ?? s.name ?? String(s.id),
+      })),
+    [translationRequiredStatusesForFilter]
+  );
+  const translationRequiredStatusOptionsForFilter = useMemo(
+    () =>
+      translationRequiredStatusesForFilter.map((s) => ({
+        value: String(s.id),
+        label: s.displayName ?? s.name ?? String(s.id),
+      })),
+    [translationRequiredStatusesForFilter]
   );
 
   const hasStatusFilter = filterState.activityStatusIds.length > 0;
@@ -849,10 +890,34 @@ export function ActivityTable({
     [activitiesQuery.data]
   );
 
+  const filterContext = useMemo((): FilterActivityRowsContext | undefined => {
+    const hasTranslationStatus =
+      translationRequiredStatusOptionsForFilter.length > 0;
+    const hasTranslationLanguages =
+      translationLanguageOptionsForFilter.length > 0;
+    if (!hasTranslationStatus && !hasTranslationLanguages) return undefined;
+    return {
+      ...(hasTranslationStatus && {
+        translationRequiredStatusOptions:
+          translationRequiredStatusOptionsForFilter,
+      }),
+      ...(hasTranslationLanguages && {
+        translationLanguageOptions: translationLanguageOptionsForFilter,
+      }),
+    };
+  }, [
+    translationRequiredStatusOptionsForFilter,
+    translationLanguageOptionsForFilter,
+  ]);
+
   const filteredData = useMemo(() => {
     const afterKeyword = filterActivityRowsByKeyword(data, searchKeyword);
-    return filterActivityRowsByFilters(afterKeyword, filterState);
-  }, [data, searchKeyword, filterState]);
+    return filterActivityRowsByFilters(
+      afterKeyword,
+      filterState,
+      filterContext
+    );
+  }, [data, searchKeyword, filterState, filterContext]);
 
   const effectiveSortKey = sortKey ?? DEFAULT_SORT_KEY;
   const effectiveSortDirection =
@@ -1114,6 +1179,8 @@ export function ActivityTable({
       pitchRequiredStatusOptions={pitchRequiredStatusOptions}
       statusOptions={statusOptions}
       tagOptions={tagOptions}
+      translationStatusOptions={translationStatusOptions}
+      translationOptions={translationOptions}
       ministryOptions={ministryOptions}
       organizationOptions={organizationOptions}
       commsContactOptions={commsContactOptions}

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -63,6 +63,7 @@ import { useActivityTablePreferences } from '@/hooks/useActivityTablePreferences
 import { useAuth } from '@/hooks/useAuth';
 import { useActivityList } from '@/hooks/useCalendar';
 import { useUsers } from '@/hooks/useLookups';
+import { filterActivityRowsByKeyword } from '@/lib/activity-query-utils';
 import {
   formatDateRange,
   formatExactDate,
@@ -608,6 +609,7 @@ export function ActivityTable({
   const sortDirection = preferences.sortDirection;
   const showCompleted = preferences.showCompleted;
   const showDeleted = preferences.showDeleted;
+  const searchKeyword = preferences.searchKeyword;
   const [pageIndex, setPageIndex] = useState(0);
   const pagination = useMemo(
     () => ({ pageIndex, pageSize: preferences.pageSize }),
@@ -667,6 +669,15 @@ export function ActivityTable({
     }
   }, [activityFilters]);
 
+  // Reset to first page when search keyword changes
+  const prevSearchKeywordRef = useRef(searchKeyword);
+  useEffect(() => {
+    if (prevSearchKeywordRef.current !== searchKeyword) {
+      prevSearchKeywordRef.current = searchKeyword;
+      setPageIndex(0);
+    }
+  }, [searchKeyword]);
+
   const activitiesQuery = useActivityList(activityFilters);
   const usersQuery = useUsers();
   const loading = activitiesQuery.isPending && !activitiesQuery.data;
@@ -712,14 +723,19 @@ export function ActivityTable({
     [activitiesQuery.data]
   );
 
+  const filteredData = useMemo(
+    () => filterActivityRowsByKeyword(data, searchKeyword),
+    [data, searchKeyword]
+  );
+
   const effectiveSortKey = sortKey ?? DEFAULT_SORT_KEY;
   const effectiveSortDirection =
     sortKey !== null ? sortDirection : DEFAULT_SORT_DIRECTION;
   const sortedData = useMemo(() => {
-    return [...data].sort((a, b) =>
+    return [...filteredData].sort((a, b) =>
       compareActivityRows(a, b, effectiveSortKey, effectiveSortDirection)
     );
-  }, [data, effectiveSortKey, effectiveSortDirection]);
+  }, [filteredData, effectiveSortKey, effectiveSortDirection]);
 
   // Track which row ids we have seen so we can animate only newly arrived rows on refetch
   const seenIdsRef = useRef<Set<number>>(new Set());
@@ -934,6 +950,15 @@ export function ActivityTable({
     return filters;
   }, [showCompleted, showDeleted, canSeeDeleted, setPreferences]);
 
+  const searchLayoutProps = useMemo(
+    () => ({
+      searchKeyword,
+      onSearchKeywordChange: (value: string) =>
+        setPreferences({ searchKeyword: value }),
+    }),
+    [searchKeyword, setPreferences]
+  );
+
   // Loading state
   if (loading) {
     return (
@@ -949,6 +974,7 @@ export function ActivityTable({
         singularLabel="entry"
         pluralLabel="entries"
         filters={eventTableFilters}
+        {...searchLayoutProps}
       >
         <div className="flex flex-col items-center justify-center gap-3 py-12">
           <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
@@ -971,7 +997,7 @@ export function ActivityTable({
     );
   }
 
-  // Empty state
+  // Empty state (no activities from server)
   if (data.length === 0) {
     return (
       <ActivityTableLayout
@@ -986,6 +1012,7 @@ export function ActivityTable({
         singularLabel="entry"
         pluralLabel="entries"
         filters={eventTableFilters}
+        {...searchLayoutProps}
       >
         <div className="py-12 text-center text-sm text-slate-600">
           <div className="mb-2 font-semibold">No activities found</div>
@@ -999,6 +1026,7 @@ export function ActivityTable({
 
   const pageRows = table.getRowModel().rows;
 
+  // Single return so ActivityTableLayout (and search input) stay mounted when switching to empty-search state; preserves focus.
   return (
     <TooltipProvider delayDuration={400}>
       <div className="min-w-0 space-y-4">
@@ -1014,150 +1042,164 @@ export function ActivityTable({
           singularLabel="entry"
           pluralLabel="entries"
           filters={eventTableFilters}
+          {...searchLayoutProps}
         >
-          <table
-            className={`${tableTable} min-w-[640px] border-separate border-spacing-0`}
-            role="grid"
-            aria-colcount={columns.length}
-          >
-            <thead className={tableThead}>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    const pinStyles = getCommonPinningStyles(header.column);
-                    const meta = header.column.columnDef.meta as
-                      | { sortKey?: string; sortKeys?: string[] }
-                      | undefined;
-                    const isSortable =
-                      meta?.sortKey != null ||
-                      (meta?.sortKeys?.length ?? 0) > 0;
-                    const sortPayload = meta?.sortKeys ?? meta?.sortKey;
-                    const hasMultiSort = (meta?.sortKeys?.length ?? 0) > 0;
-                    return (
-                      <th
-                        key={header.id}
-                        className={cn(tableTh, hasMultiSort && 'group')}
-                        style={{
-                          width: header.getSize(),
-                          minWidth:
-                            header.column.columnDef.minSize ?? header.getSize(),
-                          maxWidth:
-                            header.column.columnDef.maxSize ?? header.getSize(),
-                          cursor: isSortable ? 'pointer' : 'default',
-                          ...pinStyles,
-                          ...(pinStyles.position === 'sticky'
-                            ? { backgroundColor: 'rgb(248 250 252)' }
-                            : {}),
-                        }}
-                        onClick={(e) => {
-                          if (
-                            (e.target as HTMLElement).closest(
-                              `[${COLUMN_SORT_DROPDOWN_DATA_ATTR}]`
-                            )
-                          ) {
-                            return;
-                          }
-                          const onHeaderSort = (
-                            table.options.meta as
-                              | {
-                                  handleHeaderSort?: (
-                                    key: string | string[]
-                                  ) => void;
-                                }
-                              | undefined
-                          )?.handleHeaderSort;
-                          if (sortPayload != null && onHeaderSort)
-                            onHeaderSort(sortPayload);
-                        }}
-                      >
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                      </th>
-                    );
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {pageRows.map((row) => {
-                const isNewRow = newRowIds.has(row.original.id);
-                return (
-                  <tr
-                    key={row.id}
-                    className={`group/row ${tableBodyRow} cursor-pointer ${
-                      isNewRow ? 'animate-in fade-in-0 duration-300' : ''
-                    }`}
-                    tabIndex={0}
-                    onClick={(e) => {
-                      if (
-                        (e.target as HTMLElement).closest('[data-no-row-nav]')
-                      )
-                        return;
-                      if (window.getSelection()?.toString().trim()) return;
-                      void navigate(`/activity/${row.original.id}`);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key !== 'Enter' && e.key !== ' ') return;
-                      if (
-                        (e.target as HTMLElement).closest('[data-no-row-nav]')
-                      )
-                        return;
-                      e.preventDefault();
-                      void navigate(`/activity/${row.original.id}`);
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => {
-                      const pinStyles = getCommonPinningStyles(cell.column);
-                      const isOverview = cell.column.id === 'overview';
+          {filteredData.length === 0 ? (
+            <div className="py-12 text-center text-sm text-slate-600">
+              <div className="mb-2 font-semibold">
+                No activities match your search
+              </div>
+              <div>Try a different keyword or clear the search.</div>
+            </div>
+          ) : (
+            <table
+              className={`${tableTable} min-w-[640px] border-separate border-spacing-0`}
+              role="grid"
+              aria-colcount={columns.length}
+            >
+              <thead className={tableThead}>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const pinStyles = getCommonPinningStyles(header.column);
+                      const meta = header.column.columnDef.meta as
+                        | { sortKey?: string; sortKeys?: string[] }
+                        | undefined;
+                      const isSortable =
+                        meta?.sortKey != null ||
+                        (meta?.sortKeys?.length ?? 0) > 0;
+                      const sortPayload = meta?.sortKeys ?? meta?.sortKey;
+                      const hasMultiSort = (meta?.sortKeys?.length ?? 0) > 0;
                       return (
-                        <td
-                          key={cell.id}
-                          className={`${tableTd} border-b border-slate-100 ${
-                            isOverview
-                              ? 'bg-white/95 group-hover/row:bg-slate-50/50 supports-backdrop-filter:bg-white/80'
-                              : ''
-                          }`}
+                        <th
+                          key={header.id}
+                          className={cn(tableTh, hasMultiSort && 'group')}
                           style={{
-                            width: cell.column.getSize(),
+                            width: header.getSize(),
                             minWidth:
-                              cell.column.columnDef.minSize ??
-                              cell.column.getSize(),
+                              header.column.columnDef.minSize ??
+                              header.getSize(),
                             maxWidth:
-                              cell.column.columnDef.maxSize ??
-                              cell.column.getSize(),
+                              header.column.columnDef.maxSize ??
+                              header.getSize(),
+                            cursor: isSortable ? 'pointer' : 'default',
                             ...pinStyles,
+                            ...(pinStyles.position === 'sticky'
+                              ? { backgroundColor: 'rgb(248 250 252)' }
+                              : {}),
+                          }}
+                          onClick={(e) => {
+                            if (
+                              (e.target as HTMLElement).closest(
+                                `[${COLUMN_SORT_DROPDOWN_DATA_ATTR}]`
+                              )
+                            ) {
+                              return;
+                            }
+                            const onHeaderSort = (
+                              table.options.meta as
+                                | {
+                                    handleHeaderSort?: (
+                                      key: string | string[]
+                                    ) => void;
+                                  }
+                                | undefined
+                            )?.handleHeaderSort;
+                            if (sortPayload != null && onHeaderSort)
+                              onHeaderSort(sortPayload);
                           }}
                         >
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
-                        </td>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </th>
                       );
                     })}
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                ))}
+              </thead>
+              <tbody>
+                {pageRows.map((row) => {
+                  const isNewRow = newRowIds.has(row.original.id);
+                  return (
+                    <tr
+                      key={row.id}
+                      className={`group/row ${tableBodyRow} cursor-pointer ${
+                        isNewRow ? 'animate-in fade-in-0 duration-300' : ''
+                      }`}
+                      tabIndex={0}
+                      onClick={(e) => {
+                        if (
+                          (e.target as HTMLElement).closest('[data-no-row-nav]')
+                        )
+                          return;
+                        if (window.getSelection()?.toString().trim()) return;
+                        void navigate(`/activity/${row.original.id}`);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key !== 'Enter' && e.key !== ' ') return;
+                        if (
+                          (e.target as HTMLElement).closest('[data-no-row-nav]')
+                        )
+                          return;
+                        e.preventDefault();
+                        void navigate(`/activity/${row.original.id}`);
+                      }}
+                    >
+                      {row.getVisibleCells().map((cell) => {
+                        const pinStyles = getCommonPinningStyles(cell.column);
+                        const isOverview = cell.column.id === 'overview';
+                        return (
+                          <td
+                            key={cell.id}
+                            className={`${tableTd} border-b border-slate-100 ${
+                              isOverview
+                                ? 'bg-white/95 group-hover/row:bg-slate-50/50 supports-backdrop-filter:bg-white/80'
+                                : ''
+                            }`}
+                            style={{
+                              width: cell.column.getSize(),
+                              minWidth:
+                                cell.column.columnDef.minSize ??
+                                cell.column.getSize(),
+                              maxWidth:
+                                cell.column.columnDef.maxSize ??
+                                cell.column.getSize(),
+                              ...pinStyles,
+                            }}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
         </ActivityTableLayout>
 
-        <TablePagination
-          totalItems={sortedData.length}
-          page={pagination.pageIndex + 1}
-          pageSize={pagination.pageSize}
-          onPageChange={(page) =>
-            setPagination((prev) => ({ ...prev, pageIndex: page - 1 }))
-          }
-          onPageSizeChange={(pageSize) =>
-            setPagination((prev) => ({ ...prev, pageSize, pageIndex: 0 }))
-          }
-          scrollContainerRef={tableScrollRef}
-        />
+        {filteredData.length > 0 && (
+          <TablePagination
+            totalItems={sortedData.length}
+            page={pagination.pageIndex + 1}
+            pageSize={pagination.pageSize}
+            onPageChange={(page) =>
+              setPagination((prev) => ({ ...prev, pageIndex: page - 1 }))
+            }
+            onPageSizeChange={(pageSize) =>
+              setPagination((prev) => ({ ...prev, pageSize, pageIndex: 0 }))
+            }
+            scrollContainerRef={tableScrollRef}
+          />
+        )}
       </div>
     </TooltipProvider>
   );

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -65,6 +65,9 @@ import { useActivityList } from '@/hooks/useCalendar';
 import {
   useActivityStatuses,
   useCategories,
+  useEventPlanners,
+  useMinistries,
+  useOrganizations,
   usePitchRequiredStatuses,
   useTags,
   useUsers,
@@ -629,6 +632,10 @@ export function ActivityTable({
   const { data: pitchRequiredStatusesForFilter = [] } =
     usePitchRequiredStatuses();
   const { data: tagsForFilter = [] } = useTags();
+  const { data: ministriesForFilter = [] } = useMinistries();
+  const { data: organizationsForFilter = [] } = useOrganizations();
+  const { data: usersForFilter = [] } = useUsers();
+  const { data: eventPlannersForFilter = [] } = useEventPlanners();
   const categoryOptions = useMemo(
     () =>
       categoriesForFilter
@@ -674,6 +681,39 @@ export function ActivityTable({
         label: t.displayName ?? t.label ?? String(t.id),
       })),
     [tagsForFilter]
+  );
+
+  const ministryOptions = useMemo(
+    () =>
+      ministriesForFilter.map((m) => ({
+        value: String(m.id),
+        label: m.displayName ?? m.name ?? m.label ?? String(m.id),
+      })),
+    [ministriesForFilter]
+  );
+  const organizationOptions = useMemo(
+    () =>
+      organizationsForFilter.map((o) => ({
+        value: String(o.id),
+        label: o.displayName ?? o.name ?? o.label ?? String(o.id),
+      })),
+    [organizationsForFilter]
+  );
+  const commsContactOptions = useMemo(
+    () =>
+      usersForFilter.map((u) => ({
+        value: String(u.id),
+        label: u.name ?? u.email ?? String(u.id),
+      })),
+    [usersForFilter]
+  );
+  const eventPlannerOptions = useMemo(
+    () =>
+      eventPlannersForFilter.map((ep) => ({
+        value: String(ep.id),
+        label: ep.label ?? String(ep.id),
+      })),
+    [eventPlannersForFilter]
   );
 
   const hasStatusFilter = filterState.activityStatusIds.length > 0;
@@ -1074,6 +1114,10 @@ export function ActivityTable({
       pitchRequiredStatusOptions={pitchRequiredStatusOptions}
       statusOptions={statusOptions}
       tagOptions={tagOptions}
+      ministryOptions={ministryOptions}
+      organizationOptions={organizationOptions}
+      commsContactOptions={commsContactOptions}
+      eventPlannerOptions={eventPlannerOptions}
     />
   );
 

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -66,6 +66,7 @@ import {
   useActivityStatuses,
   useCategories,
   usePitchRequiredStatuses,
+  useTags,
   useUsers,
 } from '@/hooks/useLookups';
 import {
@@ -627,6 +628,7 @@ export function ActivityTable({
   const { data: activityStatusesForFilter = [] } = useActivityStatuses();
   const { data: pitchRequiredStatusesForFilter = [] } =
     usePitchRequiredStatuses();
+  const { data: tagsForFilter = [] } = useTags();
   const categoryOptions = useMemo(
     () =>
       categoriesForFilter
@@ -663,6 +665,15 @@ export function ActivityTable({
         label: s.displayName,
       })),
     [pitchRequiredStatusesForFilter]
+  );
+
+  const tagOptions = useMemo(
+    () =>
+      tagsForFilter.map((t) => ({
+        value: String(t.id),
+        label: t.displayName ?? t.label ?? String(t.id),
+      })),
+    [tagsForFilter]
   );
 
   const hasStatusFilter = filterState.activityStatusIds.length > 0;
@@ -1062,6 +1073,7 @@ export function ActivityTable({
       categoryOptions={categoryOptions}
       pitchRequiredStatusOptions={pitchRequiredStatusOptions}
       statusOptions={statusOptions}
+      tagOptions={tagOptions}
     />
   );
 

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -688,9 +688,8 @@ export function ActivityTable({
   });
 
   const activityFilters = useMemo((): ActivityListQueryParams => {
-    const dr = filterState.dateRange;
-    const base: ActivityListQueryParams = {
-      excludeCompleted: !effectiveShowCompleted,
+    return {
+      includeCompleted: effectiveShowCompleted,
       includeDeleted: effectiveShowDeleted,
       ...(leadTeamId !== undefined && { leadTeamId }),
       ...(commsContactLeadUserId !== undefined && {
@@ -700,18 +699,6 @@ export function ActivityTable({
       ...(sharedWithTeamIds !== undefined &&
         sharedWithTeamIds.length > 0 && { sharedWithTeamIds }),
     };
-    if (dr.startDate && !dr.noStartDate) {
-      base.startDateFrom = dr.startDate;
-      base.endDateFrom = dr.startDate;
-    }
-    if (dr.endDate && !dr.noEndDate) {
-      base.startDateTo = dr.endDate;
-      base.endDateTo = dr.endDate;
-    }
-    if (filterState.activityStatusIds.length === 1) {
-      base.activityStatusId = filterState.activityStatusIds[0];
-    }
-    return base;
   }, [
     effectiveShowCompleted,
     effectiveShowDeleted,
@@ -719,8 +706,6 @@ export function ActivityTable({
     commsContactLeadUserId,
     sharedWithTeamId,
     sharedWithTeamIds,
-    filterState.dateRange,
-    filterState.activityStatusIds,
   ]);
 
   // Reset to first page when user changes filters so results match expectations
@@ -738,7 +723,7 @@ export function ActivityTable({
           (id, i) => id === activityFilters.sharedWithTeamIds![i]
         ));
     const same =
-      prev.excludeCompleted === activityFilters.excludeCompleted &&
+      prev.includeCompleted === activityFilters.includeCompleted &&
       prev.includeDeleted === activityFilters.includeDeleted &&
       prev.leadTeamId === activityFilters.leadTeamId &&
       prev.commsContactLeadUserId === activityFilters.commsContactLeadUserId &&

--- a/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTable.tsx
@@ -578,7 +578,23 @@ function StatusCell({
 // Main table component
 // ---------------------------------------------------------------------------
 
-export function ActivityTable() {
+export interface ActivityTableProps {
+  /** When set, only activities with this lead team are shown (e.g. ministry tab). */
+  leadTeamId?: number;
+  /** When set, only activities where this user is comms contact lead are shown. */
+  commsContactLeadUserId?: number;
+  /** When set, only activities shared with this team are shown. */
+  sharedWithTeamId?: number;
+  /** When set, only activities shared with any of these teams are shown. */
+  sharedWithTeamIds?: number[];
+}
+
+export function ActivityTable({
+  leadTeamId,
+  commsContactLeadUserId,
+  sharedWithTeamId,
+  sharedWithTeamIds,
+}: ActivityTableProps = {}) {
   const navigate = useNavigate();
   const { user } = useAuth();
   const canSeeDeleted =
@@ -605,17 +621,46 @@ export function ActivityTable() {
     () => ({
       excludeCompleted: !showCompleted,
       includeDeleted: showDeleted && canSeeDeleted,
+      ...(leadTeamId !== undefined && { leadTeamId }),
+      ...(commsContactLeadUserId !== undefined && {
+        commsContactLeadUserId,
+      }),
+      ...(sharedWithTeamId !== undefined && { sharedWithTeamId }),
+      ...(sharedWithTeamIds !== undefined &&
+        sharedWithTeamIds.length > 0 && { sharedWithTeamIds }),
     }),
-    [showCompleted, showDeleted, canSeeDeleted]
+    [
+      showCompleted,
+      showDeleted,
+      canSeeDeleted,
+      leadTeamId,
+      commsContactLeadUserId,
+      sharedWithTeamId,
+      sharedWithTeamIds,
+    ]
   );
 
   // Reset to first page when user changes filters so results match expectations
   const prevFiltersRef = useRef(activityFilters);
   useEffect(() => {
     const prev = prevFiltersRef.current;
+    const sameSharedWithTeamIds =
+      (prev.sharedWithTeamIds == null &&
+        activityFilters.sharedWithTeamIds == null) ||
+      (prev.sharedWithTeamIds != null &&
+        activityFilters.sharedWithTeamIds != null &&
+        prev.sharedWithTeamIds.length ===
+          activityFilters.sharedWithTeamIds.length &&
+        prev.sharedWithTeamIds.every(
+          (id, i) => id === activityFilters.sharedWithTeamIds![i]
+        ));
     const same =
       prev.excludeCompleted === activityFilters.excludeCompleted &&
-      prev.includeDeleted === activityFilters.includeDeleted;
+      prev.includeDeleted === activityFilters.includeDeleted &&
+      prev.leadTeamId === activityFilters.leadTeamId &&
+      prev.commsContactLeadUserId === activityFilters.commsContactLeadUserId &&
+      prev.sharedWithTeamId === activityFilters.sharedWithTeamId &&
+      sameSharedWithTeamIds;
     if (!same) {
       prevFiltersRef.current = activityFilters;
       setPageIndex(0);

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -10,10 +10,12 @@ import { Input } from '@/components/ui/input';
 import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
 
 import type { ActivityFilterState } from './activityFilterState';
+import { ConfirmedFilter } from './ConfirmedFilter';
 import { LookAheadFilter } from './LookAheadFilter';
 import { PitchFilter } from './PitchFilter';
 import { ScheduledDateFilter } from './ScheduledDateFilter';
 import { isDateRangeActive } from './ScheduledDateRangeFields';
+import { TagsFilter, type TagFilterOption } from './TagsFilter';
 
 export interface ActivityTableFiltersProps {
   filterState: ActivityFilterState;
@@ -29,6 +31,7 @@ export interface ActivityTableFiltersProps {
   categoryOptions: { value: string; label: string }[];
   pitchRequiredStatusOptions: { value: string; label: string }[];
   statusOptions: { value: string; label: string }[];
+  tagOptions: TagFilterOption[];
 }
 
 function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
@@ -40,6 +43,9 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     pitchDateFilter,
     lookAheadStatusValues,
     lookAheadSectionValues,
+    dateConfirmedFilter,
+    timeConfirmedFilter,
+    tagIds,
   } = filterState;
   const pitchDateRangeActive =
     pitchDateFilter.kind === 'scheduled' &&
@@ -58,7 +64,10 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     categoryNames.length > 0 ||
     activityStatusIds.length > 0 ||
     pitchActive ||
-    lookAheadActive
+    lookAheadActive ||
+    dateConfirmedFilter !== 'any' ||
+    timeConfirmedFilter !== 'any' ||
+    tagIds.length > 0
   );
 }
 
@@ -76,6 +85,7 @@ export function ActivityTableFilters({
   categoryOptions,
   pitchRequiredStatusOptions,
   statusOptions,
+  tagOptions,
 }: ActivityTableFiltersProps) {
   const anyActive = useMemo(
     () => hasAnyFilterActive(filterState),
@@ -128,8 +138,21 @@ export function ActivityTableFilters({
       pitchDateFilter: { kind: 'any' },
       lookAheadStatusValues: [],
       lookAheadSectionValues: [],
+      dateConfirmedFilter: 'any',
+      timeConfirmedFilter: 'any',
+      tagIds: [],
     });
   }, [onFilterStateChange]);
+
+  const handleTagIdsChange = useCallback(
+    (tagIds: number[]) => {
+      onFilterStateChange({
+        ...filterState,
+        tagIds,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
 
   const categorySelectedValues = filterState.categoryNames;
   const statusSelectedValues = filterState.activityStatusIds.map(String);
@@ -138,7 +161,7 @@ export function ActivityTableFilters({
     <div
       className="mb-4 flex flex-wrap items-center justify-between gap-4"
       role="search"
-      aria-label="Filter activities by date, category, pitch, look ahead, status, and keyword"
+      aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, and keyword"
     >
       <div className="flex flex-wrap items-center gap-2">
         <ScheduledDateFilter
@@ -160,11 +183,20 @@ export function ActivityTableFilters({
           filterState={filterState}
           onFilterStateChange={onFilterStateChange}
         />
+        <ConfirmedFilter
+          filterState={filterState}
+          onFilterStateChange={onFilterStateChange}
+        />
         <FilterCheckboxDropdown
           label="Status"
           options={statusOptions}
           selectedValues={statusSelectedValues}
           onChange={handleStatusChange}
+        />
+        <TagsFilter
+          tagOptions={tagOptions}
+          selectedTagIds={filterState.tagIds}
+          onTagIdsChange={handleTagIdsChange}
         />
         {anyActive && (
           <Button

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -1,0 +1,207 @@
+import { Search, X } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+
+import {
+  SortDropdown,
+  type SortColumnConfig,
+} from '@/components/Table/SortDropdown';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
+
+import type { ActivityFilterState } from './activityFilterState';
+import { PitchFilter } from './PitchFilter';
+import { ScheduledDateFilter } from './ScheduledDateFilter';
+
+export interface ActivityTableFiltersProps {
+  filterState: ActivityFilterState;
+  onFilterStateChange: (state: ActivityFilterState) => void;
+  searchKeyword: string;
+  onSearchKeywordChange: (value: string) => void;
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc';
+  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
+  defaultSortKey: string;
+  defaultSortDirection: 'asc' | 'desc';
+  sortColumns: SortColumnConfig[];
+  categoryOptions: { value: string; label: string }[];
+  pitchRequiredStatusOptions: { value: string; label: string }[];
+  statusOptions: { value: string; label: string }[];
+}
+
+function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
+  const {
+    dateRange,
+    categoryNames,
+    activityStatusIds,
+    pitchRequiredStatusNames,
+    pitchDateFilter,
+  } = filterState;
+  const pitchDateRangeActive =
+    pitchDateFilter.kind === 'scheduled' &&
+    (pitchDateFilter.dateRange.startDate !== '' ||
+      pitchDateFilter.dateRange.endDate !== '' ||
+      pitchDateFilter.dateRange.noStartDate ||
+      pitchDateFilter.dateRange.noEndDate);
+  const pitchActive =
+    pitchRequiredStatusNames.length > 0 ||
+    pitchDateFilter.kind !== 'any' ||
+    pitchDateRangeActive;
+  return (
+    dateRange.startDate !== '' ||
+    dateRange.endDate !== '' ||
+    dateRange.noStartDate ||
+    dateRange.noEndDate ||
+    categoryNames.length > 0 ||
+    activityStatusIds.length > 0 ||
+    pitchActive
+  );
+}
+
+export function ActivityTableFilters({
+  filterState,
+  onFilterStateChange,
+  searchKeyword,
+  onSearchKeywordChange,
+  sortKey,
+  sortDirection,
+  onSortChange,
+  defaultSortKey,
+  defaultSortDirection,
+  sortColumns,
+  categoryOptions,
+  pitchRequiredStatusOptions,
+  statusOptions,
+}: ActivityTableFiltersProps) {
+  const anyActive = useMemo(
+    () => hasAnyFilterActive(filterState),
+    [filterState]
+  );
+
+  const handleDateRangeChange = useCallback(
+    (dateRange: ActivityFilterState['dateRange']) => {
+      onFilterStateChange({
+        ...filterState,
+        dateRange,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
+  const handleCategoryChange = useCallback(
+    (values: string[]) => {
+      onFilterStateChange({
+        ...filterState,
+        categoryNames: values,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
+  const handleStatusChange = useCallback(
+    (values: string[]) => {
+      onFilterStateChange({
+        ...filterState,
+        activityStatusIds: values
+          .map((v) => parseInt(v, 10))
+          .filter((n) => !Number.isNaN(n)),
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
+  const handleClearAllFilters = useCallback(() => {
+    onFilterStateChange({
+      dateRange: {
+        startDate: '',
+        endDate: '',
+        noStartDate: false,
+        noEndDate: false,
+      },
+      categoryNames: [],
+      activityStatusIds: [],
+      pitchRequiredStatusNames: [],
+      pitchDateFilter: { kind: 'any' },
+    });
+  }, [onFilterStateChange]);
+
+  const categorySelectedValues = filterState.categoryNames;
+  const statusSelectedValues = filterState.activityStatusIds.map(String);
+
+  return (
+    <div
+      className="mb-4 flex flex-wrap items-center justify-between gap-4"
+      role="search"
+      aria-label="Filter activities by date, category, pitch, status, and keyword"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <ScheduledDateFilter
+          value={filterState.dateRange}
+          onChange={handleDateRangeChange}
+        />
+        <FilterCheckboxDropdown
+          label="Category"
+          options={categoryOptions}
+          selectedValues={categorySelectedValues}
+          onChange={handleCategoryChange}
+        />
+        <PitchFilter
+          filterState={filterState}
+          onFilterStateChange={onFilterStateChange}
+          pitchRequiredStatusOptions={pitchRequiredStatusOptions}
+        />
+        <FilterCheckboxDropdown
+          label="Status"
+          options={statusOptions}
+          selectedValues={statusSelectedValues}
+          onChange={handleStatusChange}
+        />
+        {anyActive && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="animate-in fade-in duration-200"
+            onClick={handleClearAllFilters}
+            aria-label="Clear all filters"
+          >
+            Clear all filters
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="relative max-w-md min-w-[240px] flex-1">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+          <Input
+            type="text"
+            placeholder="Search activities..."
+            value={searchKeyword}
+            onChange={(e) => onSearchKeywordChange(e.target.value)}
+            className="pr-8 pl-8"
+            aria-label="Search activities"
+          />
+          {searchKeyword && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              onClick={() => onSearchKeywordChange('')}
+              aria-label="Clear search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        <SortDropdown
+          hideDirectionLabel
+          columns={sortColumns}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSortChange={onSortChange}
+          defaultSortKey={defaultSortKey}
+          defaultSortDirection={defaultSortDirection}
+          ariaLabel="Sort by"
+        />
+      </div>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -17,6 +17,11 @@ import { PitchFilter } from './PitchFilter';
 import { ScheduledDateFilter } from './ScheduledDateFilter';
 import { isDateRangeActive } from './ScheduledDateRangeFields';
 import { TagsFilter, type TagFilterOption } from './TagsFilter';
+import {
+  TranslationsFilter,
+  type TranslationFilterOption,
+  type TranslationStatusFilterOption,
+} from './TranslationsFilter';
 
 export interface ActivityTableFiltersProps {
   filterState: ActivityFilterState;
@@ -37,6 +42,8 @@ export interface ActivityTableFiltersProps {
   organizationOptions: LeadFilterOption[];
   commsContactOptions: LeadFilterOption[];
   eventPlannerOptions: LeadFilterOption[];
+  translationStatusOptions: TranslationStatusFilterOption[];
+  translationOptions: TranslationFilterOption[];
 }
 
 function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
@@ -55,6 +62,8 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     leadOrgIds,
     commsContactLeadUserIds,
     eventPlannerLeadIds,
+    translationRequiredStatusIds,
+    translationLanguageIds,
   } = filterState;
   const pitchDateRangeActive =
     pitchDateFilter.kind === 'scheduled' &&
@@ -70,6 +79,9 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     leadOrgIds.length > 0 ||
     commsContactLeadUserIds.length > 0 ||
     eventPlannerLeadIds.length > 0;
+  const translationsActive =
+    translationRequiredStatusIds.length > 0 ||
+    translationLanguageIds.length > 0;
   return (
     dateRange.startDate !== '' ||
     dateRange.endDate !== '' ||
@@ -82,7 +94,8 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     dateConfirmedFilter !== 'any' ||
     timeConfirmedFilter !== 'any' ||
     tagIds.length > 0 ||
-    leadsActive
+    leadsActive ||
+    translationsActive
   );
 }
 
@@ -105,6 +118,8 @@ export function ActivityTableFilters({
   organizationOptions,
   commsContactOptions,
   eventPlannerOptions,
+  translationStatusOptions,
+  translationOptions,
 }: ActivityTableFiltersProps) {
   const anyActive = useMemo(
     () => hasAnyFilterActive(filterState),
@@ -165,6 +180,8 @@ export function ActivityTableFilters({
       leadOrgIds: [],
       commsContactLeadUserIds: [],
       eventPlannerLeadIds: [],
+      translationRequiredStatusIds: [],
+      translationLanguageIds: [],
     });
   }, [onFilterStateChange]);
 
@@ -178,64 +195,100 @@ export function ActivityTableFilters({
     [filterState, onFilterStateChange]
   );
 
+  const handleTranslationRequiredStatusIdsChange = useCallback(
+    (translationRequiredStatusIds: number[]) => {
+      onFilterStateChange({
+        ...filterState,
+        translationRequiredStatusIds,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
+  const handleTranslationLanguageIdsChange = useCallback(
+    (translationLanguageIds: number[]) => {
+      onFilterStateChange({
+        ...filterState,
+        translationLanguageIds,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
   const categorySelectedValues = filterState.categoryNames;
   const statusSelectedValues = filterState.activityStatusIds.map(String);
 
   return (
     <div
-      className="mb-4 flex flex-wrap items-center justify-between gap-4"
+      className="mb-4 flex flex-nowrap items-center justify-between gap-4"
       role="search"
-      aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, leads, and keyword"
+      aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, translations, leads, and keyword"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <ScheduledDateFilter
-          value={filterState.dateRange}
-          onChange={handleDateRangeChange}
-        />
-        <FilterCheckboxDropdown
-          label="Category"
-          options={categoryOptions}
-          selectedValues={categorySelectedValues}
-          onChange={handleCategoryChange}
-        />
-        <PitchFilter
-          filterState={filterState}
-          onFilterStateChange={onFilterStateChange}
-          pitchRequiredStatusOptions={pitchRequiredStatusOptions}
-        />
-        <LookAheadFilter
-          filterState={filterState}
-          onFilterStateChange={onFilterStateChange}
-        />
-        <ConfirmedFilter
-          filterState={filterState}
-          onFilterStateChange={onFilterStateChange}
-        />
-        <FilterCheckboxDropdown
-          label="Status"
-          options={statusOptions}
-          selectedValues={statusSelectedValues}
-          onChange={handleStatusChange}
-        />
-        <TagsFilter
-          tagOptions={tagOptions}
-          selectedTagIds={filterState.tagIds}
-          onTagIdsChange={handleTagIdsChange}
-        />
-        <LeadsFilter
-          filterState={filterState}
-          onFilterStateChange={onFilterStateChange}
-          ministryOptions={ministryOptions}
-          organizationOptions={organizationOptions}
-          commsContactOptions={commsContactOptions}
-          eventPlannerOptions={eventPlannerOptions}
-        />
+      <div className="flex max-w-4xl min-w-0 flex-1 items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <div className="scrollbar-hide flex min-h-9 flex-nowrap items-center gap-2 overflow-x-auto overflow-y-hidden pr-4 *:shrink-0">
+            <ScheduledDateFilter
+              value={filterState.dateRange}
+              onChange={handleDateRangeChange}
+            />
+            <FilterCheckboxDropdown
+              label="Category"
+              options={categoryOptions}
+              selectedValues={categorySelectedValues}
+              onChange={handleCategoryChange}
+            />
+            <PitchFilter
+              filterState={filterState}
+              onFilterStateChange={onFilterStateChange}
+              pitchRequiredStatusOptions={pitchRequiredStatusOptions}
+            />
+            <LookAheadFilter
+              filterState={filterState}
+              onFilterStateChange={onFilterStateChange}
+            />
+            <ConfirmedFilter
+              filterState={filterState}
+              onFilterStateChange={onFilterStateChange}
+            />
+            <FilterCheckboxDropdown
+              label="Status"
+              options={statusOptions}
+              selectedValues={statusSelectedValues}
+              onChange={handleStatusChange}
+            />
+            <TagsFilter
+              tagOptions={tagOptions}
+              selectedTagIds={filterState.tagIds}
+              onTagIdsChange={handleTagIdsChange}
+            />
+            <TranslationsFilter
+              translationStatusOptions={translationStatusOptions}
+              translationOptions={translationOptions}
+              selectedStatusIds={filterState.translationRequiredStatusIds}
+              selectedLanguageIds={filterState.translationLanguageIds}
+              onStatusIdsChange={handleTranslationRequiredStatusIdsChange}
+              onLanguageIdsChange={handleTranslationLanguageIdsChange}
+            />
+            <LeadsFilter
+              filterState={filterState}
+              onFilterStateChange={onFilterStateChange}
+              ministryOptions={ministryOptions}
+              organizationOptions={organizationOptions}
+              commsContactOptions={commsContactOptions}
+              eventPlannerOptions={eventPlannerOptions}
+            />
+          </div>
+          <div
+            className="from-background pointer-events-none absolute top-0 right-0 bottom-0 w-12 bg-linear-to-l to-transparent"
+            aria-hidden
+          />
+        </div>
         {anyActive && (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="animate-in fade-in duration-200"
+            className="animate-in fade-in h-9 shrink-0 duration-200"
             onClick={handleClearAllFilters}
             aria-label="Clear all filters"
           >
@@ -243,7 +296,7 @@ export function ActivityTableFilters({
           </Button>
         )}
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <div className="relative max-w-md min-w-[240px] flex-1">
           <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
           <Input

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -1,6 +1,7 @@
 import { Search, X } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 
+import { ResponsiveFilterRow } from '@/components/ResponsiveFilterRow';
 import {
   SortDropdown,
   type SortColumnConfig,
@@ -218,83 +219,121 @@ export function ActivityTableFilters({
   const categorySelectedValues = filterState.categoryNames;
   const statusSelectedValues = filterState.activityStatusIds.map(String);
 
+  const filterSlots = useMemo(
+    () => [
+      <ScheduledDateFilter
+        key="date"
+        value={filterState.dateRange}
+        onChange={handleDateRangeChange}
+      />,
+      <FilterCheckboxDropdown
+        key="category"
+        label="Category"
+        options={categoryOptions}
+        selectedValues={categorySelectedValues}
+        onChange={handleCategoryChange}
+      />,
+      <PitchFilter
+        key="pitch"
+        filterState={filterState}
+        onFilterStateChange={onFilterStateChange}
+        pitchRequiredStatusOptions={pitchRequiredStatusOptions}
+      />,
+      <LookAheadFilter
+        key="lookAhead"
+        filterState={filterState}
+        onFilterStateChange={onFilterStateChange}
+      />,
+      <ConfirmedFilter
+        key="confirmed"
+        filterState={filterState}
+        onFilterStateChange={onFilterStateChange}
+      />,
+      <FilterCheckboxDropdown
+        key="status"
+        label="Status"
+        options={statusOptions}
+        selectedValues={statusSelectedValues}
+        onChange={handleStatusChange}
+      />,
+      <TagsFilter
+        key="tags"
+        tagOptions={tagOptions}
+        selectedTagIds={filterState.tagIds}
+        onTagIdsChange={handleTagIdsChange}
+      />,
+      <TranslationsFilter
+        key="translations"
+        translationStatusOptions={translationStatusOptions}
+        translationOptions={translationOptions}
+        selectedStatusIds={filterState.translationRequiredStatusIds}
+        selectedLanguageIds={filterState.translationLanguageIds}
+        onStatusIdsChange={handleTranslationRequiredStatusIdsChange}
+        onLanguageIdsChange={handleTranslationLanguageIdsChange}
+      />,
+      <LeadsFilter
+        key="leads"
+        filterState={filterState}
+        onFilterStateChange={onFilterStateChange}
+        ministryOptions={ministryOptions}
+        organizationOptions={organizationOptions}
+        commsContactOptions={commsContactOptions}
+        eventPlannerOptions={eventPlannerOptions}
+      />,
+    ],
+    [
+      filterState,
+      onFilterStateChange,
+      categoryOptions,
+      categorySelectedValues,
+      handleCategoryChange,
+      handleDateRangeChange,
+      handleStatusChange,
+      handleTagIdsChange,
+      handleTranslationRequiredStatusIdsChange,
+      handleTranslationLanguageIdsChange,
+      pitchRequiredStatusOptions,
+      statusOptions,
+      statusSelectedValues,
+      tagOptions,
+      translationStatusOptions,
+      translationOptions,
+      ministryOptions,
+      organizationOptions,
+      commsContactOptions,
+      eventPlannerOptions,
+    ]
+  );
+
   return (
     <div
-      className="mb-4 flex flex-nowrap items-center justify-between gap-4"
+      className="mb-4 flex flex-nowrap items-center justify-between gap-8"
       role="search"
       aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, translations, leads, and keyword"
     >
-      <div className="flex max-w-4xl min-w-0 flex-1 items-center gap-2">
-        <div className="relative min-w-0 flex-1">
-          <div className="scrollbar-hide flex min-h-9 flex-nowrap items-center gap-2 overflow-x-auto overflow-y-hidden pr-4 *:shrink-0">
-            <ScheduledDateFilter
-              value={filterState.dateRange}
-              onChange={handleDateRangeChange}
-            />
-            <FilterCheckboxDropdown
-              label="Category"
-              options={categoryOptions}
-              selectedValues={categorySelectedValues}
-              onChange={handleCategoryChange}
-            />
-            <PitchFilter
-              filterState={filterState}
-              onFilterStateChange={onFilterStateChange}
-              pitchRequiredStatusOptions={pitchRequiredStatusOptions}
-            />
-            <LookAheadFilter
-              filterState={filterState}
-              onFilterStateChange={onFilterStateChange}
-            />
-            <ConfirmedFilter
-              filterState={filterState}
-              onFilterStateChange={onFilterStateChange}
-            />
-            <FilterCheckboxDropdown
-              label="Status"
-              options={statusOptions}
-              selectedValues={statusSelectedValues}
-              onChange={handleStatusChange}
-            />
-            <TagsFilter
-              tagOptions={tagOptions}
-              selectedTagIds={filterState.tagIds}
-              onTagIdsChange={handleTagIdsChange}
-            />
-            <TranslationsFilter
-              translationStatusOptions={translationStatusOptions}
-              translationOptions={translationOptions}
-              selectedStatusIds={filterState.translationRequiredStatusIds}
-              selectedLanguageIds={filterState.translationLanguageIds}
-              onStatusIdsChange={handleTranslationRequiredStatusIdsChange}
-              onLanguageIdsChange={handleTranslationLanguageIdsChange}
-            />
-            <LeadsFilter
-              filterState={filterState}
-              onFilterStateChange={onFilterStateChange}
-              ministryOptions={ministryOptions}
-              organizationOptions={organizationOptions}
-              commsContactOptions={commsContactOptions}
-              eventPlannerOptions={eventPlannerOptions}
-            />
-          </div>
-          <div
-            className="from-background pointer-events-none absolute top-0 right-0 bottom-0 w-12 bg-linear-to-l to-transparent"
-            aria-hidden
-          />
-        </div>
-        {anyActive && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="animate-in fade-in h-9 shrink-0 duration-200"
-            onClick={handleClearAllFilters}
-            aria-label="Clear all filters"
-          >
-            Clear all filters
-          </Button>
-        )}
+      <div className="flex max-w-4xl min-w-0 flex-1 items-center">
+        <ResponsiveFilterRow
+          overflowTriggerLabel="All filters"
+          overflowTriggerClassName="h-10"
+          reservedWidthForTrailing={120}
+          trailingContent={
+            anyActive ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="flex h-10 shrink-0 items-center gap-1"
+                onClick={handleClearAllFilters}
+                aria-label="Clear all filters"
+              >
+                <X className="h-3.5 w-3.5" />
+                Clear filters
+              </Button>
+            ) : undefined
+          }
+        >
+          {filterSlots}
+        </ResponsiveFilterRow>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <div className="relative max-w-md min-w-[240px] flex-1">

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -11,6 +11,7 @@ import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdow
 
 import type { ActivityFilterState } from './activityFilterState';
 import { ConfirmedFilter } from './ConfirmedFilter';
+import { LeadsFilter, type LeadFilterOption } from './LeadsFilter';
 import { LookAheadFilter } from './LookAheadFilter';
 import { PitchFilter } from './PitchFilter';
 import { ScheduledDateFilter } from './ScheduledDateFilter';
@@ -32,6 +33,10 @@ export interface ActivityTableFiltersProps {
   pitchRequiredStatusOptions: { value: string; label: string }[];
   statusOptions: { value: string; label: string }[];
   tagOptions: TagFilterOption[];
+  ministryOptions: LeadFilterOption[];
+  organizationOptions: LeadFilterOption[];
+  commsContactOptions: LeadFilterOption[];
+  eventPlannerOptions: LeadFilterOption[];
 }
 
 function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
@@ -46,6 +51,10 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     dateConfirmedFilter,
     timeConfirmedFilter,
     tagIds,
+    leadMinistryIds,
+    leadOrgIds,
+    commsContactLeadUserIds,
+    eventPlannerLeadIds,
   } = filterState;
   const pitchDateRangeActive =
     pitchDateFilter.kind === 'scheduled' &&
@@ -56,6 +65,11 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     pitchDateRangeActive;
   const lookAheadActive =
     lookAheadStatusValues.length > 0 || lookAheadSectionValues.length > 0;
+  const leadsActive =
+    leadMinistryIds.length > 0 ||
+    leadOrgIds.length > 0 ||
+    commsContactLeadUserIds.length > 0 ||
+    eventPlannerLeadIds.length > 0;
   return (
     dateRange.startDate !== '' ||
     dateRange.endDate !== '' ||
@@ -67,7 +81,8 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     lookAheadActive ||
     dateConfirmedFilter !== 'any' ||
     timeConfirmedFilter !== 'any' ||
-    tagIds.length > 0
+    tagIds.length > 0 ||
+    leadsActive
   );
 }
 
@@ -86,6 +101,10 @@ export function ActivityTableFilters({
   pitchRequiredStatusOptions,
   statusOptions,
   tagOptions,
+  ministryOptions,
+  organizationOptions,
+  commsContactOptions,
+  eventPlannerOptions,
 }: ActivityTableFiltersProps) {
   const anyActive = useMemo(
     () => hasAnyFilterActive(filterState),
@@ -141,6 +160,10 @@ export function ActivityTableFilters({
       dateConfirmedFilter: 'any',
       timeConfirmedFilter: 'any',
       tagIds: [],
+      leadMinistryIds: [],
+      leadOrgIds: [],
+      commsContactLeadUserIds: [],
+      eventPlannerLeadIds: [],
     });
   }, [onFilterStateChange]);
 
@@ -161,7 +184,7 @@ export function ActivityTableFilters({
     <div
       className="mb-4 flex flex-wrap items-center justify-between gap-4"
       role="search"
-      aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, and keyword"
+      aria-label="Filter activities by date, category, pitch, look ahead, confirmed, status, tags, leads, and keyword"
     >
       <div className="flex flex-wrap items-center gap-2">
         <ScheduledDateFilter
@@ -197,6 +220,14 @@ export function ActivityTableFilters({
           tagOptions={tagOptions}
           selectedTagIds={filterState.tagIds}
           onTagIdsChange={handleTagIdsChange}
+        />
+        <LeadsFilter
+          filterState={filterState}
+          onFilterStateChange={onFilterStateChange}
+          ministryOptions={ministryOptions}
+          organizationOptions={organizationOptions}
+          commsContactOptions={commsContactOptions}
+          eventPlannerOptions={eventPlannerOptions}
         />
         {anyActive && (
           <Button

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -143,6 +143,7 @@ export function ActivityTableFilters({
     [filterState, onFilterStateChange]
   );
 
+  /** Clears all filter state only. Search keyword is intentionally left unchanged so users can adjust filters without losing their search. If search is later moved to the left with filters, consider extending this to also call onSearchKeywordChange(''). */
   const handleClearAllFilters = useCallback(() => {
     onFilterStateChange({
       dateRange: {

--- a/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableFilters.tsx
@@ -10,8 +10,10 @@ import { Input } from '@/components/ui/input';
 import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
 
 import type { ActivityFilterState } from './activityFilterState';
+import { LookAheadFilter } from './LookAheadFilter';
 import { PitchFilter } from './PitchFilter';
 import { ScheduledDateFilter } from './ScheduledDateFilter';
+import { isDateRangeActive } from './ScheduledDateRangeFields';
 
 export interface ActivityTableFiltersProps {
   filterState: ActivityFilterState;
@@ -36,17 +38,18 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     activityStatusIds,
     pitchRequiredStatusNames,
     pitchDateFilter,
+    lookAheadStatusValues,
+    lookAheadSectionValues,
   } = filterState;
   const pitchDateRangeActive =
     pitchDateFilter.kind === 'scheduled' &&
-    (pitchDateFilter.dateRange.startDate !== '' ||
-      pitchDateFilter.dateRange.endDate !== '' ||
-      pitchDateFilter.dateRange.noStartDate ||
-      pitchDateFilter.dateRange.noEndDate);
+    isDateRangeActive(pitchDateFilter.dateRange);
   const pitchActive =
     pitchRequiredStatusNames.length > 0 ||
     pitchDateFilter.kind !== 'any' ||
     pitchDateRangeActive;
+  const lookAheadActive =
+    lookAheadStatusValues.length > 0 || lookAheadSectionValues.length > 0;
   return (
     dateRange.startDate !== '' ||
     dateRange.endDate !== '' ||
@@ -54,7 +57,8 @@ function hasAnyFilterActive(filterState: ActivityFilterState): boolean {
     dateRange.noEndDate ||
     categoryNames.length > 0 ||
     activityStatusIds.length > 0 ||
-    pitchActive
+    pitchActive ||
+    lookAheadActive
   );
 }
 
@@ -122,6 +126,8 @@ export function ActivityTableFilters({
       activityStatusIds: [],
       pitchRequiredStatusNames: [],
       pitchDateFilter: { kind: 'any' },
+      lookAheadStatusValues: [],
+      lookAheadSectionValues: [],
     });
   }, [onFilterStateChange]);
 
@@ -132,7 +138,7 @@ export function ActivityTableFilters({
     <div
       className="mb-4 flex flex-wrap items-center justify-between gap-4"
       role="search"
-      aria-label="Filter activities by date, category, pitch, status, and keyword"
+      aria-label="Filter activities by date, category, pitch, look ahead, status, and keyword"
     >
       <div className="flex flex-wrap items-center gap-2">
         <ScheduledDateFilter
@@ -149,6 +155,10 @@ export function ActivityTableFilters({
           filterState={filterState}
           onFilterStateChange={onFilterStateChange}
           pitchRequiredStatusOptions={pitchRequiredStatusOptions}
+        />
+        <LookAheadFilter
+          filterState={filterState}
+          onFilterStateChange={onFilterStateChange}
         />
         <FilterCheckboxDropdown
           label="Status"

--- a/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
@@ -1,3 +1,4 @@
+import { Search } from 'lucide-react';
 import type { ReactNode, RefObject } from 'react';
 
 import {
@@ -9,6 +10,7 @@ import {
   TableSummaryBar,
   type BooleanFilter,
 } from '@/components/Table/TableSummaryBar';
+import { Input } from '@/components/ui/input';
 
 export interface ActivityTableLayoutProps {
   /** Ref forwarded to the scroll container for scroll-to-top on pagination. */
@@ -25,6 +27,9 @@ export interface ActivityTableLayoutProps {
   singularLabel: string;
   pluralLabel: string;
   filters?: BooleanFilter[];
+  /** Optional keyword search (persisted with other preferences). */
+  searchKeyword?: string;
+  onSearchKeywordChange?: (value: string) => void;
   /** Content inside the scroll area (table, loading spinner, or empty state). */
   children: ReactNode;
 }
@@ -46,11 +51,29 @@ export function ActivityTableLayout({
   singularLabel,
   pluralLabel,
   filters = [],
+  searchKeyword,
+  onSearchKeywordChange,
   children,
 }: ActivityTableLayoutProps) {
+  const showSearch =
+    searchKeyword !== undefined && onSearchKeywordChange !== undefined;
+
   return (
     <div className="min-w-0 space-y-4">
       <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
+        {showSearch && (
+          <div className="relative mr-auto max-w-md min-w-[240px] flex-1">
+            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              placeholder="Search activities..."
+              value={searchKeyword}
+              onChange={(e) => onSearchKeywordChange(e.target.value)}
+              className="pl-8"
+              aria-label="Search activities"
+            />
+          </div>
+        )}
         <SortDropdown
           hideDirectionLabel
           columns={sortColumns}

--- a/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
+++ b/calendar-ui/src/components/ActivityTable/ActivityTableLayout.tsx
@@ -1,90 +1,37 @@
-import { Search } from 'lucide-react';
 import type { ReactNode, RefObject } from 'react';
 
-import {
-  SortDropdown,
-  type SortColumnConfig,
-} from '@/components/Table/SortDropdown';
 import { TableScrollContainer } from '@/components/Table/TableScrollContainer';
 import {
   TableSummaryBar,
   type BooleanFilter,
 } from '@/components/Table/TableSummaryBar';
-import { Input } from '@/components/ui/input';
 
 export interface ActivityTableLayoutProps {
   /** Ref forwarded to the scroll container for scroll-to-top on pagination. */
   scrollRef: RefObject<HTMLDivElement | null>;
-  /** Sort dropdown config and state. */
-  sortColumns: SortColumnConfig[];
-  sortKey: string | null;
-  sortDirection: 'asc' | 'desc';
-  onSortChange: (key: string | null, direction: 'asc' | 'desc') => void;
-  defaultSortKey: string;
-  defaultSortDirection: 'asc' | 'desc';
   /** Summary bar. */
   count: number;
   singularLabel: string;
   pluralLabel: string;
   filters?: BooleanFilter[];
-  /** Optional keyword search (persisted with other preferences). */
-  searchKeyword?: string;
-  onSearchKeywordChange?: (value: string) => void;
   /** Content inside the scroll area (table, loading spinner, or empty state). */
   children: ReactNode;
 }
 
 /**
- * Shared layout shell for ActivityTable: toolbar (sort dropdown + summary bar with filters)
- * and scroll container. Used for loading, empty, and success states so the toolbar and
- * container structure are defined in one place.
+ * Shared layout shell for ActivityTable: summary bar and scroll container.
+ * Search and sort live in ActivityTableFilters above this layout.
  */
 export function ActivityTableLayout({
   scrollRef,
-  sortColumns,
-  sortKey,
-  sortDirection,
-  onSortChange,
-  defaultSortKey,
-  defaultSortDirection,
   count,
   singularLabel,
   pluralLabel,
   filters = [],
-  searchKeyword,
-  onSearchKeywordChange,
   children,
 }: ActivityTableLayoutProps) {
-  const showSearch =
-    searchKeyword !== undefined && onSearchKeywordChange !== undefined;
-
   return (
     <div className="min-w-0 space-y-4">
-      <div className="mb-4 flex flex-wrap items-center justify-end gap-4">
-        {showSearch && (
-          <div className="relative mr-auto max-w-md min-w-[240px] flex-1">
-            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
-            <Input
-              type="search"
-              placeholder="Search activities..."
-              value={searchKeyword}
-              onChange={(e) => onSearchKeywordChange(e.target.value)}
-              className="pl-8"
-              aria-label="Search activities"
-            />
-          </div>
-        )}
-        <SortDropdown
-          hideDirectionLabel
-          columns={sortColumns}
-          sortKey={sortKey}
-          sortDirection={sortDirection}
-          onSortChange={onSortChange}
-          defaultSortKey={defaultSortKey}
-          defaultSortDirection={defaultSortDirection}
-          ariaLabel="Sort by"
-        />
-      </div>
       <TableSummaryBar
         count={count}
         singularLabel={singularLabel}

--- a/calendar-ui/src/components/ActivityTable/ConfirmedFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/ConfirmedFilter.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+import {
+  CONFIRMED_STATUS_LABEL,
+  UNCONFIRMED_STATUS_LABEL,
+} from '@/lib/datetime-utils';
+
+import type { ActivityFilterState } from './activityFilterState';
+import { FilterSectionLabel } from './FilterSectionLabel';
+
+export interface ConfirmedFilterProps {
+  filterState: ActivityFilterState;
+  onFilterStateChange: (state: ActivityFilterState) => void;
+}
+
+type ConfirmedFilterValue = ActivityFilterState['dateConfirmedFilter'];
+
+function isConfirmedFilterActive(
+  dateConfirmedFilter: ConfirmedFilterValue,
+  timeConfirmedFilter: ConfirmedFilterValue
+): boolean {
+  return dateConfirmedFilter !== 'any' || timeConfirmedFilter !== 'any';
+}
+
+export function ConfirmedFilter({
+  filterState,
+  onFilterStateChange,
+}: ConfirmedFilterProps) {
+  const { dateConfirmedFilter, timeConfirmedFilter } = filterState;
+
+  const active = useMemo(
+    () => isConfirmedFilterActive(dateConfirmedFilter, timeConfirmedFilter),
+    [dateConfirmedFilter, timeConfirmedFilter]
+  );
+
+  const handleClearTrigger = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      dateConfirmedFilter: 'any',
+      timeConfirmedFilter: 'any',
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleDateSelect = useCallback(
+    (value: 'confirmed' | 'not_confirmed') => {
+      const next: ConfirmedFilterValue =
+        dateConfirmedFilter === value ? 'any' : value;
+      onFilterStateChange({
+        ...filterState,
+        dateConfirmedFilter: next,
+      });
+    },
+    [filterState, onFilterStateChange, dateConfirmedFilter]
+  );
+
+  const handleTimeSelect = useCallback(
+    (value: 'confirmed' | 'not_confirmed') => {
+      const next: ConfirmedFilterValue =
+        timeConfirmedFilter === value ? 'any' : value;
+      onFilterStateChange({
+        ...filterState,
+        timeConfirmedFilter: next,
+      });
+    },
+    [filterState, onFilterStateChange, timeConfirmedFilter]
+  );
+
+  const handleClearDate = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      dateConfirmedFilter: 'any',
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleClearTime = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      timeConfirmedFilter: 'any',
+    });
+  }, [filterState, onFilterStateChange]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <FilterTrigger
+          label="Confirmed"
+          active={active}
+          count={1}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Confirmed filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[200px]">
+        <FilterSectionLabel
+          onClearAll={
+            dateConfirmedFilter !== 'any' ? handleClearDate : undefined
+          }
+        >
+          Date
+        </FilterSectionLabel>
+        <DropdownMenuCheckboxItem
+          checked={dateConfirmedFilter === 'confirmed'}
+          onCheckedChange={() => handleDateSelect('confirmed')}
+          onSelect={(e) => e.preventDefault()}
+        >
+          {CONFIRMED_STATUS_LABEL}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={dateConfirmedFilter === 'not_confirmed'}
+          onCheckedChange={() => handleDateSelect('not_confirmed')}
+          onSelect={(e) => e.preventDefault()}
+        >
+          {UNCONFIRMED_STATUS_LABEL}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <FilterSectionLabel
+          onClearAll={
+            timeConfirmedFilter !== 'any' ? handleClearTime : undefined
+          }
+        >
+          Time
+        </FilterSectionLabel>
+        <DropdownMenuCheckboxItem
+          checked={timeConfirmedFilter === 'confirmed'}
+          onCheckedChange={() => handleTimeSelect('confirmed')}
+          onSelect={(e) => e.preventDefault()}
+        >
+          {CONFIRMED_STATUS_LABEL}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={timeConfirmedFilter === 'not_confirmed'}
+          onCheckedChange={() => handleTimeSelect('not_confirmed')}
+          onSelect={(e) => e.preventDefault()}
+        >
+          {UNCONFIRMED_STATUS_LABEL}
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/ConfirmedFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/ConfirmedFilter.tsx
@@ -41,6 +41,10 @@ export function ConfirmedFilter({
     [dateConfirmedFilter, timeConfirmedFilter]
   );
 
+  const confirmedCount =
+    (dateConfirmedFilter !== 'any' ? 1 : 0) +
+    (timeConfirmedFilter !== 'any' ? 1 : 0);
+
   const handleClearTrigger = useCallback(() => {
     onFilterStateChange({
       ...filterState,
@@ -93,7 +97,7 @@ export function ConfirmedFilter({
         <FilterTrigger
           label="Confirmed"
           active={active}
-          count={1}
+          count={confirmedCount}
           onClear={handleClearTrigger}
           clearAriaLabel="Clear Confirmed filter"
         />

--- a/calendar-ui/src/components/ActivityTable/FilterSearchableList.tsx
+++ b/calendar-ui/src/components/ActivityTable/FilterSearchableList.tsx
@@ -1,0 +1,126 @@
+import { Check, Search, X } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Input } from '@/components/ui/input';
+
+export interface FilterSearchableListOption {
+  value: string;
+  label: string;
+}
+
+export interface FilterSearchableListProps {
+  options: FilterSearchableListOption[];
+  selectedIds: number[];
+  onToggle: (id: number) => void;
+  searchPlaceholder?: string;
+  searchAriaLabel?: string;
+  emptyMessage?: string;
+  showClearButton?: boolean;
+  onClear?: () => void;
+  maxHeight?: string;
+  /** When provided with onSearchChange, search is controlled (parent can reset on close). */
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+}
+
+/**
+ * Shared presentational component: search input, scrollable multi-select list
+ * with checkmarks, optional empty state message, and optional "Clear filters" footer.
+ * Used by TagsFilter and LeadsFilter (LeadSubList).
+ */
+export function FilterSearchableList({
+  options,
+  selectedIds,
+  onToggle,
+  searchPlaceholder = 'Search...',
+  searchAriaLabel = 'Search',
+  emptyMessage = 'No results',
+  showClearButton = false,
+  onClear,
+  maxHeight = '250px',
+  searchValue: controlledSearchValue,
+  onSearchChange: controlledOnSearchChange,
+}: FilterSearchableListProps) {
+  const [internalSearch, setInternalSearch] = useState('');
+  const isControlled =
+    controlledSearchValue !== undefined &&
+    controlledOnSearchChange !== undefined;
+  const searchTerm = isControlled ? controlledSearchValue : internalSearch;
+  const setSearchTerm = isControlled
+    ? controlledOnSearchChange
+    : setInternalSearch;
+
+  const filteredOptions = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (term === '') return options;
+    return options.filter((opt) => opt.label.toLowerCase().includes(term));
+  }, [options, searchTerm]);
+
+  const handleToggle = useCallback(
+    (value: string) => {
+      const id = parseInt(value, 10);
+      if (!Number.isFinite(id)) return;
+      onToggle(id);
+    },
+    [onToggle]
+  );
+
+  const hasSelection = selectedIds.length > 0;
+
+  return (
+    <>
+      <div className="border-b p-2">
+        <div className="relative">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
+          <Input
+            type="text"
+            className="h-8 pr-3 pl-8 text-sm"
+            placeholder={searchPlaceholder}
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            aria-label={searchAriaLabel}
+          />
+        </div>
+      </div>
+      <div className="overflow-y-auto py-1" style={{ maxHeight }}>
+        {filteredOptions.length === 0 ? (
+          <div className="text-muted-foreground px-3 py-2 text-center text-sm">
+            {emptyMessage}
+          </div>
+        ) : (
+          filteredOptions.map((opt) => {
+            const id = parseInt(opt.value, 10);
+            const checked = Number.isFinite(id) && selectedIds.includes(id);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                className="focus:bg-accent focus:text-accent-foreground hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-left text-sm outline-none select-none"
+                onClick={() => Number.isFinite(id) && handleToggle(opt.value)}
+              >
+                <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+                  {checked ? <Check className="size-4" /> : null}
+                </span>
+                <span className="truncate">{opt.label}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+      {showClearButton && hasSelection && onClear && (
+        <>
+          <div className="border-t" />
+          <button
+            type="button"
+            className="hover:bg-accent text-muted-foreground flex w-full items-center gap-2 px-3 py-2 text-sm"
+            onClick={onClear}
+          >
+            <X className="h-3.5 w-3.5" />
+            Clear filters
+          </button>
+        </>
+      )}
+    </>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/FilterSearchableList.tsx
+++ b/calendar-ui/src/components/ActivityTable/FilterSearchableList.tsx
@@ -117,7 +117,7 @@ export function FilterSearchableList({
             onClick={onClear}
           >
             <X className="h-3.5 w-3.5" />
-            Clear filters
+            Clear all
           </button>
         </>
       )}

--- a/calendar-ui/src/components/ActivityTable/FilterSectionLabel.tsx
+++ b/calendar-ui/src/components/ActivityTable/FilterSectionLabel.tsx
@@ -1,0 +1,54 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { DropdownMenuLabel } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+/**
+ * Shared section heading for filter dropdowns (e.g. Pitch, Look Ahead).
+ * Use for "Pitch status", "Look Ahead section", etc. to keep styling consistent.
+ * Optionally show a "Clear all" button that calls onClearAll when provided.
+ */
+const FILTER_SECTION_LABEL_CLASS = 'text-foreground text-xs font-normal';
+
+export interface FilterSectionLabelProps extends ComponentPropsWithoutRef<
+  typeof DropdownMenuLabel
+> {
+  /** When provided, shows a "Clear all" button that calls this when clicked (clears filters in this section). */
+  onClearAll?: () => void;
+}
+
+export function FilterSectionLabel({
+  className,
+  onClearAll,
+  children,
+  ...props
+}: FilterSectionLabelProps) {
+  const handleClearClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onClearAll?.();
+  };
+
+  return (
+    <DropdownMenuLabel
+      className={cn(FILTER_SECTION_LABEL_CLASS, className)}
+      {...props}
+    >
+      {onClearAll ? (
+        <div className="flex w-full items-center justify-between gap-2">
+          <span>{children}</span>
+          <button
+            type="button"
+            onClick={handleClearClick}
+            className="text-primary shrink-0 text-xs font-normal hover:underline"
+            aria-label="Clear all filters in this section"
+          >
+            Clear all
+          </button>
+        </div>
+      ) : (
+        children
+      )}
+    </DropdownMenuLabel>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/FilterSectionLabel.tsx
+++ b/calendar-ui/src/components/ActivityTable/FilterSectionLabel.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, MouseEvent } from 'react';
 
 import { DropdownMenuLabel } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
@@ -23,7 +23,7 @@ export function FilterSectionLabel({
   children,
   ...props
 }: FilterSectionLabelProps) {
-  const handleClearClick = (e: React.MouseEvent) => {
+  const handleClearClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     onClearAll?.();

--- a/calendar-ui/src/components/ActivityTable/LeadsFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/LeadsFilter.tsx
@@ -1,4 +1,3 @@
-import { Check, Search } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -9,10 +8,10 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
 import { FilterTrigger } from '@/components/users/FilterTrigger';
 
 import type { ActivityFilterState } from './activityFilterState';
+import { FilterSearchableList } from './FilterSearchableList';
 
 export interface LeadFilterOption {
   value: string;
@@ -28,85 +27,12 @@ export interface LeadsFilterProps {
   eventPlannerOptions: LeadFilterOption[];
 }
 
-function filterOptionsBySearch(
-  options: LeadFilterOption[],
-  search: string
-): LeadFilterOption[] {
-  const term = search.trim().toLowerCase();
-  if (term === '') return options;
-  return options.filter((opt) => opt.label.toLowerCase().includes(term));
-}
-
 function isLeadsFilterActive(filterState: ActivityFilterState): boolean {
   return (
     filterState.leadMinistryIds.length > 0 ||
     filterState.leadOrgIds.length > 0 ||
     filterState.commsContactLeadUserIds.length > 0 ||
     filterState.eventPlannerLeadIds.length > 0
-  );
-}
-
-/** Same list-item pattern as TagsFilter: button with Check icon when checked, pl-8 for icon space. */
-function LeadSubList({
-  options,
-  selectedIds,
-  onToggle,
-  searchValue,
-  onSearchChange,
-  searchAriaLabel,
-}: {
-  options: LeadFilterOption[];
-  selectedIds: number[];
-  onToggle: (id: number) => void;
-  searchValue: string;
-  onSearchChange: (value: string) => void;
-  searchAriaLabel: string;
-}) {
-  const filtered = useMemo(
-    () => filterOptionsBySearch(options, searchValue),
-    [options, searchValue]
-  );
-  return (
-    <>
-      <div className="border-b p-2">
-        <div className="relative">
-          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
-          <Input
-            type="text"
-            className="h-8 pr-3 pl-8 text-sm"
-            value={searchValue}
-            onChange={(e) => onSearchChange(e.target.value)}
-            onKeyDown={(e) => e.stopPropagation()}
-            aria-label={searchAriaLabel}
-          />
-        </div>
-      </div>
-      <div className="max-h-[250px] overflow-y-auto py-1">
-        {filtered.length === 0 ? (
-          <div className="text-muted-foreground px-3 py-2 text-center text-sm">
-            No results
-          </div>
-        ) : (
-          filtered.map((opt) => {
-            const id = parseInt(opt.value, 10);
-            const checked = Number.isFinite(id) && selectedIds.includes(id);
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                className="focus:bg-accent focus:text-accent-foreground hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-left text-sm outline-none select-none"
-                onClick={() => Number.isFinite(id) && onToggle(id)}
-              >
-                <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-                  {checked ? <Check className="size-4" /> : null}
-                </span>
-                <span className="truncate">{opt.label}</span>
-              </button>
-            );
-          })
-        )}
-      </div>
-    </>
   );
 }
 
@@ -119,10 +45,6 @@ export function LeadsFilter({
   eventPlannerOptions,
 }: LeadsFilterProps) {
   const [open, setOpen] = useState(false);
-  const [ministrySearch, setMinistrySearch] = useState('');
-  const [organizationSearch, setOrganizationSearch] = useState('');
-  const [commsSearch, setCommsSearch] = useState('');
-  const [eventPlannerSearch, setEventPlannerSearch] = useState('');
 
   const active = useMemo(
     () => isLeadsFilterActive(filterState),
@@ -192,24 +114,26 @@ export function LeadsFilter({
     [filterState, onFilterStateChange]
   );
 
+  const handleClearMinistry = useCallback(() => {
+    onFilterStateChange({ ...filterState, leadMinistryIds: [] });
+  }, [filterState, onFilterStateChange]);
+  const handleClearOrg = useCallback(() => {
+    onFilterStateChange({ ...filterState, leadOrgIds: [] });
+  }, [filterState, onFilterStateChange]);
+  const handleClearComms = useCallback(() => {
+    onFilterStateChange({ ...filterState, commsContactLeadUserIds: [] });
+  }, [filterState, onFilterStateChange]);
+  const handleClearEventPlanner = useCallback(() => {
+    onFilterStateChange({ ...filterState, eventPlannerLeadIds: [] });
+  }, [filterState, onFilterStateChange]);
+
   const ministryCount = filterState.leadMinistryIds.length;
   const orgCount = filterState.leadOrgIds.length;
   const commsCount = filterState.commsContactLeadUserIds.length;
   const eventPlannerCount = filterState.eventPlannerLeadIds.length;
 
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={(v) => {
-        setOpen(v);
-        if (!v) {
-          setMinistrySearch('');
-          setOrganizationSearch('');
-          setCommsSearch('');
-          setEventPlannerSearch('');
-        }
-      }}
-    >
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <FilterTrigger
           label="Leads"
@@ -222,7 +146,6 @@ export function LeadsFilter({
       <DropdownMenuContent
         className="min-w-48"
         align="start"
-        onOpenAutoFocus={(e) => e.preventDefault()}
         aria-label="Filter by leads (ministry, organization, comms contact, event planner)"
       >
         <DropdownMenuSub>
@@ -230,13 +153,15 @@ export function LeadsFilter({
             {ministryCount > 0 ? `Ministry (${ministryCount})` : 'Ministry'}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-64 p-0">
-            <LeadSubList
+            <FilterSearchableList
               options={ministryOptions}
               selectedIds={filterState.leadMinistryIds}
               onToggle={handleMinistryToggle}
-              searchValue={ministrySearch}
-              onSearchChange={setMinistrySearch}
+              searchPlaceholder="Search ministries..."
               searchAriaLabel="Search ministries"
+              emptyMessage="No results"
+              showClearButton
+              onClear={handleClearMinistry}
             />
           </DropdownMenuSubContent>
         </DropdownMenuSub>
@@ -245,13 +170,15 @@ export function LeadsFilter({
             {orgCount > 0 ? `Organization (${orgCount})` : 'Organization'}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-64 p-0">
-            <LeadSubList
+            <FilterSearchableList
               options={organizationOptions}
               selectedIds={filterState.leadOrgIds}
               onToggle={handleOrgToggle}
-              searchValue={organizationSearch}
-              onSearchChange={setOrganizationSearch}
+              searchPlaceholder="Search organizations..."
               searchAriaLabel="Search organizations"
+              emptyMessage="No results"
+              showClearButton
+              onClear={handleClearOrg}
             />
           </DropdownMenuSubContent>
         </DropdownMenuSub>
@@ -260,13 +187,15 @@ export function LeadsFilter({
             {commsCount > 0 ? `Comms contact (${commsCount})` : 'Comms contact'}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-64 p-0">
-            <LeadSubList
+            <FilterSearchableList
               options={commsContactOptions}
               selectedIds={filterState.commsContactLeadUserIds}
               onToggle={handleCommsToggle}
-              searchValue={commsSearch}
-              onSearchChange={setCommsSearch}
+              searchPlaceholder="Search comms contacts..."
               searchAriaLabel="Search comms contacts"
+              emptyMessage="No results"
+              showClearButton
+              onClear={handleClearComms}
             />
           </DropdownMenuSubContent>
         </DropdownMenuSub>
@@ -277,13 +206,15 @@ export function LeadsFilter({
               : 'Event planner'}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-64 p-0">
-            <LeadSubList
+            <FilterSearchableList
               options={eventPlannerOptions}
               selectedIds={filterState.eventPlannerLeadIds}
               onToggle={handleEventPlannerToggle}
-              searchValue={eventPlannerSearch}
-              onSearchChange={setEventPlannerSearch}
+              searchPlaceholder="Search event planners..."
               searchAriaLabel="Search event planners"
+              emptyMessage="No results"
+              showClearButton
+              onClear={handleClearEventPlanner}
             />
           </DropdownMenuSubContent>
         </DropdownMenuSub>

--- a/calendar-ui/src/components/ActivityTable/LeadsFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/LeadsFilter.tsx
@@ -1,0 +1,293 @@
+import { Check, Search } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+import type { ActivityFilterState } from './activityFilterState';
+
+export interface LeadFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface LeadsFilterProps {
+  filterState: ActivityFilterState;
+  onFilterStateChange: (state: ActivityFilterState) => void;
+  ministryOptions: LeadFilterOption[];
+  organizationOptions: LeadFilterOption[];
+  commsContactOptions: LeadFilterOption[];
+  eventPlannerOptions: LeadFilterOption[];
+}
+
+function filterOptionsBySearch(
+  options: LeadFilterOption[],
+  search: string
+): LeadFilterOption[] {
+  const term = search.trim().toLowerCase();
+  if (term === '') return options;
+  return options.filter((opt) => opt.label.toLowerCase().includes(term));
+}
+
+function isLeadsFilterActive(filterState: ActivityFilterState): boolean {
+  return (
+    filterState.leadMinistryIds.length > 0 ||
+    filterState.leadOrgIds.length > 0 ||
+    filterState.commsContactLeadUserIds.length > 0 ||
+    filterState.eventPlannerLeadIds.length > 0
+  );
+}
+
+/** Same list-item pattern as TagsFilter: button with Check icon when checked, pl-8 for icon space. */
+function LeadSubList({
+  options,
+  selectedIds,
+  onToggle,
+  searchValue,
+  onSearchChange,
+  searchAriaLabel,
+}: {
+  options: LeadFilterOption[];
+  selectedIds: number[];
+  onToggle: (id: number) => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchAriaLabel: string;
+}) {
+  const filtered = useMemo(
+    () => filterOptionsBySearch(options, searchValue),
+    [options, searchValue]
+  );
+  return (
+    <>
+      <div className="border-b p-2">
+        <div className="relative">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
+          <Input
+            type="text"
+            className="h-8 pr-3 pl-8 text-sm"
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            aria-label={searchAriaLabel}
+          />
+        </div>
+      </div>
+      <div className="max-h-[250px] overflow-y-auto py-1">
+        {filtered.length === 0 ? (
+          <div className="text-muted-foreground px-3 py-2 text-center text-sm">
+            No results
+          </div>
+        ) : (
+          filtered.map((opt) => {
+            const id = parseInt(opt.value, 10);
+            const checked = Number.isFinite(id) && selectedIds.includes(id);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                className="focus:bg-accent focus:text-accent-foreground hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-left text-sm outline-none select-none"
+                onClick={() => Number.isFinite(id) && onToggle(id)}
+              >
+                <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+                  {checked ? <Check className="size-4" /> : null}
+                </span>
+                <span className="truncate">{opt.label}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </>
+  );
+}
+
+export function LeadsFilter({
+  filterState,
+  onFilterStateChange,
+  ministryOptions,
+  organizationOptions,
+  commsContactOptions,
+  eventPlannerOptions,
+}: LeadsFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [ministrySearch, setMinistrySearch] = useState('');
+  const [organizationSearch, setOrganizationSearch] = useState('');
+  const [commsSearch, setCommsSearch] = useState('');
+  const [eventPlannerSearch, setEventPlannerSearch] = useState('');
+
+  const active = useMemo(
+    () => isLeadsFilterActive(filterState),
+    [
+      filterState.leadMinistryIds.length,
+      filterState.leadOrgIds.length,
+      filterState.commsContactLeadUserIds.length,
+      filterState.eventPlannerLeadIds.length,
+    ]
+  );
+  const totalCount =
+    filterState.leadMinistryIds.length +
+    filterState.leadOrgIds.length +
+    filterState.commsContactLeadUserIds.length +
+    filterState.eventPlannerLeadIds.length;
+
+  const handleClearTrigger = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      leadMinistryIds: [],
+      leadOrgIds: [],
+      commsContactLeadUserIds: [],
+      eventPlannerLeadIds: [],
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleMinistryToggle = useCallback(
+    (id: number) => {
+      const next = filterState.leadMinistryIds.includes(id)
+        ? filterState.leadMinistryIds.filter((x) => x !== id)
+        : [...filterState.leadMinistryIds, id];
+      onFilterStateChange({ ...filterState, leadMinistryIds: next });
+    },
+    [filterState, onFilterStateChange]
+  );
+  const handleOrgToggle = useCallback(
+    (id: number) => {
+      const next = filterState.leadOrgIds.includes(id)
+        ? filterState.leadOrgIds.filter((x) => x !== id)
+        : [...filterState.leadOrgIds, id];
+      onFilterStateChange({ ...filterState, leadOrgIds: next });
+    },
+    [filterState, onFilterStateChange]
+  );
+  const handleCommsToggle = useCallback(
+    (id: number) => {
+      const next = filterState.commsContactLeadUserIds.includes(id)
+        ? filterState.commsContactLeadUserIds.filter((x) => x !== id)
+        : [...filterState.commsContactLeadUserIds, id];
+      onFilterStateChange({
+        ...filterState,
+        commsContactLeadUserIds: next,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+  const handleEventPlannerToggle = useCallback(
+    (id: number) => {
+      const next = filterState.eventPlannerLeadIds.includes(id)
+        ? filterState.eventPlannerLeadIds.filter((x) => x !== id)
+        : [...filterState.eventPlannerLeadIds, id];
+      onFilterStateChange({
+        ...filterState,
+        eventPlannerLeadIds: next,
+      });
+    },
+    [filterState, onFilterStateChange]
+  );
+
+  const ministryCount = filterState.leadMinistryIds.length;
+  const orgCount = filterState.leadOrgIds.length;
+  const commsCount = filterState.commsContactLeadUserIds.length;
+  const eventPlannerCount = filterState.eventPlannerLeadIds.length;
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) {
+          setMinistrySearch('');
+          setOrganizationSearch('');
+          setCommsSearch('');
+          setEventPlannerSearch('');
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <FilterTrigger
+          label="Leads"
+          active={active}
+          count={totalCount}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Leads filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="min-w-48"
+        align="start"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        aria-label="Filter by leads (ministry, organization, comms contact, event planner)"
+      >
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {ministryCount > 0 ? `Ministry (${ministryCount})` : 'Ministry'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-0">
+            <LeadSubList
+              options={ministryOptions}
+              selectedIds={filterState.leadMinistryIds}
+              onToggle={handleMinistryToggle}
+              searchValue={ministrySearch}
+              onSearchChange={setMinistrySearch}
+              searchAriaLabel="Search ministries"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {orgCount > 0 ? `Organization (${orgCount})` : 'Organization'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-0">
+            <LeadSubList
+              options={organizationOptions}
+              selectedIds={filterState.leadOrgIds}
+              onToggle={handleOrgToggle}
+              searchValue={organizationSearch}
+              onSearchChange={setOrganizationSearch}
+              searchAriaLabel="Search organizations"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {commsCount > 0 ? `Comms contact (${commsCount})` : 'Comms contact'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-0">
+            <LeadSubList
+              options={commsContactOptions}
+              selectedIds={filterState.commsContactLeadUserIds}
+              onToggle={handleCommsToggle}
+              searchValue={commsSearch}
+              onSearchChange={setCommsSearch}
+              searchAriaLabel="Search comms contacts"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {eventPlannerCount > 0
+              ? `Event planner (${eventPlannerCount})`
+              : 'Event planner'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-0">
+            <LeadSubList
+              options={eventPlannerOptions}
+              selectedIds={filterState.eventPlannerLeadIds}
+              onToggle={handleEventPlannerToggle}
+              searchValue={eventPlannerSearch}
+              onSearchChange={setEventPlannerSearch}
+              searchAriaLabel="Search event planners"
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/LookAheadFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/LookAheadFilter.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+import {
+  lookAheadSectionOptions,
+  lookAheadStatusOptions,
+} from '@/constants/form-options';
+
+import type { ActivityFilterState } from './activityFilterState';
+import { FilterSectionLabel } from './FilterSectionLabel';
+
+export interface LookAheadFilterProps {
+  filterState: ActivityFilterState;
+  onFilterStateChange: (state: ActivityFilterState) => void;
+}
+
+function isLookAheadFilterActive(
+  lookAheadStatusValues: string[],
+  lookAheadSectionValues: string[]
+): boolean {
+  return lookAheadStatusValues.length > 0 || lookAheadSectionValues.length > 0;
+}
+
+export function LookAheadFilter({
+  filterState,
+  onFilterStateChange,
+}: LookAheadFilterProps) {
+  const { lookAheadStatusValues, lookAheadSectionValues } = filterState;
+
+  const active = useMemo(
+    () =>
+      isLookAheadFilterActive(lookAheadStatusValues, lookAheadSectionValues),
+    [lookAheadStatusValues, lookAheadSectionValues]
+  );
+
+  const handleClearTrigger = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      lookAheadStatusValues: [],
+      lookAheadSectionValues: [],
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleStatusToggle = useCallback(
+    (value: string) => {
+      const next = lookAheadStatusValues.includes(value)
+        ? lookAheadStatusValues.filter((v) => v !== value)
+        : [...lookAheadStatusValues, value];
+      onFilterStateChange({
+        ...filterState,
+        lookAheadStatusValues: next,
+      });
+    },
+    [filterState, onFilterStateChange, lookAheadStatusValues]
+  );
+
+  const handleSectionToggle = useCallback(
+    (value: string) => {
+      const next = lookAheadSectionValues.includes(value)
+        ? lookAheadSectionValues.filter((v) => v !== value)
+        : [...lookAheadSectionValues, value];
+      onFilterStateChange({
+        ...filterState,
+        lookAheadSectionValues: next,
+      });
+    },
+    [filterState, onFilterStateChange, lookAheadSectionValues]
+  );
+
+  const handleClearLookAheadStatus = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      lookAheadStatusValues: [],
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleClearLookAheadSection = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      lookAheadSectionValues: [],
+    });
+  }, [filterState, onFilterStateChange]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <FilterTrigger
+          label="Look Ahead"
+          active={active}
+          count={1}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Look Ahead filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="max-h-[min(70vh,400px)] min-w-[280px] overflow-y-auto"
+        align="start"
+      >
+        <FilterSectionLabel
+          onClearAll={
+            lookAheadStatusValues.length > 0
+              ? handleClearLookAheadStatus
+              : undefined
+          }
+        >
+          Look Ahead status
+        </FilterSectionLabel>
+        {lookAheadStatusOptions.map((opt) => (
+          <DropdownMenuCheckboxItem
+            key={opt.value}
+            checked={lookAheadStatusValues.includes(opt.value)}
+            onCheckedChange={() => handleStatusToggle(opt.value)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            <span className="truncate">{opt.label}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        <FilterSectionLabel
+          onClearAll={
+            lookAheadSectionValues.length > 0
+              ? handleClearLookAheadSection
+              : undefined
+          }
+        >
+          Look Ahead section
+        </FilterSectionLabel>
+        {lookAheadSectionOptions.map((opt) => (
+          <DropdownMenuCheckboxItem
+            key={opt.value}
+            checked={lookAheadSectionValues.includes(opt.value)}
+            onCheckedChange={() => handleSectionToggle(opt.value)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            <span className="truncate">{opt.label}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/LookAheadFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/LookAheadFilter.tsx
@@ -40,6 +40,9 @@ export function LookAheadFilter({
     [lookAheadStatusValues, lookAheadSectionValues]
   );
 
+  const lookAheadCount =
+    lookAheadStatusValues.length + lookAheadSectionValues.length;
+
   const handleClearTrigger = useCallback(() => {
     onFilterStateChange({
       ...filterState,
@@ -94,7 +97,7 @@ export function LookAheadFilter({
         <FilterTrigger
           label="Look Ahead"
           active={active}
-          count={1}
+          count={lookAheadCount}
           onClear={handleClearTrigger}
           clearAriaLabel="Clear Look Ahead filter"
         />

--- a/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useMemo } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+import {
+  DEFAULT_PITCH_DATE_RANGE,
+  type ActivityFilterState,
+  type PitchDateFilter,
+} from './activityFilterState';
+import { ScheduledDateRangeFields } from './ScheduledDateRangeFields';
+
+export interface PitchFilterProps {
+  /** Full filter state; only pitch-related fields are read/updated. */
+  filterState: ActivityFilterState;
+  onFilterStateChange: (state: ActivityFilterState) => void;
+  pitchRequiredStatusOptions: { value: string; label: string }[];
+}
+
+function isPitchFilterActive(
+  pitchRequiredStatusNames: string[],
+  pitchDateFilter: PitchDateFilter
+): boolean {
+  if (pitchRequiredStatusNames.length > 0) return true;
+  if (pitchDateFilter.kind !== 'any') return true;
+  if (
+    pitchDateFilter.kind === 'scheduled' &&
+    (pitchDateFilter.dateRange.startDate !== '' ||
+      pitchDateFilter.dateRange.endDate !== '' ||
+      pitchDateFilter.dateRange.noStartDate ||
+      pitchDateFilter.dateRange.noEndDate)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+const PITCH_DATE_ANY = '';
+const PITCH_DATE_NOT_SCHEDULED = 'not_scheduled';
+const PITCH_DATE_SCHEDULED = 'scheduled';
+
+export function PitchFilter({
+  filterState,
+  onFilterStateChange,
+  pitchRequiredStatusOptions,
+}: PitchFilterProps) {
+  const { pitchRequiredStatusNames, pitchDateFilter } = filterState;
+
+  const active = useMemo(
+    () => isPitchFilterActive(pitchRequiredStatusNames, pitchDateFilter),
+    [pitchRequiredStatusNames, pitchDateFilter]
+  );
+
+  const pitchDateRadioValue =
+    pitchDateFilter.kind === 'any' ? PITCH_DATE_ANY : pitchDateFilter.kind;
+
+  const handleClearTrigger = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      pitchRequiredStatusNames: [],
+      pitchDateFilter: { kind: 'any' },
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleSetPitchDateAny = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      pitchDateFilter: { kind: 'any' },
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handlePitchStatusToggle = useCallback(
+    (value: string) => {
+      const next = pitchRequiredStatusNames.includes(value)
+        ? pitchRequiredStatusNames.filter((v) => v !== value)
+        : [...pitchRequiredStatusNames, value];
+      onFilterStateChange({
+        ...filterState,
+        pitchRequiredStatusNames: next,
+      });
+    },
+    [filterState, onFilterStateChange, pitchRequiredStatusNames]
+  );
+
+  const handlePitchDateRadioChange = useCallback(
+    (value: string) => {
+      const currentKind = pitchDateFilter.kind;
+
+      if (value === currentKind) {
+        onFilterStateChange({
+          ...filterState,
+          pitchDateFilter: { kind: 'any' },
+        });
+        return;
+      }
+
+      if (value === PITCH_DATE_NOT_SCHEDULED) {
+        onFilterStateChange({
+          ...filterState,
+          pitchDateFilter: { kind: 'not_scheduled' },
+        });
+        return;
+      }
+
+      if (value === PITCH_DATE_SCHEDULED) {
+        onFilterStateChange({
+          ...filterState,
+          pitchDateFilter: {
+            kind: 'scheduled',
+            dateRange: { ...DEFAULT_PITCH_DATE_RANGE },
+          },
+        });
+        return;
+      }
+    },
+    [filterState, onFilterStateChange, pitchDateFilter.kind]
+  );
+
+  const handlePitchDateRangeChange = useCallback(
+    (dateRange: typeof DEFAULT_PITCH_DATE_RANGE) => {
+      if (pitchDateFilter.kind !== 'scheduled') return;
+      onFilterStateChange({
+        ...filterState,
+        pitchDateFilter: { kind: 'scheduled', dateRange },
+      });
+    },
+    [filterState, onFilterStateChange, pitchDateFilter.kind]
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <FilterTrigger
+          label="Pitch"
+          active={active}
+          count={1}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Pitch filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="max-h-[min(70vh,400px)] min-w-[280px] overflow-y-auto"
+        align="start"
+      >
+        <DropdownMenuLabel className="text-foreground font-normal">
+          Pitch status
+        </DropdownMenuLabel>
+        {pitchRequiredStatusOptions.length === 0 ? (
+          <p className="text-muted-foreground px-2 py-2 text-center text-sm">
+            No options
+          </p>
+        ) : (
+          pitchRequiredStatusOptions.map((opt) => (
+            <DropdownMenuCheckboxItem
+              key={opt.value}
+              checked={pitchRequiredStatusNames.includes(opt.value)}
+              onCheckedChange={() => handlePitchStatusToggle(opt.value)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              <span className="truncate">{opt.label}</span>
+            </DropdownMenuCheckboxItem>
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-foreground font-normal">
+          Pitch date
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={pitchDateRadioValue}
+          onValueChange={handlePitchDateRadioChange}
+        >
+          <DropdownMenuRadioItem
+            value={PITCH_DATE_NOT_SCHEDULED}
+            onSelect={(e) => {
+              if (pitchDateFilter.kind === 'not_scheduled') {
+                e.preventDefault();
+                handleSetPitchDateAny();
+              }
+            }}
+          >
+            Not scheduled for panel
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem
+            value={PITCH_DATE_SCHEDULED}
+            onSelect={(e) => {
+              if (pitchDateFilter.kind === 'scheduled') {
+                e.preventDefault();
+                handleSetPitchDateAny();
+              }
+            }}
+          >
+            Scheduled for panel
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+
+        {pitchDateFilter.kind === 'scheduled' && (
+          <div className="border-t px-2 pt-2 pb-2">
+            <ScheduledDateRangeFields
+              value={pitchDateFilter.dateRange}
+              onChange={handlePitchDateRangeChange}
+              endNoDateLabel="No end date (all upcoming pitches)"
+              clearButtonLabel="Clear dates"
+            />
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
@@ -4,9 +4,6 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
@@ -17,6 +14,7 @@ import {
   type ActivityFilterState,
   type PitchDateFilter,
 } from './activityFilterState';
+import { FilterSectionLabel } from './FilterSectionLabel';
 import { ScheduledDateRangeFields } from './ScheduledDateRangeFields';
 
 export interface PitchFilterProps {
@@ -32,21 +30,8 @@ function isPitchFilterActive(
 ): boolean {
   if (pitchRequiredStatusNames.length > 0) return true;
   if (pitchDateFilter.kind !== 'any') return true;
-  if (
-    pitchDateFilter.kind === 'scheduled' &&
-    (pitchDateFilter.dateRange.startDate !== '' ||
-      pitchDateFilter.dateRange.endDate !== '' ||
-      pitchDateFilter.dateRange.noStartDate ||
-      pitchDateFilter.dateRange.noEndDate)
-  ) {
-    return true;
-  }
   return false;
 }
-
-const PITCH_DATE_ANY = '';
-const PITCH_DATE_NOT_SCHEDULED = 'not_scheduled';
-const PITCH_DATE_SCHEDULED = 'scheduled';
 
 export function PitchFilter({
   filterState,
@@ -60,20 +45,10 @@ export function PitchFilter({
     [pitchRequiredStatusNames, pitchDateFilter]
   );
 
-  const pitchDateRadioValue =
-    pitchDateFilter.kind === 'any' ? PITCH_DATE_ANY : pitchDateFilter.kind;
-
   const handleClearTrigger = useCallback(() => {
     onFilterStateChange({
       ...filterState,
       pitchRequiredStatusNames: [],
-      pitchDateFilter: { kind: 'any' },
-    });
-  }, [filterState, onFilterStateChange]);
-
-  const handleSetPitchDateAny = useCallback(() => {
-    onFilterStateChange({
-      ...filterState,
       pitchDateFilter: { kind: 'any' },
     });
   }, [filterState, onFilterStateChange]);
@@ -91,38 +66,26 @@ export function PitchFilter({
     [filterState, onFilterStateChange, pitchRequiredStatusNames]
   );
 
-  const handlePitchDateRadioChange = useCallback(
-    (value: string) => {
-      const currentKind = pitchDateFilter.kind;
-
-      if (value === currentKind) {
-        onFilterStateChange({
-          ...filterState,
-          pitchDateFilter: { kind: 'any' },
-        });
-        return;
-      }
-
-      if (value === PITCH_DATE_NOT_SCHEDULED) {
-        onFilterStateChange({
-          ...filterState,
-          pitchDateFilter: { kind: 'not_scheduled' },
-        });
-        return;
-      }
-
-      if (value === PITCH_DATE_SCHEDULED) {
-        onFilterStateChange({
-          ...filterState,
-          pitchDateFilter: {
-            kind: 'scheduled',
-            dateRange: { ...DEFAULT_PITCH_DATE_RANGE },
-          },
-        });
-        return;
-      }
+  const handlePitchDateNotScheduledChange = useCallback(
+    (checked: boolean) => {
+      onFilterStateChange({
+        ...filterState,
+        pitchDateFilter: checked ? { kind: 'not_scheduled' } : { kind: 'any' },
+      });
     },
-    [filterState, onFilterStateChange, pitchDateFilter.kind]
+    [filterState, onFilterStateChange]
+  );
+
+  const handlePitchDateScheduledChange = useCallback(
+    (checked: boolean) => {
+      onFilterStateChange({
+        ...filterState,
+        pitchDateFilter: checked
+          ? { kind: 'scheduled', dateRange: { ...DEFAULT_PITCH_DATE_RANGE } }
+          : { kind: 'any' },
+      });
+    },
+    [filterState, onFilterStateChange]
   );
 
   const handlePitchDateRangeChange = useCallback(
@@ -135,6 +98,20 @@ export function PitchFilter({
     },
     [filterState, onFilterStateChange, pitchDateFilter.kind]
   );
+
+  const handleClearPitchStatus = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      pitchRequiredStatusNames: [],
+    });
+  }, [filterState, onFilterStateChange]);
+
+  const handleClearPitchDate = useCallback(() => {
+    onFilterStateChange({
+      ...filterState,
+      pitchDateFilter: { kind: 'any' },
+    });
+  }, [filterState, onFilterStateChange]);
 
   return (
     <DropdownMenu>
@@ -151,9 +128,15 @@ export function PitchFilter({
         className="max-h-[min(70vh,400px)] min-w-[280px] overflow-y-auto"
         align="start"
       >
-        <DropdownMenuLabel className="text-foreground font-normal">
+        <FilterSectionLabel
+          onClearAll={
+            pitchRequiredStatusNames.length > 0
+              ? handleClearPitchStatus
+              : undefined
+          }
+        >
           Pitch status
-        </DropdownMenuLabel>
+        </FilterSectionLabel>
         {pitchRequiredStatusOptions.length === 0 ? (
           <p className="text-muted-foreground px-2 py-2 text-center text-sm">
             No options
@@ -171,36 +154,29 @@ export function PitchFilter({
           ))
         )}
         <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-foreground font-normal">
-          Pitch date
-        </DropdownMenuLabel>
-        <DropdownMenuRadioGroup
-          value={pitchDateRadioValue}
-          onValueChange={handlePitchDateRadioChange}
+        <FilterSectionLabel
+          onClearAll={
+            pitchDateFilter.kind !== 'any' ? handleClearPitchDate : undefined
+          }
         >
-          <DropdownMenuRadioItem
-            value={PITCH_DATE_NOT_SCHEDULED}
-            onSelect={(e) => {
-              if (pitchDateFilter.kind === 'not_scheduled') {
-                e.preventDefault();
-                handleSetPitchDateAny();
-              }
-            }}
-          >
-            Not scheduled for panel
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem
-            value={PITCH_DATE_SCHEDULED}
-            onSelect={(e) => {
-              if (pitchDateFilter.kind === 'scheduled') {
-                e.preventDefault();
-                handleSetPitchDateAny();
-              }
-            }}
-          >
-            Scheduled for panel
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
+          Pitch date
+        </FilterSectionLabel>
+        <DropdownMenuCheckboxItem
+          checked={pitchDateFilter.kind === 'not_scheduled'}
+          onCheckedChange={handlePitchDateNotScheduledChange}
+          onSelect={(e) => e.preventDefault()}
+        >
+          Not scheduled for panel
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={pitchDateFilter.kind === 'scheduled'}
+          onCheckedChange={(checked) =>
+            handlePitchDateScheduledChange(checked === true)
+          }
+          onSelect={(e) => e.preventDefault()}
+        >
+          Scheduled for panel
+        </DropdownMenuCheckboxItem>
 
         {pitchDateFilter.kind === 'scheduled' && (
           <div className="border-t px-2 pt-2 pb-2">

--- a/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/PitchFilter.tsx
@@ -45,6 +45,13 @@ export function PitchFilter({
     [pitchRequiredStatusNames, pitchDateFilter]
   );
 
+  const pitchCount = useMemo(
+    () =>
+      pitchRequiredStatusNames.length +
+      (pitchDateFilter.kind !== 'any' ? 1 : 0),
+    [pitchRequiredStatusNames.length, pitchDateFilter.kind]
+  );
+
   const handleClearTrigger = useCallback(() => {
     onFilterStateChange({
       ...filterState,
@@ -119,7 +126,7 @@ export function PitchFilter({
         <FilterTrigger
           label="Pitch"
           active={active}
-          count={1}
+          count={pitchCount}
           onClear={handleClearTrigger}
           clearAriaLabel="Clear Pitch filter"
         />
@@ -139,7 +146,7 @@ export function PitchFilter({
         </FilterSectionLabel>
         {pitchRequiredStatusOptions.length === 0 ? (
           <p className="text-muted-foreground px-2 py-2 text-center text-sm">
-            No options
+            No results
           </p>
         ) : (
           pitchRequiredStatusOptions.map((opt) => (

--- a/calendar-ui/src/components/ActivityTable/ScheduledDateFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/ScheduledDateFilter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   Popover,
@@ -8,6 +8,7 @@ import {
 import { FilterTrigger } from '@/components/users/FilterTrigger';
 
 import {
+  isDateRangeActive,
   ScheduledDateRangeFields,
   type DateRangeValue,
 } from './ScheduledDateRangeFields';
@@ -19,22 +20,12 @@ interface ScheduledDateFilterProps {
   onChange: (value: DateRangeValue) => void;
 }
 
-function isDateRangeActive(dateRange: DateRangeValue): boolean {
-  return (
-    dateRange.startDate !== '' ||
-    dateRange.endDate !== '' ||
-    dateRange.noStartDate ||
-    dateRange.noEndDate
-  );
-}
-
 export function ScheduledDateFilter({
   value,
   onChange,
 }: ScheduledDateFilterProps) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<DateRangeValue>(() => value);
-  const commitOnCloseRef = useRef<DateRangeValue | null>(null);
 
   const active = isDateRangeActive(value);
 
@@ -55,22 +46,23 @@ export function ScheduledDateFilter({
   const handleMainOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (nextOpen) {
-        commitOnCloseRef.current = null;
         setDraft(value);
         setOpen(true);
       } else {
-        const toCommit = commitOnCloseRef.current ?? draft;
-        commitOnCloseRef.current = null;
-        onChange(toCommit);
+        onChange(draft);
         setOpen(false);
       }
     },
     [value, draft, onChange]
   );
 
-  const handleDraftChange = useCallback((next: DateRangeValue) => {
-    setDraft(next);
-  }, []);
+  const handleDraftChange = useCallback(
+    (next: DateRangeValue) => {
+      setDraft(next);
+      onChange(next);
+    },
+    [onChange]
+  );
 
   const handleAfterClear = useCallback(() => {
     const empty = {
@@ -79,10 +71,10 @@ export function ScheduledDateFilter({
       noStartDate: false,
       noEndDate: false,
     };
-    commitOnCloseRef.current = empty;
+    onChange(empty);
     setDraft(empty);
     setOpen(false);
-  }, []);
+  }, [onChange]);
 
   return (
     <Popover open={open} onOpenChange={handleMainOpenChange} modal>

--- a/calendar-ui/src/components/ActivityTable/ScheduledDateFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/ScheduledDateFilter.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+import {
+  ScheduledDateRangeFields,
+  type DateRangeValue,
+} from './ScheduledDateRangeFields';
+
+export type { DateRangeValue } from './ScheduledDateRangeFields';
+
+interface ScheduledDateFilterProps {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue) => void;
+}
+
+function isDateRangeActive(dateRange: DateRangeValue): boolean {
+  return (
+    dateRange.startDate !== '' ||
+    dateRange.endDate !== '' ||
+    dateRange.noStartDate ||
+    dateRange.noEndDate
+  );
+}
+
+export function ScheduledDateFilter({
+  value,
+  onChange,
+}: ScheduledDateFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<DateRangeValue>(() => value);
+  const commitOnCloseRef = useRef<DateRangeValue | null>(null);
+
+  const active = isDateRangeActive(value);
+
+  useEffect(() => {
+    if (!open) setDraft(value);
+  }, [open, value]);
+
+  const handleClearTrigger = useCallback(() => {
+    onChange({
+      startDate: '',
+      endDate: '',
+      noStartDate: false,
+      noEndDate: false,
+    });
+    setOpen(false);
+  }, [onChange]);
+
+  const handleMainOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        commitOnCloseRef.current = null;
+        setDraft(value);
+        setOpen(true);
+      } else {
+        const toCommit = commitOnCloseRef.current ?? draft;
+        commitOnCloseRef.current = null;
+        onChange(toCommit);
+        setOpen(false);
+      }
+    },
+    [value, draft, onChange]
+  );
+
+  const handleDraftChange = useCallback((next: DateRangeValue) => {
+    setDraft(next);
+  }, []);
+
+  const handleAfterClear = useCallback(() => {
+    const empty = {
+      startDate: '',
+      endDate: '',
+      noStartDate: false,
+      noEndDate: false,
+    };
+    commitOnCloseRef.current = empty;
+    setDraft(empty);
+    setOpen(false);
+  }, []);
+
+  return (
+    <Popover open={open} onOpenChange={handleMainOpenChange} modal>
+      <PopoverTrigger asChild>
+        <FilterTrigger
+          label="Date"
+          active={active}
+          count={1}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear date filter"
+        />
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <div className="p-3">
+          <ScheduledDateRangeFields
+            value={draft}
+            onChange={handleDraftChange}
+            clearButtonLabel="Clear dates"
+            onAfterClear={handleAfterClear}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/ScheduledDateRangeFields.tsx
+++ b/calendar-ui/src/components/ActivityTable/ScheduledDateRangeFields.tsx
@@ -1,0 +1,402 @@
+import {
+  addDays,
+  addMonths,
+  format,
+  startOfDay,
+  subDays,
+  subMonths,
+} from 'date-fns';
+import { Calendar as CalendarIcon, ChevronDown } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+/** Past-oriented presets for start date. */
+export const START_PRESETS = [
+  {
+    label: 'Today',
+    getStart: () => format(startOfDay(new Date()), 'yyyy-MM-dd'),
+  },
+  {
+    label: '7 days ago',
+    getStart: () => format(subDays(startOfDay(new Date()), 7), 'yyyy-MM-dd'),
+  },
+  {
+    label: '14 days ago',
+    getStart: () => format(subDays(startOfDay(new Date()), 14), 'yyyy-MM-dd'),
+  },
+  {
+    label: '1 month ago',
+    getStart: () => format(subMonths(startOfDay(new Date()), 1), 'yyyy-MM-dd'),
+  },
+  {
+    label: '3 months ago',
+    getStart: () => format(subMonths(startOfDay(new Date()), 3), 'yyyy-MM-dd'),
+  },
+] as const;
+
+/** Future-oriented presets for end date. */
+export const END_PRESETS = [
+  {
+    label: 'Today',
+    getEnd: () => format(startOfDay(new Date()), 'yyyy-MM-dd'),
+  },
+  {
+    label: '7 days out',
+    getEnd: () => format(addDays(startOfDay(new Date()), 7), 'yyyy-MM-dd'),
+  },
+  {
+    label: '14 days out',
+    getEnd: () => format(addDays(startOfDay(new Date()), 14), 'yyyy-MM-dd'),
+  },
+  {
+    label: '1 month out',
+    getEnd: () => format(addMonths(startOfDay(new Date()), 1), 'yyyy-MM-dd'),
+  },
+  {
+    label: '3 months out',
+    getEnd: () => format(addMonths(startOfDay(new Date()), 3), 'yyyy-MM-dd'),
+  },
+] as const;
+
+export interface DateRangeValue {
+  startDate: string;
+  endDate: string;
+  noStartDate: boolean;
+  noEndDate: boolean;
+}
+
+export interface ScheduledDateRangeFieldsProps {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue) => void;
+  /** Label for the end-date "no date" control (e.g. "No end date (all upcoming pitches)"). Default "Reset". */
+  endNoDateLabel?: string;
+  /** Label for the clear button. Default "Clear dates". */
+  clearButtonLabel?: string;
+  /** Called after clear is applied (e.g. parent can close popover). */
+  onAfterClear?: () => void;
+}
+
+const calendarYearFrom = new Date().getFullYear() - 5;
+const calendarYearTo = new Date().getFullYear() + 5;
+
+const calendarDropdownCaptionClassNames = {
+  caption:
+    'flex flex-row justify-center items-center gap-2 pt-1 relative w-full',
+  caption_label: 'hidden',
+  caption_dropdowns: 'flex flex-row gap-3 items-center flex-1 justify-center',
+  dropdown_month: '',
+  dropdown_year: '',
+};
+
+const calendarFormatters = {
+  formatMonthCaption: (date: Date) => format(date, 'MMM'),
+};
+
+const calendarDropdownLabels = {
+  labelMonthDropdown: () => '',
+  labelYearDropdown: () => '',
+};
+
+export function ScheduledDateRangeFields({
+  value,
+  onChange,
+  endNoDateLabel = 'Reset',
+  clearButtonLabel = 'Clear dates',
+  onAfterClear,
+}: ScheduledDateRangeFieldsProps) {
+  const [startCalendarOpen, setStartCalendarOpen] = useState(false);
+  const [endCalendarOpen, setEndCalendarOpen] = useState(false);
+
+  const startLabel = useMemo(() => {
+    if (value.noStartDate) return 'No start date';
+    if (value.startDate)
+      return format(new Date(value.startDate + 'T12:00:00'), 'MMM d, yyyy');
+    return 'No start date';
+  }, [value.startDate, value.noStartDate]);
+
+  const endLabel = useMemo(() => {
+    if (value.noEndDate) return 'No end date';
+    if (value.endDate)
+      return format(new Date(value.endDate + 'T12:00:00'), 'MMM d, yyyy');
+    return 'No end date';
+  }, [value.endDate, value.noEndDate]);
+
+  const startDateObj = value.startDate
+    ? new Date(value.startDate + 'T12:00:00')
+    : undefined;
+  const endDateObj = value.endDate
+    ? new Date(value.endDate + 'T12:00:00')
+    : undefined;
+
+  const handleStartSelect = useCallback(
+    (date: Date | undefined) => {
+      if (!date) return;
+      onChange({
+        ...value,
+        startDate: format(date, 'yyyy-MM-dd'),
+        noStartDate: false,
+      });
+    },
+    [value, onChange]
+  );
+
+  const handleEndSelect = useCallback(
+    (date: Date | undefined) => {
+      if (!date) return;
+      onChange({
+        ...value,
+        endDate: format(date, 'yyyy-MM-dd'),
+        noEndDate: false,
+      });
+    },
+    [value, onChange]
+  );
+
+  const handleStartPreset = useCallback(
+    (getStart: () => string) => {
+      onChange({
+        ...value,
+        startDate: getStart(),
+        noStartDate: false,
+      });
+    },
+    [value, onChange]
+  );
+
+  const handleEndPreset = useCallback(
+    (getEnd: () => string) => {
+      onChange({
+        ...value,
+        endDate: getEnd(),
+        noEndDate: false,
+      });
+    },
+    [value, onChange]
+  );
+
+  const handleStartNoDate = useCallback(() => {
+    onChange({
+      ...value,
+      noStartDate: true,
+      startDate: '',
+    });
+  }, [value, onChange]);
+
+  const handleEndNoDate = useCallback(() => {
+    onChange({
+      ...value,
+      noEndDate: true,
+      endDate: '',
+    });
+  }, [value, onChange]);
+
+  const handleClear = useCallback(() => {
+    onChange({
+      startDate: '',
+      endDate: '',
+      noStartDate: false,
+      noEndDate: false,
+    });
+    onAfterClear?.();
+  }, [onChange, onAfterClear]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Popover open={startCalendarOpen} onOpenChange={setStartCalendarOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className={cn(
+                'min-w-[160px] flex-1 justify-start text-left font-normal',
+                !value.startDate &&
+                  !value.noStartDate &&
+                  'text-muted-foreground'
+              )}
+            >
+              <CalendarIcon className="mr-2 h-3.5 w-3.5" />
+              {startLabel}
+              <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <div className="flex flex-col items-center p-3">
+              <div className="flex w-full items-center justify-between">
+                <span className="text-sm font-medium">Select start date</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={!value.startDate}
+                  className={cn('text-sm', value.startDate && 'text-primary')}
+                  onClick={handleStartNoDate}
+                >
+                  Reset
+                </Button>
+              </div>
+              <div className="flex w-full flex-col items-center">
+                <div className="flex w-fit flex-col">
+                  <Calendar
+                    mode="single"
+                    selected={startDateObj}
+                    onSelect={handleStartSelect}
+                    initialFocus
+                    captionLayout="dropdown-buttons"
+                    defaultMonth={startDateObj ?? new Date()}
+                    fromYear={calendarYearFrom}
+                    toYear={calendarYearTo}
+                    classNames={calendarDropdownCaptionClassNames}
+                    formatters={calendarFormatters}
+                    labels={calendarDropdownLabels}
+                    disabled={(date) =>
+                      Boolean(
+                        value.endDate &&
+                        date > new Date(value.endDate + 'T23:59:59')
+                      )
+                    }
+                  />
+                </div>
+              </div>
+              <div className="w-full border-t pt-4">
+                <div className="flex flex-col items-center gap-1.5">
+                  <div className="flex justify-center gap-1.5">
+                    {START_PRESETS.slice(0, 3).map((p) => (
+                      <Button
+                        key={p.label}
+                        variant="outline"
+                        size="sm"
+                        className="text-[14px]"
+                        onClick={() => handleStartPreset(p.getStart)}
+                      >
+                        {p.label}
+                      </Button>
+                    ))}
+                  </div>
+                  <div className="flex justify-center gap-1.5">
+                    {START_PRESETS.slice(3, 5).map((p) => (
+                      <Button
+                        key={p.label}
+                        variant="outline"
+                        size="sm"
+                        className="text-[14px]"
+                        onClick={() => handleStartPreset(p.getStart)}
+                      >
+                        {p.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+        <span className="text-muted-foreground shrink-0" aria-hidden>
+          →
+        </span>
+        <Popover open={endCalendarOpen} onOpenChange={setEndCalendarOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className={cn(
+                'min-w-[160px] flex-1 justify-start text-left font-normal',
+                !value.endDate && !value.noEndDate && 'text-muted-foreground'
+              )}
+            >
+              <CalendarIcon className="mr-2 h-3.5 w-3.5" />
+              {endLabel}
+              <ChevronDown className="ml-auto h-3.5 w-3.5 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <div className="flex flex-col items-center p-3">
+              <div className="flex w-full items-center justify-between">
+                <span className="text-sm font-medium">Select end date</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={!value.endDate}
+                  className={cn('text-sm', value.endDate && 'text-primary')}
+                  onClick={handleEndNoDate}
+                >
+                  {endNoDateLabel}
+                </Button>
+              </div>
+              <div className="flex w-full flex-col items-center">
+                <div className="flex w-fit flex-col">
+                  <Calendar
+                    mode="single"
+                    selected={endDateObj}
+                    onSelect={handleEndSelect}
+                    initialFocus
+                    captionLayout="dropdown-buttons"
+                    defaultMonth={endDateObj ?? new Date()}
+                    fromYear={calendarYearFrom}
+                    toYear={calendarYearTo}
+                    classNames={calendarDropdownCaptionClassNames}
+                    formatters={calendarFormatters}
+                    labels={calendarDropdownLabels}
+                    disabled={(date) =>
+                      Boolean(
+                        value.startDate &&
+                        date < new Date(value.startDate + 'T00:00:00')
+                      )
+                    }
+                  />
+                </div>
+              </div>
+              <div className="w-full border-t pt-4">
+                <div className="flex flex-col items-center gap-1.5">
+                  <div className="flex justify-center gap-1.5">
+                    {END_PRESETS.slice(0, 3).map((p) => (
+                      <Button
+                        key={p.label}
+                        variant="outline"
+                        size="sm"
+                        className="text-[14px]"
+                        onClick={() => handleEndPreset(p.getEnd)}
+                      >
+                        {p.label}
+                      </Button>
+                    ))}
+                  </div>
+                  <div className="flex justify-center gap-1.5">
+                    {END_PRESETS.slice(3, 5).map((p) => (
+                      <Button
+                        key={p.label}
+                        variant="outline"
+                        size="sm"
+                        className="text-[14px]"
+                        onClick={() => handleEndPreset(p.getEnd)}
+                      >
+                        {p.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground w-full"
+        onClick={handleClear}
+      >
+        {clearButtonLabel}
+      </Button>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/ScheduledDateRangeFields.tsx
+++ b/calendar-ui/src/components/ActivityTable/ScheduledDateRangeFields.tsx
@@ -3,11 +3,12 @@ import {
   addMonths,
   format,
   startOfDay,
+  startOfMonth,
   subDays,
   subMonths,
 } from 'date-fns';
 import { Calendar as CalendarIcon, ChevronDown } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
@@ -73,6 +74,16 @@ export interface DateRangeValue {
   noEndDate: boolean;
 }
 
+/** True when the date range has any constraint (dates set or "no start/end date" toggles). */
+export function isDateRangeActive(dateRange: DateRangeValue): boolean {
+  return (
+    dateRange.startDate !== '' ||
+    dateRange.endDate !== '' ||
+    dateRange.noStartDate ||
+    dateRange.noEndDate
+  );
+}
+
 export interface ScheduledDateRangeFieldsProps {
   value: DateRangeValue;
   onChange: (value: DateRangeValue) => void;
@@ -114,6 +125,31 @@ export function ScheduledDateRangeFields({
 }: ScheduledDateRangeFieldsProps) {
   const [startCalendarOpen, setStartCalendarOpen] = useState(false);
   const [endCalendarOpen, setEndCalendarOpen] = useState(false);
+
+  const [startCalendarMonth, setStartCalendarMonth] = useState<Date>(() =>
+    value.startDate
+      ? startOfMonth(new Date(value.startDate + 'T12:00:00'))
+      : startOfMonth(new Date())
+  );
+  const [endCalendarMonth, setEndCalendarMonth] = useState<Date>(() =>
+    value.endDate
+      ? startOfMonth(new Date(value.endDate + 'T12:00:00'))
+      : startOfMonth(new Date())
+  );
+
+  useEffect(() => {
+    if (value.startDate) {
+      setStartCalendarMonth(
+        startOfMonth(new Date(value.startDate + 'T12:00:00'))
+      );
+    }
+  }, [value.startDate]);
+
+  useEffect(() => {
+    if (value.endDate) {
+      setEndCalendarMonth(startOfMonth(new Date(value.endDate + 'T12:00:00')));
+    }
+  }, [value.endDate]);
 
   const startLabel = useMemo(() => {
     if (value.noStartDate) return 'No start date';
@@ -249,9 +285,10 @@ export function ScheduledDateRangeFields({
                     mode="single"
                     selected={startDateObj}
                     onSelect={handleStartSelect}
+                    month={startCalendarMonth}
+                    onMonthChange={setStartCalendarMonth}
                     initialFocus
                     captionLayout="dropdown-buttons"
-                    defaultMonth={startDateObj ?? new Date()}
                     fromYear={calendarYearFrom}
                     toYear={calendarYearTo}
                     classNames={calendarDropdownCaptionClassNames}
@@ -338,9 +375,10 @@ export function ScheduledDateRangeFields({
                     mode="single"
                     selected={endDateObj}
                     onSelect={handleEndSelect}
+                    month={endCalendarMonth}
+                    onMonthChange={setEndCalendarMonth}
                     initialFocus
                     captionLayout="dropdown-buttons"
-                    defaultMonth={endDateObj ?? new Date()}
                     fromYear={calendarYearFrom}
                     toYear={calendarYearTo}
                     classNames={calendarDropdownCaptionClassNames}

--- a/calendar-ui/src/components/ActivityTable/TagsFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/TagsFilter.tsx
@@ -1,13 +1,13 @@
-import { Check, Search, X } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
-import { Input } from '@/components/ui/input';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+import { FilterSearchableList } from './FilterSearchableList';
 
 export interface TagFilterOption {
   value: string;
@@ -30,16 +30,8 @@ export function TagsFilter({
 
   const hasSelection = selectedTagIds.length > 0;
 
-  const filteredOptions = useMemo(() => {
-    const term = searchTerm.trim().toLowerCase();
-    if (term === '') return tagOptions;
-    return tagOptions.filter((opt) => opt.label.toLowerCase().includes(term));
-  }, [tagOptions, searchTerm]);
-
   const handleToggle = useCallback(
-    (value: string) => {
-      const id = parseInt(value, 10);
-      if (!Number.isFinite(id)) return;
+    (id: number) => {
       if (selectedTagIds.includes(id)) {
         onTagIdsChange(selectedTagIds.filter((tid) => tid !== id));
       } else {
@@ -76,57 +68,18 @@ export function TagsFilter({
         />
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="start">
-        <div className="border-b p-2">
-          <div className="relative">
-            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
-            <Input
-              type="text"
-              className="h-8 pr-3 pl-8 text-sm"
-              placeholder="Search tags..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              aria-label="Search tags"
-            />
-          </div>
-        </div>
-        <div className="max-h-[250px] overflow-y-auto py-1">
-          {filteredOptions.length === 0 ? (
-            <div className="text-muted-foreground px-3 py-2 text-center text-sm">
-              No results
-            </div>
-          ) : (
-            filteredOptions.map((opt) => {
-              const checked = selectedTagIds.includes(parseInt(opt.value, 10));
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  className="focus:bg-accent focus:text-accent-foreground hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-left text-sm outline-none select-none"
-                  onClick={() => handleToggle(opt.value)}
-                >
-                  <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-                    {checked ? <Check className="size-4" /> : null}
-                  </span>
-                  <span className="truncate">{opt.label}</span>
-                </button>
-              );
-            })
-          )}
-          {hasSelection && (
-            <>
-              <div className="my-1 border-t" />
-              <button
-                type="button"
-                className="hover:bg-accent text-muted-foreground flex w-full items-center gap-2 px-3 py-2 text-sm"
-                onClick={handleClearFilters}
-              >
-                <X className="h-3.5 w-3.5" />
-                Clear filters
-              </button>
-            </>
-          )}
-        </div>
+        <FilterSearchableList
+          options={tagOptions}
+          selectedIds={selectedTagIds}
+          onToggle={handleToggle}
+          searchPlaceholder="Search tags..."
+          searchAriaLabel="Search tags"
+          emptyMessage="No results"
+          showClearButton
+          onClear={handleClearFilters}
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/calendar-ui/src/components/ActivityTable/TagsFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/TagsFilter.tsx
@@ -1,0 +1,133 @@
+import { Check, Search, X } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+export interface TagFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface TagsFilterProps {
+  tagOptions: TagFilterOption[];
+  selectedTagIds: number[];
+  onTagIdsChange: (tagIds: number[]) => void;
+}
+
+export function TagsFilter({
+  tagOptions,
+  selectedTagIds,
+  onTagIdsChange,
+}: TagsFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const hasSelection = selectedTagIds.length > 0;
+
+  const filteredOptions = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (term === '') return tagOptions;
+    return tagOptions.filter((opt) => opt.label.toLowerCase().includes(term));
+  }, [tagOptions, searchTerm]);
+
+  const handleToggle = useCallback(
+    (value: string) => {
+      const id = parseInt(value, 10);
+      if (!Number.isFinite(id)) return;
+      if (selectedTagIds.includes(id)) {
+        onTagIdsChange(selectedTagIds.filter((tid) => tid !== id));
+      } else {
+        onTagIdsChange([...selectedTagIds, id]);
+      }
+    },
+    [selectedTagIds, onTagIdsChange]
+  );
+
+  const handleClearFilters = useCallback(() => {
+    onTagIdsChange([]);
+    setOpen(false);
+  }, [onTagIdsChange]);
+
+  const handleClearTrigger = useCallback(() => {
+    onTagIdsChange([]);
+  }, [onTagIdsChange]);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) setSearchTerm('');
+      }}
+    >
+      <PopoverTrigger asChild>
+        <FilterTrigger
+          label="Tags"
+          active={hasSelection}
+          count={selectedTagIds.length}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Tags filter"
+        />
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <div className="border-b p-2">
+          <div className="relative">
+            <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
+            <Input
+              type="text"
+              className="h-8 pr-3 pl-8 text-sm"
+              placeholder="Search tags..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
+              aria-label="Search tags"
+            />
+          </div>
+        </div>
+        <div className="max-h-[250px] overflow-y-auto py-1">
+          {filteredOptions.length === 0 ? (
+            <div className="text-muted-foreground px-3 py-2 text-center text-sm">
+              No results
+            </div>
+          ) : (
+            filteredOptions.map((opt) => {
+              const checked = selectedTagIds.includes(parseInt(opt.value, 10));
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className="focus:bg-accent focus:text-accent-foreground hover:bg-accent relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-left text-sm outline-none select-none"
+                  onClick={() => handleToggle(opt.value)}
+                >
+                  <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+                    {checked ? <Check className="size-4" /> : null}
+                  </span>
+                  <span className="truncate">{opt.label}</span>
+                </button>
+              );
+            })
+          )}
+          {hasSelection && (
+            <>
+              <div className="my-1 border-t" />
+              <button
+                type="button"
+                className="hover:bg-accent text-muted-foreground flex w-full items-center gap-2 px-3 py-2 text-sm"
+                onClick={handleClearFilters}
+              >
+                <X className="h-3.5 w-3.5" />
+                Clear filters
+              </button>
+            </>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/TranslationsFilter.tsx
+++ b/calendar-ui/src/components/ActivityTable/TranslationsFilter.tsx
@@ -1,0 +1,182 @@
+import { X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
+
+import { FilterSearchableList } from './FilterSearchableList';
+
+export interface TranslationFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface TranslationStatusFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface TranslationsFilterProps {
+  translationStatusOptions: TranslationStatusFilterOption[];
+  translationOptions: TranslationFilterOption[];
+  selectedStatusIds: number[];
+  selectedLanguageIds: number[];
+  onStatusIdsChange: (ids: number[]) => void;
+  onLanguageIdsChange: (ids: number[]) => void;
+}
+
+function isTranslationsFilterActive(
+  statusCount: number,
+  languageCount: number
+): boolean {
+  return statusCount > 0 || languageCount > 0;
+}
+
+export function TranslationsFilter({
+  translationStatusOptions,
+  translationOptions,
+  selectedStatusIds,
+  selectedLanguageIds,
+  onStatusIdsChange,
+  onLanguageIdsChange,
+}: TranslationsFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const statusCount = selectedStatusIds.length;
+  const languageCount = selectedLanguageIds.length;
+  const active = isTranslationsFilterActive(statusCount, languageCount);
+  const totalCount = statusCount + languageCount;
+
+  const handleClearTrigger = useCallback(() => {
+    onStatusIdsChange([]);
+    onLanguageIdsChange([]);
+  }, [onStatusIdsChange, onLanguageIdsChange]);
+
+  const handleStatusToggle = useCallback(
+    (id: number) => {
+      if (selectedStatusIds.includes(id)) {
+        onStatusIdsChange(selectedStatusIds.filter((x) => x !== id));
+      } else {
+        onStatusIdsChange([...selectedStatusIds, id]);
+      }
+    },
+    [selectedStatusIds, onStatusIdsChange]
+  );
+
+  const handleLanguageToggle = useCallback(
+    (id: number) => {
+      if (selectedLanguageIds.includes(id)) {
+        onLanguageIdsChange(selectedLanguageIds.filter((lid) => lid !== id));
+      } else {
+        onLanguageIdsChange([...selectedLanguageIds, id]);
+      }
+    },
+    [selectedLanguageIds, onLanguageIdsChange]
+  );
+
+  const handleClearStatus = useCallback(() => {
+    onStatusIdsChange([]);
+  }, [onStatusIdsChange]);
+
+  const handleClearLanguages = useCallback(() => {
+    onLanguageIdsChange([]);
+    setOpen(false);
+  }, [onLanguageIdsChange]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) setSearchTerm('');
+  }, []);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <FilterTrigger
+          label="Translations"
+          active={active}
+          count={totalCount}
+          onClear={handleClearTrigger}
+          clearAriaLabel="Clear Translations filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="min-w-48"
+        align="start"
+        aria-label="Filter by translations (status, languages)"
+      >
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {statusCount > 0
+              ? `Translations status (${statusCount})`
+              : 'Translations status'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="min-w-48">
+            {translationStatusOptions.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-center text-sm">
+                No results
+              </p>
+            ) : (
+              translationStatusOptions.map((opt) => {
+                const id = parseInt(opt.value, 10);
+                const checked =
+                  Number.isFinite(id) && selectedStatusIds.includes(id);
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={opt.value}
+                    checked={checked}
+                    onCheckedChange={() =>
+                      Number.isFinite(id) && handleStatusToggle(id)
+                    }
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    <span className="truncate">{opt.label}</span>
+                  </DropdownMenuCheckboxItem>
+                );
+              })
+            )}
+            {statusCount > 0 && (
+              <button
+                type="button"
+                className="hover:bg-accent text-muted-foreground flex w-full items-center gap-2 border-t px-3 py-2 text-sm"
+                onClick={handleClearStatus}
+              >
+                <X className="h-3.5 w-3.5" />
+                Clear all
+              </button>
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {languageCount > 0
+              ? `Translations (${languageCount})`
+              : 'Translations'}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-64 p-0">
+            <FilterSearchableList
+              options={translationOptions}
+              selectedIds={selectedLanguageIds}
+              onToggle={handleLanguageToggle}
+              searchPlaceholder="Search languages..."
+              searchAriaLabel="Search languages"
+              emptyMessage="No results"
+              showClearButton
+              onClear={handleClearLanguages}
+              searchValue={searchTerm}
+              onSearchChange={setSearchTerm}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/calendar-ui/src/components/ActivityTable/activityFilterState.ts
+++ b/calendar-ui/src/components/ActivityTable/activityFilterState.ts
@@ -37,6 +37,14 @@ export interface ActivityFilterState {
   timeConfirmedFilter: 'any' | 'confirmed' | 'not_confirmed';
   /** Selected tag IDs (multi-select). */
   tagIds: number[];
+  /** Lead ministry IDs (multi-select). */
+  leadMinistryIds: number[];
+  /** Lead organization IDs (multi-select). */
+  leadOrgIds: number[];
+  /** Comms contact lead user IDs (multi-select). */
+  commsContactLeadUserIds: number[];
+  /** Event planner lead IDs (multi-select). */
+  eventPlannerLeadIds: number[];
 }
 
 export type ConfirmedFilterValue = ActivityFilterState['dateConfirmedFilter'];
@@ -64,4 +72,8 @@ export const DEFAULT_ACTIVITY_FILTER_STATE: ActivityFilterState = {
   dateConfirmedFilter: 'any',
   timeConfirmedFilter: 'any',
   tagIds: [],
+  leadMinistryIds: [],
+  leadOrgIds: [],
+  commsContactLeadUserIds: [],
+  eventPlannerLeadIds: [],
 };

--- a/calendar-ui/src/components/ActivityTable/activityFilterState.ts
+++ b/calendar-ui/src/components/ActivityTable/activityFilterState.ts
@@ -31,7 +31,15 @@ export interface ActivityFilterState {
   lookAheadStatusValues: string[];
   /** Look Ahead section values (e.g. 'events', 'issues'). */
   lookAheadSectionValues: string[];
+  /** Date section confirmation: any (no filter), confirmed, or not_confirmed. */
+  dateConfirmedFilter: 'any' | 'confirmed' | 'not_confirmed';
+  /** Time section confirmation: any (no filter), confirmed, or not_confirmed. */
+  timeConfirmedFilter: 'any' | 'confirmed' | 'not_confirmed';
+  /** Selected tag IDs (multi-select). */
+  tagIds: number[];
 }
+
+export type ConfirmedFilterValue = ActivityFilterState['dateConfirmedFilter'];
 
 export const DEFAULT_PITCH_DATE_RANGE: DateRangeValue = {
   startDate: '',
@@ -53,4 +61,7 @@ export const DEFAULT_ACTIVITY_FILTER_STATE: ActivityFilterState = {
   pitchDateFilter: { kind: 'any' },
   lookAheadStatusValues: [],
   lookAheadSectionValues: [],
+  dateConfirmedFilter: 'any',
+  timeConfirmedFilter: 'any',
+  tagIds: [],
 };

--- a/calendar-ui/src/components/ActivityTable/activityFilterState.ts
+++ b/calendar-ui/src/components/ActivityTable/activityFilterState.ts
@@ -45,6 +45,10 @@ export interface ActivityFilterState {
   commsContactLeadUserIds: number[];
   /** Event planner lead IDs (multi-select). */
   eventPlannerLeadIds: number[];
+  /** Translation required status IDs (multi-select), e.g. pending, required, not_required. */
+  translationRequiredStatusIds: number[];
+  /** Translation language IDs (multi-select). */
+  translationLanguageIds: number[];
 }
 
 export type ConfirmedFilterValue = ActivityFilterState['dateConfirmedFilter'];
@@ -76,4 +80,6 @@ export const DEFAULT_ACTIVITY_FILTER_STATE: ActivityFilterState = {
   leadOrgIds: [],
   commsContactLeadUserIds: [],
   eventPlannerLeadIds: [],
+  translationRequiredStatusIds: [],
+  translationLanguageIds: [],
 };

--- a/calendar-ui/src/components/ActivityTable/activityFilterState.ts
+++ b/calendar-ui/src/components/ActivityTable/activityFilterState.ts
@@ -1,0 +1,50 @@
+import type { DateRangeValue } from './ScheduledDateRangeFields';
+
+/**
+ * Activity table filter state (Date, Category, Status, Pitch).
+ * Used by ActivityTableFilters and persisted in URL + sessionStorage via useActivityTablePreferences.
+ */
+
+/** Pitch date filter: any (no filter), not_scheduled, or scheduled with optional date range. */
+export type PitchDateFilter =
+  | { kind: 'any' }
+  | { kind: 'not_scheduled' }
+  | { kind: 'scheduled'; dateRange: DateRangeValue };
+
+export interface ActivityFilterState {
+  /** Scheduled date range; empty string = no filter for that bound. */
+  dateRange: {
+    startDate: string;
+    endDate: string;
+    noStartDate: boolean;
+    noEndDate: boolean;
+  };
+  /** Category display names (match row.activityCategories). */
+  categoryNames: string[];
+  /** Activity status IDs (match row.activityStatusId). */
+  activityStatusIds: number[];
+  /** Pitch required status display names (match row.pitchRequiredStatus). */
+  pitchRequiredStatusNames: string[];
+  /** Pitch date filter; 'any' = no radio selected (deselect by clicking selected radio again). */
+  pitchDateFilter: PitchDateFilter;
+}
+
+export const DEFAULT_PITCH_DATE_RANGE: DateRangeValue = {
+  startDate: '',
+  endDate: '',
+  noStartDate: false,
+  noEndDate: false,
+};
+
+export const DEFAULT_ACTIVITY_FILTER_STATE: ActivityFilterState = {
+  dateRange: {
+    startDate: '',
+    endDate: '',
+    noStartDate: false,
+    noEndDate: false,
+  },
+  categoryNames: [],
+  activityStatusIds: [],
+  pitchRequiredStatusNames: [],
+  pitchDateFilter: { kind: 'any' },
+};

--- a/calendar-ui/src/components/ActivityTable/activityFilterState.ts
+++ b/calendar-ui/src/components/ActivityTable/activityFilterState.ts
@@ -27,6 +27,10 @@ export interface ActivityFilterState {
   pitchRequiredStatusNames: string[];
   /** Pitch date filter; 'any' = no radio selected (deselect by clicking selected radio again). */
   pitchDateFilter: PitchDateFilter;
+  /** Look Ahead status values (e.g. 'new', 'changed'). */
+  lookAheadStatusValues: string[];
+  /** Look Ahead section values (e.g. 'events', 'issues'). */
+  lookAheadSectionValues: string[];
 }
 
 export const DEFAULT_PITCH_DATE_RANGE: DateRangeValue = {
@@ -47,4 +51,6 @@ export const DEFAULT_ACTIVITY_FILTER_STATE: ActivityFilterState = {
   activityStatusIds: [],
   pitchRequiredStatusNames: [],
   pitchDateFilter: { kind: 'any' },
+  lookAheadStatusValues: [],
+  lookAheadSectionValues: [],
 };

--- a/calendar-ui/src/components/ActivityTable/activityTableRow.ts
+++ b/calendar-ui/src/components/ActivityTable/activityTableRow.ts
@@ -45,6 +45,11 @@ export interface ActivityTableRow {
   commsLeadName: string | null;
   commsContactsCount: number;
   eventLead: string | null;
+  /** IDs for client-side lead filtering */
+  leadMinistryId: number | null;
+  leadOrgId: number | null;
+  commsContactLeadUserId: number | null;
+  eventPlannerLeadId: number | null;
 
   // Materials column
   translationsRequired: string[];
@@ -128,6 +133,10 @@ export function mapActivityResponseToTableRow(
     commsLeadName: commsLead?.name ?? null,
     commsContactsCount: activity.commsContacts.length,
     eventLead: activity.eventLead,
+    leadMinistryId: activity.leadMinistryId ?? null,
+    leadOrgId: activity.leadOrgId ?? null,
+    commsContactLeadUserId: commsLead?.userId ?? null,
+    eventPlannerLeadId: activity.eventPlannerLeadId ?? null,
 
     // Materials
     translationsRequired: activity.translationsRequired,

--- a/calendar-ui/src/components/ActivityTable/activityTableRow.ts
+++ b/calendar-ui/src/components/ActivityTable/activityTableRow.ts
@@ -53,6 +53,7 @@ export interface ActivityTableRow {
 
   // Status column
   activityStatus: string;
+  activityStatusId: number;
   lastUpdatedDateTime: string;
   lastUpdatedBy: number;
   createdDateTime: string;
@@ -135,6 +136,7 @@ export function mapActivityResponseToTableRow(
 
     // Status
     activityStatus: activity.activityStatus,
+    activityStatusId: activity.activityStatusId ?? 0,
     lastUpdatedDateTime: activity.lastUpdatedDateTime,
     lastUpdatedBy: activity.lastUpdatedBy,
     createdDateTime: activity.createdDateTime,

--- a/calendar-ui/src/components/ResponsiveFilterRow.tsx
+++ b/calendar-ui/src/components/ResponsiveFilterRow.tsx
@@ -1,0 +1,231 @@
+import { ChevronDown } from 'lucide-react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+const SLOT_GAP_PX = 8;
+const OVERFLOW_BUTTON_RESERVE_PX = 110;
+const TRAILING_GROUP_OFFSET_PX = 32;
+
+export interface ResponsiveFilterRowProps {
+  /** Ordered list of filter components (or any React nodes) to show in the row. */
+  children: ReactNode[];
+  /** Label for the overflow trigger when some filters are hidden. Default "All filters". */
+  overflowTriggerLabel?: string;
+  /** Class name for the overflow trigger button (e.g. h-10 for alignment). */
+  overflowTriggerClassName?: string;
+  /** Optional content rendered after "All filters" (e.g. Clear filters button). Keeps a consistent gap from the last visible filter and from "All filters". */
+  trailingContent?: ReactNode;
+  /** Width in px to reserve for trailing content when measuring. When set, a spacer is rendered when trailingContent is null so layout stays stable. */
+  reservedWidthForTrailing?: number;
+  /** Class name for the row container. */
+  className?: string;
+  /** Class name for the inner flex container that holds visible slots. */
+  containerClassName?: string;
+}
+
+/**
+ * Renders as many children as fit in one row; the rest are moved into an
+ * "All filters" dropdown. Uses ResizeObserver and layout measurement to
+ * compute how many slots fit. Reusable for any list of filter-like components.
+ */
+export function ResponsiveFilterRow({
+  children,
+  overflowTriggerLabel = 'All filters',
+  overflowTriggerClassName,
+  trailingContent,
+  reservedWidthForTrailing,
+  className,
+  containerClassName,
+}: ResponsiveFilterRowProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [visibleCount, setVisibleCount] = useState<number | null>(null);
+  const prevContainerWidthRef = useRef(0);
+
+  const count = children.length;
+  const slots = count === 0 ? [] : children;
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const updateWidth = () => {
+      setContainerWidth(node.clientWidth);
+    };
+
+    updateWidth();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(node);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const prev = prevContainerWidthRef.current;
+    if (prev !== containerWidth) {
+      prevContainerWidthRef.current = containerWidth;
+      if (prev > 0 && containerWidth > 0) {
+        setVisibleCount(null);
+      }
+    }
+  }, [containerWidth]);
+
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node || count === 0) {
+      setVisibleCount(count);
+      return;
+    }
+    if (containerWidth === 0) {
+      setVisibleCount(count);
+      return;
+    }
+    if (visibleCount !== null) return;
+
+    const measureRow = node.querySelector<HTMLElement>(
+      '[data-responsive-filter-row-measure="true"]'
+    );
+    if (!measureRow) return;
+
+    const slotWrappers = measureRow.querySelectorAll<HTMLElement>(
+      '[data-responsive-filter-slot="true"]'
+    );
+    const trailingReserve = reservedWidthForTrailing ?? 0;
+    const availableWidth =
+      containerWidth -
+      TRAILING_GROUP_OFFSET_PX -
+      (count > 1 ? OVERFLOW_BUTTON_RESERVE_PX : 0) -
+      trailingReserve;
+
+    let used = 0;
+    let fitCount = 0;
+    for (let i = 0; i < slotWrappers.length; i++) {
+      const w = slotWrappers[i].offsetWidth;
+      const need = used + (i > 0 ? SLOT_GAP_PX : 0) + w;
+      if (need > availableWidth) break;
+      used = need;
+      fitCount = i + 1;
+    }
+
+    setVisibleCount(Math.max(0, fitCount));
+  }, [visibleCount, containerWidth, count, reservedWidthForTrailing]);
+
+  const finalVisible =
+    visibleCount == null ? count : Math.min(Math.max(0, visibleCount), count);
+  const visibleSlots = slots.slice(0, finalVisible);
+  const overflowSlots = slots.slice(finalVisible);
+  const hasOverflow = overflowSlots.length > 0;
+
+  if (count === 0) {
+    return (
+      <div
+        ref={containerRef}
+        className={cn('flex min-w-0 flex-1 items-center', className)}
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'flex min-w-0 flex-1 items-center justify-start',
+        className
+      )}
+    >
+      {visibleCount === null ? (
+        <div
+          data-responsive-filter-row-measure="true"
+          className={cn(
+            'flex flex-nowrap items-center gap-2 overflow-hidden',
+            containerClassName
+          )}
+          style={{ visibility: 'hidden', position: 'absolute' }}
+        >
+          {slots.map((child, i) => (
+            <div
+              key={i}
+              data-responsive-filter-slot="true"
+              className="shrink-0"
+            >
+              {child}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex min-h-10 shrink-0 items-center">
+          <div
+            className={cn(
+              'flex flex-nowrap items-center gap-2',
+              finalVisible > 0 && 'pr-8',
+              containerClassName
+            )}
+          >
+            {visibleSlots.map((child, i) => (
+              <div key={i} className="shrink-0">
+                {child}
+              </div>
+            ))}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {hasOverflow && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className={cn(
+                      'border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 min-w-[100px] shrink-0 justify-between gap-1 font-normal',
+                      overflowTriggerClassName
+                    )}
+                    aria-label={`${overflowTriggerLabel}; ${overflowSlots.length} more filters`}
+                  >
+                    <span>{overflowTriggerLabel}</span>
+                    <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="max-h-[min(80vh,400px)] min-w-[200px] overflow-y-auto p-2"
+                >
+                  <div className="flex flex-col gap-2">
+                    {overflowSlots.map((child, i) => (
+                      <div key={i} className="shrink-0">
+                        {child}
+                      </div>
+                    ))}
+                  </div>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            {reservedWidthForTrailing != null
+              ? (trailingContent ?? (
+                  <span
+                    className="shrink-0"
+                    style={{ width: reservedWidthForTrailing }}
+                    aria-hidden
+                  />
+                ))
+              : trailingContent}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/calendar-ui/src/components/Table/SortDropdown.tsx
+++ b/calendar-ui/src/components/Table/SortDropdown.tsx
@@ -105,7 +105,14 @@ export function SortDropdown({
             : (col.defaultDirection ?? 'asc');
           const SortIcon = direction === 'asc' ? ArrowUp : ArrowDown;
           return (
-            <DropdownMenuItem key={col.id} onSelect={() => handleSelect(col)}>
+            <DropdownMenuItem
+              key={col.id}
+              onSelect={(e) => {
+                // Keep sort menu open so user can toggle asc/desc without auto-closing
+                e.preventDefault();
+                handleSelect(col);
+              }}
+            >
               {isActive ? (
                 <SortIcon className="h-4 w-4 shrink-0" aria-hidden />
               ) : (

--- a/calendar-ui/src/components/Table/TableSummaryBar.tsx
+++ b/calendar-ui/src/components/Table/TableSummaryBar.tsx
@@ -1,4 +1,9 @@
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 export interface BooleanFilter {
@@ -6,6 +11,10 @@ export interface BooleanFilter {
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  /** When true, checkbox is disabled and not editable. */
+  disabled?: boolean;
+  /** Shown only when disabled is true; directs user why the control is disabled. */
+  disabledTooltip?: string;
 }
 
 interface TableSummaryBarProps {
@@ -38,20 +47,39 @@ export function TableSummaryBar({
       </span>
       {filters.length > 0 && (
         <div className="flex flex-wrap items-center gap-4">
-          {filters.map((filter) => (
-            <label
-              key={filter.id}
-              className="flex cursor-pointer items-center gap-2 text-sm text-stone-500"
-            >
-              <Checkbox
-                checked={filter.checked}
-                onCheckedChange={(v) => filter.onCheckedChange(v === true)}
-                aria-label={filter.label}
-                className="border-stone-500"
-              />
-              {filter.label}
-            </label>
-          ))}
+          {filters.map((filter) => {
+            const isDisabled = filter.disabled === true;
+            const labelClassName = cn(
+              'flex items-center gap-2 text-sm text-stone-500',
+              isDisabled ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'
+            );
+            const labelContent = (
+              <>
+                <Checkbox
+                  checked={filter.checked}
+                  onCheckedChange={(v) => filter.onCheckedChange(v === true)}
+                  aria-label={filter.label}
+                  className="border-stone-500"
+                  disabled={isDisabled}
+                />
+                {filter.label}
+              </>
+            );
+            return (
+              <span key={filter.id}>
+                {isDisabled && filter.disabledTooltip ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <label className={labelClassName}>{labelContent}</label>
+                    </TooltipTrigger>
+                    <TooltipContent>{filter.disabledTooltip}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <label className={labelClassName}>{labelContent}</label>
+                )}
+              </span>
+            );
+          })}
         </div>
       )}
     </div>

--- a/calendar-ui/src/components/Table/tableConstants.ts
+++ b/calendar-ui/src/components/Table/tableConstants.ts
@@ -12,8 +12,9 @@ export const tableContainer =
   'flex min-w-0 w-full max-w-full flex-col overflow-hidden rounded-lg border border-slate-200 bg-white';
 
 /** Inner scrollable div (assign ref for scrollTo). Bounded so horizontal scroll is inside this div. */
+/* [overflow-y:scroll] can be removed if causing layout shift */
 export const tableScrollWrapper =
-  'min-h-0 min-w-0 w-full max-w-full flex-1 overflow-auto';
+  'min-h-0 min-w-0 w-full max-w-full flex-1 overflow-auto [overflow-y:scroll]';
 
 /** Base table element; add min-w-[Npx] per table if needed */
 export const tableTable = 'w-full table-fixed border-collapse';

--- a/calendar-ui/src/components/teams/TeamManagementFilters.tsx
+++ b/calendar-ui/src/components/teams/TeamManagementFilters.tsx
@@ -1,4 +1,4 @@
-import { Search } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 
 import {
   SortDropdown,
@@ -48,13 +48,23 @@ export function TeamManagementFilters({
           <div className="relative max-w-md min-w-[240px] flex-1">
             <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
             <Input
-              type="search"
+              type="text"
               placeholder="Search teams..."
               value={keyword}
               onChange={(e) => onKeywordChange(e.target.value)}
-              className="pl-8"
+              className="pr-8 pl-8"
               aria-label="Keyword search"
             />
+            {keyword && (
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                onClick={() => onKeywordChange('')}
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
           </div>
           <SortDropdown
             columns={TEAM_SORT_COLUMNS}

--- a/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
+++ b/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
@@ -20,6 +20,8 @@ interface FilterCheckboxDropdownProps {
   onChange: (values: string[]) => void;
   disabled?: boolean;
   className?: string;
+  /** Message when options list is empty. Default "No results" for consistency with other filter dropdowns. */
+  emptyMessage?: string;
 }
 
 /**
@@ -33,6 +35,7 @@ export function FilterCheckboxDropdown({
   onChange,
   disabled = false,
   className,
+  emptyMessage = 'No results',
 }: FilterCheckboxDropdownProps) {
   const hasSelection = selectedValues.length > 0;
 
@@ -63,7 +66,7 @@ export function FilterCheckboxDropdown({
       <DropdownMenuContent className="max-h-64 overflow-auto" align="start">
         {options.length === 0 ? (
           <p className="text-muted-foreground py-2 text-center text-sm">
-            No options
+            {emptyMessage}
           </p>
         ) : (
           options.map((opt) => (

--- a/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
+++ b/calendar-ui/src/components/users/FilterCheckboxDropdown.tsx
@@ -1,14 +1,12 @@
-import { ChevronDown, X } from 'lucide-react';
 import { useCallback } from 'react';
 
-import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { cn } from '@/lib/utils';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
 
 export interface FilterCheckboxOption {
   value: string;
@@ -49,51 +47,18 @@ export function FilterCheckboxDropdown({
     [onChange, selectedValues]
   );
 
-  const handleClear = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      onChange([]);
-    },
-    [onChange]
-  );
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant={hasSelection ? 'default' : 'outline'}
-          size="sm"
+        <FilterTrigger
+          label={label}
+          active={hasSelection}
+          count={selectedValues.length}
+          onClear={() => onChange([])}
+          clearAriaLabel={`Clear ${label} filter`}
           disabled={disabled}
-          className={cn(
-            'min-w-[100px] justify-between gap-1 font-normal',
-            className
-          )}
-        >
-          <span className="truncate">
-            {hasSelection ? `${label} (${selectedValues.length})` : label}
-          </span>
-          {hasSelection ? (
-            <span
-              role="button"
-              tabIndex={0}
-              onClick={handleClear}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onChange([]);
-                }
-              }}
-              className="ml-1 inline-flex cursor-pointer rounded p-0.5 hover:bg-white/20"
-              aria-label={`Clear ${label} filter`}
-            >
-              <X className="h-3.5 w-3.5" />
-            </span>
-          ) : (
-            <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-          )}
-        </Button>
+          className={className}
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-h-64 overflow-auto" align="start">
         {options.length === 0 ? (

--- a/calendar-ui/src/components/users/FilterTrigger.tsx
+++ b/calendar-ui/src/components/users/FilterTrigger.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
  * Shared styles for the filter trigger button. Single source of truth for all filter triggers.
  */
 const filterTriggerStyles = {
-  base: 'flex h-9 min-w-[100px] items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm font-normal whitespace-nowrap transition-colors',
+  base: 'flex h-10 min-w-[100px] items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm font-normal whitespace-nowrap transition-colors',
   inactive:
     'border-input bg-background hover:bg-accent hover:text-accent-foreground',
   active: 'border-primary bg-primary text-primary-foreground hover:opacity-90',

--- a/calendar-ui/src/components/users/FilterTrigger.tsx
+++ b/calendar-ui/src/components/users/FilterTrigger.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
  * Shared styles for the filter trigger button. Single source of truth for all filter triggers.
  */
 const filterTriggerStyles = {
-  base: 'flex min-w-[100px] items-center justify-between gap-1 rounded-md border px-3 py-1.5 text-sm font-normal whitespace-nowrap transition-colors',
+  base: 'flex h-9 min-w-[100px] items-center justify-between gap-1 rounded-md border px-3 py-2 text-sm font-normal whitespace-nowrap transition-colors',
   inactive:
     'border-input bg-background hover:bg-accent hover:text-accent-foreground',
   active: 'border-primary bg-primary text-primary-foreground hover:opacity-90',

--- a/calendar-ui/src/components/users/FilterTrigger.tsx
+++ b/calendar-ui/src/components/users/FilterTrigger.tsx
@@ -1,0 +1,110 @@
+import { ChevronDown, X } from 'lucide-react';
+import { useCallback } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Shared styles for the filter trigger button. Single source of truth for all filter triggers.
+ */
+const filterTriggerStyles = {
+  base: 'flex min-w-[100px] items-center justify-between gap-1 rounded-md border px-3 py-1.5 text-sm font-normal whitespace-nowrap transition-colors',
+  inactive:
+    'border-input bg-background hover:bg-accent hover:text-accent-foreground',
+  active: 'border-primary bg-primary text-primary-foreground hover:opacity-90',
+  clearIcon: 'ml-1 inline-flex cursor-pointer rounded p-0.5 hover:opacity-80',
+  chevron: 'h-4 w-4 shrink-0 opacity-50',
+} as const;
+
+export interface FilterTriggerProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'onClear'
+> {
+  /** Filter label (e.g. "Date", "Category", "Team"). */
+  label: string;
+  /** Whether the filter has a selection (shows count + clear icon). */
+  active: boolean;
+  /** Count shown when active, e.g. "Label (count)". Omit or 0 to show "Label (1)" for single-criteria filters like Date. */
+  count?: number;
+  /** Called when the clear (X) icon is clicked or activated by keyboard. */
+  onClear: () => void;
+  /** Accessible label for the clear button. */
+  clearAriaLabel: string;
+  /** React 19: ref forwarded to the root button for Radix asChild. */
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+/**
+ * Unified filter trigger button for use with Popover or DropdownMenu.
+ * Renders a single button with label, optional count when active, and a clear icon that clears the filter without opening the dropdown (uses onPointerDown to prevent Radix from opening on clear).
+ * React 19: ref is passed as a normal prop for use with Radix asChild.
+ */
+export function FilterTrigger({
+  label,
+  active,
+  count = 1,
+  onClear,
+  clearAriaLabel,
+  disabled,
+  className,
+  ref,
+  ...rest
+}: FilterTriggerProps) {
+  const handleClearClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onClear();
+    },
+    [onClear]
+  );
+
+  const handleClearPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleClearKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClear();
+      }
+    },
+    [onClear]
+  );
+
+  const displayCount = active ? count : 0;
+  const labelText = displayCount > 0 ? `${label} (${displayCount})` : label;
+
+  return (
+    <button
+      type="button"
+      ref={ref}
+      disabled={disabled}
+      className={cn(
+        filterTriggerStyles.base,
+        active ? filterTriggerStyles.active : filterTriggerStyles.inactive,
+        className
+      )}
+      {...rest}
+    >
+      <span className="truncate">{labelText}</span>
+      {active ? (
+        <span
+          role="button"
+          tabIndex={0}
+          onPointerDown={handleClearPointerDown}
+          onClick={handleClearClick}
+          onKeyDown={handleClearKeyDown}
+          className={filterTriggerStyles.clearIcon}
+          aria-label={clearAriaLabel}
+        >
+          <X className="h-3.5 w-3.5" />
+        </span>
+      ) : (
+        <ChevronDown className={filterTriggerStyles.chevron} />
+      )}
+    </button>
+  );
+}

--- a/calendar-ui/src/components/users/FilterTrigger.tsx
+++ b/calendar-ui/src/components/users/FilterTrigger.tsx
@@ -1,5 +1,12 @@
 import { ChevronDown, X } from 'lucide-react';
-import { useCallback } from 'react';
+import {
+  useCallback,
+  type ButtonHTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  type Ref,
+} from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -16,7 +23,7 @@ const filterTriggerStyles = {
 } as const;
 
 export interface FilterTriggerProps extends Omit<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  ButtonHTMLAttributes<HTMLButtonElement>,
   'children' | 'onClear'
 > {
   /** Filter label (e.g. "Date", "Category", "Team"). */
@@ -30,7 +37,7 @@ export interface FilterTriggerProps extends Omit<
   /** Accessible label for the clear button. */
   clearAriaLabel: string;
   /** React 19: ref forwarded to the root button for Radix asChild. */
-  ref?: React.Ref<HTMLButtonElement>;
+  ref?: Ref<HTMLButtonElement>;
 }
 
 /**
@@ -50,7 +57,7 @@ export function FilterTrigger({
   ...rest
 }: FilterTriggerProps) {
   const handleClearClick = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent<HTMLSpanElement>) => {
       e.preventDefault();
       e.stopPropagation();
       onClear();
@@ -58,13 +65,16 @@ export function FilterTrigger({
     [onClear]
   );
 
-  const handleClearPointerDown = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-  }, []);
+  const handleClearPointerDown = useCallback(
+    (e: PointerEvent<HTMLSpanElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    []
+  );
 
   const handleClearKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent<HTMLSpanElement>) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         e.stopPropagation();

--- a/calendar-ui/src/components/users/UserManagementFilters.tsx
+++ b/calendar-ui/src/components/users/UserManagementFilters.tsx
@@ -1,5 +1,5 @@
-import { Check, ChevronDown, Search, X } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { Check, Search, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   SortDropdown,
@@ -22,7 +22,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { FilterCheckboxDropdown } from '@/components/users/FilterCheckboxDropdown';
+import { FilterTrigger } from '@/components/users/FilterTrigger';
 import { cn } from '@/lib/utils';
+
+const KEYWORD_DEBOUNCE_MS = 400;
 
 const USER_SORT_COLUMNS: SortColumnConfig[] = [
   { id: 'name', label: 'Name', defaultDirection: 'asc' },
@@ -105,24 +108,6 @@ export function UserManagementFilters({
     [teamOptions, teamSelectedValues]
   );
   const hasTeamSelection = teamIds.length > 0;
-  const handleTeamClear = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      onTeamIdsChange([]);
-    },
-    [onTeamIdsChange]
-  );
-  const handleTeamClearKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        e.stopPropagation();
-        onTeamIdsChange([]);
-      }
-    },
-    [onTeamIdsChange]
-  );
   const handleTeamSelectItem = useCallback(
     (value: string) => {
       handleTeamSelect(value);
@@ -147,6 +132,43 @@ export function UserManagementFilters({
     onRoleIdsChange([]);
   }, [onTeamIdsChange, onRoleIdsChange]);
 
+  const [searchInput, setSearchInput] = useState(keyword);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setSearchInput(keyword);
+  }, [keyword]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+        onKeywordChange(value);
+      }, KEYWORD_DEBOUNCE_MS);
+    },
+    [onKeywordChange]
+  );
+
+  const handleClearSearch = useCallback(() => {
+    setSearchInput('');
+    onKeywordChange('');
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, [onKeywordChange]);
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
   return (
     <div
       className={className}
@@ -157,29 +179,13 @@ export function UserManagementFilters({
         <div className="flex flex-wrap items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant={hasTeamSelection ? 'default' : 'outline'}
-                size="sm"
-                className="min-w-[100px] justify-between gap-1 font-normal"
-              >
-                <span className="truncate">
-                  {hasTeamSelection ? `Team (${teamIds.length})` : 'Team'}
-                </span>
-                {hasTeamSelection ? (
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={handleTeamClear}
-                    onKeyDown={handleTeamClearKeyDown}
-                    className="ml-1 inline-flex cursor-pointer rounded p-0.5 hover:bg-white/20"
-                    aria-label="Clear Team filter"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </span>
-                ) : (
-                  <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-                )}
-              </Button>
+              <FilterTrigger
+                label="Team"
+                active={hasTeamSelection}
+                count={teamIds.length}
+                onClear={() => onTeamIdsChange([])}
+                clearAriaLabel="Clear Team filter"
+              />
             </DropdownMenuTrigger>
             <DropdownMenuContent className="w-72 p-0" align="start">
               <Command className="rounded-md border-0" shouldFilter={false}>
@@ -261,13 +267,23 @@ export function UserManagementFilters({
           <div className="relative max-w-md min-w-[240px] flex-1">
             <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
             <Input
-              type="search"
+              type="text"
               placeholder="Search by name, email, username..."
-              value={keyword}
-              onChange={(e) => onKeywordChange(e.target.value)}
-              className="pl-8"
+              value={searchInput}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pr-8 pl-8"
               aria-label="Keyword search"
             />
+            {searchInput && (
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                onClick={handleClearSearch}
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
           </div>
           <SortDropdown
             columns={USER_SORT_COLUMNS}

--- a/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
@@ -208,6 +208,8 @@ describe('useActivityTablePreferences', () => {
           leadOrgIds: [],
           commsContactLeadUserIds: [],
           eventPlannerLeadIds: [],
+          translationRequiredStatusIds: [],
+          translationLanguageIds: [],
         },
       };
       sessionStorageGet.mockImplementation((key: string) =>
@@ -258,6 +260,8 @@ describe('useActivityTablePreferences', () => {
           leadOrgIds: [] as number[],
           commsContactLeadUserIds: [] as number[],
           eventPlannerLeadIds: [] as number[],
+          translationRequiredStatusIds: [],
+          translationLanguageIds: [],
         },
       };
       sessionStorageGet.mockImplementation((key: string) =>
@@ -394,6 +398,8 @@ describe('getStoredActivityListSearch', () => {
         leadOrgIds: [] as number[],
         commsContactLeadUserIds: [] as number[],
         eventPlannerLeadIds: [] as number[],
+        translationRequiredStatusIds: [],
+        translationLanguageIds: [],
       },
     };
     sessionStorageGet.mockImplementation((key: string) =>

--- a/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
@@ -1,0 +1,408 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getStoredActivityListSearch,
+  useActivityTablePreferences,
+  type ActivityTablePreferences,
+} from './useActivityTablePreferences';
+
+const STORAGE_KEY = 'activityTablePreferences' as const;
+
+const mockSetSearchParams = vi.fn();
+let mockSearchParams: URLSearchParams;
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}));
+
+const sessionStorageGet = vi.fn();
+const sessionStorageSet = vi.fn();
+
+function makeMockStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => {
+      const result = sessionStorageGet(key);
+      return result !== undefined ? result : (store.get(key) ?? null);
+    },
+    setItem: (key: string, value: string) => {
+      sessionStorageSet(key, value);
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: () => null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+describe('useActivityTablePreferences', () => {
+  const canSeeDeleted = true;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    Object.defineProperty(window, 'sessionStorage', {
+      value: makeMockStorage(),
+      writable: true,
+    });
+    sessionStorageGet.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initial preferences', () => {
+    it('returns defaults when URL has no known params and storage is empty', () => {
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.sortKey).toBe('startDate');
+      expect(result.current.preferences.sortDirection).toBe('desc');
+      expect(result.current.preferences.showCompleted).toBe(false);
+      expect(result.current.preferences.showDeleted).toBe(false);
+      expect(result.current.preferences.pageSize).toBe(10);
+      expect(result.current.preferences.searchKeyword).toBe('');
+      expect(result.current.preferences.filterState).toEqual(
+        expect.objectContaining({
+          categoryNames: [],
+          activityStatusIds: [],
+          tagIds: [],
+          dateConfirmedFilter: 'any',
+          timeConfirmedFilter: 'any',
+        })
+      );
+    });
+
+    it('parses sort and dir from URL when present', () => {
+      mockSearchParams = new URLSearchParams('sort=lastUpdated&dir=asc');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.sortKey).toBe('lastUpdated');
+      expect(result.current.preferences.sortDirection).toBe('asc');
+    });
+
+    it('falls back to default sort when URL sort is invalid', () => {
+      mockSearchParams = new URLSearchParams('sort=invalidKey&dir=asc');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.sortKey).toBe('startDate');
+      expect(result.current.preferences.sortDirection).toBe('asc');
+    });
+
+    it('parses completed and deleted from URL', () => {
+      mockSearchParams = new URLSearchParams(
+        'sort=startDate&completed=true&deleted=true'
+      );
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.showCompleted).toBe(true);
+      expect(result.current.preferences.showDeleted).toBe(true);
+    });
+
+    it('parses pageSize from URL and clamps to valid range', () => {
+      mockSearchParams = new URLSearchParams('sort=startDate&pageSize=25');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.pageSize).toBe(25);
+    });
+
+    it('falls back to default pageSize when URL pageSize is invalid', () => {
+      mockSearchParams = new URLSearchParams('sort=startDate&pageSize=999');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.pageSize).toBe(10);
+    });
+
+    it('parses search from URL', () => {
+      mockSearchParams = new URLSearchParams('sort=startDate&search=foo+bar');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.searchKeyword).toBe('foo bar');
+    });
+
+    it('parses filter state from URL (date range, category, status, tag)', () => {
+      mockSearchParams = new URLSearchParams(
+        'sort=startDate&dateFrom=2025-01-01&dateTo=2025-01-31&category=Event,Release&status=1,2&tag=10,20'
+      );
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      const f = result.current.preferences.filterState;
+      expect(f.dateRange.startDate).toBe('2025-01-01');
+      expect(f.dateRange.endDate).toBe('2025-01-31');
+      expect(f.categoryNames).toEqual(['Event', 'Release']);
+      expect(f.activityStatusIds).toEqual([1, 2]);
+      expect(f.tagIds).toEqual([10, 20]);
+    });
+
+    it('parses confirmed filters from URL', () => {
+      mockSearchParams = new URLSearchParams(
+        'sort=startDate&dateConfirmed=confirmed&timeConfirmed=not_confirmed'
+      );
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.filterState.dateConfirmedFilter).toBe(
+        'confirmed'
+      );
+      expect(result.current.preferences.filterState.timeConfirmedFilter).toBe(
+        'not_confirmed'
+      );
+    });
+
+    it('uses sessionStorage when URL has no known params', () => {
+      const stored: ActivityTablePreferences = {
+        sortKey: 'lastUpdated',
+        sortDirection: 'asc',
+        showCompleted: true,
+        showDeleted: false,
+        pageSize: 25,
+        searchKeyword: 'stored search',
+        filterState: {
+          dateRange: {
+            startDate: '2025-02-01',
+            endDate: '2025-02-28',
+            noStartDate: false,
+            noEndDate: false,
+          },
+          categoryNames: ['Event'],
+          activityStatusIds: [1],
+          pitchRequiredStatusNames: [],
+          pitchDateFilter: { kind: 'any' },
+          lookAheadStatusValues: [],
+          lookAheadSectionValues: [],
+          dateConfirmedFilter: 'any',
+          timeConfirmedFilter: 'any',
+          tagIds: [],
+          leadMinistryIds: [],
+          leadOrgIds: [],
+          commsContactLeadUserIds: [],
+          eventPlannerLeadIds: [],
+        },
+      };
+      sessionStorageGet.mockImplementation((key: string) =>
+        key === STORAGE_KEY ? JSON.stringify(stored) : null
+      );
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.sortKey).toBe('lastUpdated');
+      expect(result.current.preferences.sortDirection).toBe('asc');
+      expect(result.current.preferences.pageSize).toBe(25);
+      expect(result.current.preferences.searchKeyword).toBe('stored search');
+      expect(result.current.preferences.filterState.dateRange.startDate).toBe(
+        '2025-02-01'
+      );
+      expect(result.current.preferences.filterState.categoryNames).toEqual([
+        'Event',
+      ]);
+    });
+
+    it('ignores sessionStorage when URL has any known param', () => {
+      const stored = {
+        sortKey: 'lastUpdated',
+        sortDirection: 'asc',
+        showCompleted: true,
+        showDeleted: false,
+        pageSize: 25,
+        searchKeyword: 'stored',
+        filterState: {
+          dateRange: {
+            startDate: '',
+            endDate: '',
+            noStartDate: false,
+            noEndDate: false,
+          },
+          categoryNames: [] as string[],
+          activityStatusIds: [] as number[],
+          pitchRequiredStatusNames: [] as string[],
+          pitchDateFilter: { kind: 'any' as const },
+          lookAheadStatusValues: [] as string[],
+          lookAheadSectionValues: [] as string[],
+          dateConfirmedFilter: 'any' as const,
+          timeConfirmedFilter: 'any' as const,
+          tagIds: [] as number[],
+          leadMinistryIds: [] as number[],
+          leadOrgIds: [] as number[],
+          commsContactLeadUserIds: [] as number[],
+          eventPlannerLeadIds: [] as number[],
+        },
+      };
+      sessionStorageGet.mockImplementation((key: string) =>
+        key === STORAGE_KEY ? JSON.stringify(stored) : null
+      );
+      mockSearchParams = new URLSearchParams('sort=startDate');
+
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      expect(result.current.preferences.sortKey).toBe('startDate');
+      expect(result.current.preferences.searchKeyword).toBe('');
+    });
+
+    it('forces showDeleted false when canSeeDeleted is false', () => {
+      mockSearchParams = new URLSearchParams('sort=startDate&deleted=true');
+
+      const { result } = renderHook(() => useActivityTablePreferences(false));
+
+      expect(result.current.preferences.showDeleted).toBe(false);
+    });
+  });
+
+  describe('setPreferences', () => {
+    it('updates preferences and writes to sessionStorage', () => {
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      act(() => {
+        result.current.setPreferences({
+          sortKey: 'lastUpdated',
+          sortDirection: 'asc',
+          pageSize: 50,
+        });
+      });
+
+      expect(result.current.preferences.sortKey).toBe('lastUpdated');
+      expect(result.current.preferences.sortDirection).toBe('asc');
+      expect(result.current.preferences.pageSize).toBe(50);
+
+      expect(sessionStorageSet).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        expect.stringContaining('"sortKey":"lastUpdated"')
+      );
+    });
+
+    it('syncs to URL immediately when non-search preference changes', () => {
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      act(() => {
+        result.current.setPreferences({ sortKey: 'activityId' });
+      });
+
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'activityId' }),
+        { replace: true }
+      );
+    });
+  });
+
+  describe('debounced URL sync for search', () => {
+    it('debounces URL update when only searchKeyword changes', () => {
+      vi.useFakeTimers();
+      mockSearchParams = new URLSearchParams('sort=startDate');
+      const { result } = renderHook(() =>
+        useActivityTablePreferences(canSeeDeleted)
+      );
+
+      act(() => {
+        result.current.setPreferences({ sortKey: 'lastUpdated' });
+      });
+      expect(mockSetSearchParams).toHaveBeenCalled();
+      mockSetSearchParams.mockClear();
+
+      act(() => {
+        result.current.setPreferences({ searchKeyword: 'foo' });
+      });
+      expect(mockSetSearchParams).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'foo' }),
+        { replace: true }
+      );
+    });
+  });
+});
+
+describe('getStoredActivityListSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'sessionStorage', {
+      value: makeMockStorage(),
+      writable: true,
+    });
+    sessionStorageGet.mockReturnValue(null);
+  });
+
+  it('returns empty string when storage has no preferences', () => {
+    expect(getStoredActivityListSearch(true)).toBe('');
+  });
+
+  it('returns query string from stored preferences', () => {
+    const stored = {
+      sortKey: 'lastUpdated',
+      sortDirection: 'desc',
+      showCompleted: false,
+      showDeleted: false,
+      pageSize: 10,
+      searchKeyword: '',
+      filterState: {
+        dateRange: {
+          startDate: '',
+          endDate: '',
+          noStartDate: false,
+          noEndDate: false,
+        },
+        categoryNames: [] as string[],
+        activityStatusIds: [] as number[],
+        pitchRequiredStatusNames: [] as string[],
+        pitchDateFilter: { kind: 'any' as const },
+        lookAheadStatusValues: [] as string[],
+        lookAheadSectionValues: [] as string[],
+        dateConfirmedFilter: 'any' as const,
+        timeConfirmedFilter: 'any' as const,
+        tagIds: [] as number[],
+        leadMinistryIds: [] as number[],
+        leadOrgIds: [] as number[],
+        commsContactLeadUserIds: [] as number[],
+        eventPlannerLeadIds: [] as number[],
+      },
+    };
+    sessionStorageGet.mockImplementation((key: string) =>
+      key === 'activityTablePreferences' ? JSON.stringify(stored) : null
+    );
+
+    const result = getStoredActivityListSearch(true);
+    expect(result).toContain('sort=lastUpdated');
+    expect(result).toContain('dir=desc');
+    expect(result.startsWith('?')).toBe(true);
+  });
+});

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -31,6 +31,8 @@ const URL_PARAM_LOOK_AHEAD_SECTION = 'lookAheadSection';
 const URL_PARAM_DATE_CONFIRMED = 'dateConfirmed';
 const URL_PARAM_TIME_CONFIRMED = 'timeConfirmed';
 const URL_PARAM_TAG = 'tag';
+const URL_PARAM_TRANSLATION = 'translation';
+const URL_PARAM_TRANSLATION_STATUS = 'translationStatus';
 
 /** Delay before syncing search keyword to URL so the input keeps focus while typing. */
 const SEARCH_SYNC_DEBOUNCE_MS = 400;
@@ -192,6 +194,24 @@ function parseFromSearchParams(
           .filter((n) => Number.isFinite(n))
       : [];
 
+  const translationParam = searchParams.get(URL_PARAM_TRANSLATION);
+  const translationLanguageIds =
+    typeof translationParam === 'string' && translationParam.trim()
+      ? translationParam
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n))
+      : [];
+
+  const translationStatusParam = searchParams.get(URL_PARAM_TRANSLATION_STATUS);
+  const translationRequiredStatusIds =
+    typeof translationStatusParam === 'string' && translationStatusParam.trim()
+      ? translationStatusParam
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n))
+      : [];
+
   const filterState: ActivityFilterState = {
     dateRange: {
       startDate: dateFrom,
@@ -212,6 +232,8 @@ function parseFromSearchParams(
     leadOrgIds: [],
     commsContactLeadUserIds: [],
     eventPlannerLeadIds: [],
+    translationRequiredStatusIds,
+    translationLanguageIds,
   };
 
   return {
@@ -362,6 +384,20 @@ function parseFromStorage(
               (n): n is number => typeof n === 'number' && Number.isFinite(n)
             )
           : [];
+        const translationLanguageIds = Array.isArray(
+          rawFilter.translationLanguageIds
+        )
+          ? (rawFilter.translationLanguageIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
+        const translationRequiredStatusIds = Array.isArray(
+          rawFilter.translationRequiredStatusIds
+        )
+          ? (rawFilter.translationRequiredStatusIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
         filterState = {
           dateRange: {
             startDate: typeof dr.startDate === 'string' ? dr.startDate : '',
@@ -390,6 +426,8 @@ function parseFromStorage(
           leadOrgIds,
           commsContactLeadUserIds,
           eventPlannerLeadIds,
+          translationRequiredStatusIds,
+          translationLanguageIds,
         };
       }
     }
@@ -432,7 +470,9 @@ function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
     searchParams.has(URL_PARAM_LOOK_AHEAD_SECTION) ||
     searchParams.has(URL_PARAM_DATE_CONFIRMED) ||
     searchParams.has(URL_PARAM_TIME_CONFIRMED) ||
-    searchParams.has(URL_PARAM_TAG)
+    searchParams.has(URL_PARAM_TAG) ||
+    searchParams.has(URL_PARAM_TRANSLATION) ||
+    searchParams.has(URL_PARAM_TRANSLATION_STATUS)
   );
 }
 
@@ -484,6 +524,8 @@ function preferencesToParams(
     [URL_PARAM_TIME_CONFIRMED]:
       f.timeConfirmedFilter === 'any' ? '' : f.timeConfirmedFilter,
     [URL_PARAM_TAG]: f.tagIds.join(','),
+    [URL_PARAM_TRANSLATION]: f.translationLanguageIds.join(','),
+    [URL_PARAM_TRANSLATION_STATUS]: f.translationRequiredStatusIds.join(','),
   };
   if (f.pitchDateFilter.kind === 'scheduled') {
     const dr = f.pitchDateFilter.dateRange;

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -422,11 +422,17 @@ function getInitialPreferences(
   );
 }
 
+/**
+ * Builds URL params from preferences. Omits any param whose value is an empty
+ * string so that "param is present" means "user set this filter". Otherwise
+ * hasAnyKnownParam would always be true and we would always read from URL
+ * instead of sessionStorage when the URL is "empty or unrelated".
+ */
 function preferencesToParams(
   prefs: ActivityTablePreferences
 ): Record<string, string> {
   const f = prefs.filterState;
-  const out: Record<string, string> = {
+  const raw: Record<string, string> = {
     [URL_PARAM_SORT]: prefs.sortKey,
     [URL_PARAM_DIR]: prefs.sortDirection,
     [URL_PARAM_COMPLETED]: String(prefs.showCompleted),
@@ -451,10 +457,16 @@ function preferencesToParams(
   };
   if (f.pitchDateFilter.kind === 'scheduled') {
     const dr = f.pitchDateFilter.dateRange;
-    out[URL_PARAM_PITCH_DATE_FROM] = dr.startDate;
-    out[URL_PARAM_PITCH_DATE_TO] = dr.endDate;
-    out[URL_PARAM_PITCH_NO_START] = String(dr.noStartDate);
-    out[URL_PARAM_PITCH_NO_END] = String(dr.noEndDate);
+    raw[URL_PARAM_PITCH_DATE_FROM] = dr.startDate;
+    raw[URL_PARAM_PITCH_DATE_TO] = dr.endDate;
+    raw[URL_PARAM_PITCH_NO_START] = String(dr.noStartDate);
+    raw[URL_PARAM_PITCH_NO_END] = String(dr.noEndDate);
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value !== '') {
+      out[key] = value;
+    }
   }
   return out;
 }

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -208,6 +208,10 @@ function parseFromSearchParams(
     dateConfirmedFilter,
     timeConfirmedFilter,
     tagIds,
+    leadMinistryIds: [],
+    leadOrgIds: [],
+    commsContactLeadUserIds: [],
+    eventPlannerLeadIds: [],
   };
 
   return {
@@ -336,6 +340,28 @@ function parseFromStorage(
               (n): n is number => typeof n === 'number' && Number.isFinite(n)
             )
           : [];
+        const leadMinistryIds = Array.isArray(rawFilter.leadMinistryIds)
+          ? (rawFilter.leadMinistryIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
+        const leadOrgIds = Array.isArray(rawFilter.leadOrgIds)
+          ? (rawFilter.leadOrgIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
+        const commsContactLeadUserIds = Array.isArray(
+          rawFilter.commsContactLeadUserIds
+        )
+          ? (rawFilter.commsContactLeadUserIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
+        const eventPlannerLeadIds = Array.isArray(rawFilter.eventPlannerLeadIds)
+          ? (rawFilter.eventPlannerLeadIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
         filterState = {
           dateRange: {
             startDate: typeof dr.startDate === 'string' ? dr.startDate : '',
@@ -360,6 +386,10 @@ function parseFromStorage(
           dateConfirmedFilter,
           timeConfirmedFilter,
           tagIds,
+          leadMinistryIds,
+          leadOrgIds,
+          commsContactLeadUserIds,
+          eventPlannerLeadIds,
         };
       }
     }

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -1,6 +1,11 @@
 import { useSearchParams } from 'react-router-dom';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import {
+  DEFAULT_ACTIVITY_FILTER_STATE,
+  type ActivityFilterState,
+} from '@/components/ActivityTable/activityFilterState';
+
 const STORAGE_KEY = 'activityTablePreferences';
 
 const URL_PARAM_SORT = 'sort';
@@ -9,6 +14,18 @@ const URL_PARAM_COMPLETED = 'completed';
 const URL_PARAM_DELETED = 'deleted';
 const URL_PARAM_PAGE_SIZE = 'pageSize';
 const URL_PARAM_SEARCH = 'search';
+const URL_PARAM_DATE_FROM = 'dateFrom';
+const URL_PARAM_DATE_TO = 'dateTo';
+const URL_PARAM_NO_START = 'noStart';
+const URL_PARAM_NO_END = 'noEnd';
+const URL_PARAM_CATEGORY = 'category';
+const URL_PARAM_STATUS = 'status';
+const URL_PARAM_PITCH_STATUS = 'pitchStatus';
+const URL_PARAM_PITCH_DATE_KIND = 'pitchDateKind';
+const URL_PARAM_PITCH_DATE_FROM = 'pitchDateFrom';
+const URL_PARAM_PITCH_DATE_TO = 'pitchDateTo';
+const URL_PARAM_PITCH_NO_START = 'pitchNoStart';
+const URL_PARAM_PITCH_NO_END = 'pitchNoEnd';
 
 /** Delay before syncing search keyword to URL so the input keeps focus while typing. */
 const SEARCH_SYNC_DEBOUNCE_MS = 400;
@@ -35,6 +52,7 @@ export interface ActivityTablePreferences {
   showDeleted: boolean;
   pageSize: number;
   searchKeyword: string;
+  filterState: ActivityFilterState;
 }
 
 const DEFAULT_PREFERENCES: ActivityTablePreferences = {
@@ -44,6 +62,7 @@ const DEFAULT_PREFERENCES: ActivityTablePreferences = {
   showDeleted: false,
   pageSize: DEFAULT_PAGE_SIZE,
   searchKeyword: '',
+  filterState: DEFAULT_ACTIVITY_FILTER_STATE,
 };
 
 function parseBool(value: string | null): boolean | null {
@@ -75,6 +94,75 @@ function parseFromSearchParams(
   const searchKeyword =
     typeof searchParam === 'string' ? searchParam.trim() : '';
 
+  const dateFrom = searchParams.get(URL_PARAM_DATE_FROM)?.trim() ?? '';
+  const dateTo = searchParams.get(URL_PARAM_DATE_TO)?.trim() ?? '';
+  const noStart = parseBool(searchParams.get(URL_PARAM_NO_START));
+  const noEnd = parseBool(searchParams.get(URL_PARAM_NO_END));
+  const categoryParam = searchParams.get(URL_PARAM_CATEGORY);
+  const categoryNames =
+    typeof categoryParam === 'string' && categoryParam.trim()
+      ? categoryParam
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const statusParam = searchParams.get(URL_PARAM_STATUS);
+  const activityStatusIds =
+    typeof statusParam === 'string' && statusParam.trim()
+      ? statusParam
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n))
+      : [];
+
+  const pitchStatusParam = searchParams.get(URL_PARAM_PITCH_STATUS);
+  const pitchRequiredStatusNames =
+    typeof pitchStatusParam === 'string' && pitchStatusParam.trim()
+      ? pitchStatusParam
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
+  const pitchDateKindParam = searchParams
+    .get(URL_PARAM_PITCH_DATE_KIND)
+    ?.trim();
+  const pitchDateFrom =
+    searchParams.get(URL_PARAM_PITCH_DATE_FROM)?.trim() ?? '';
+  const pitchDateTo = searchParams.get(URL_PARAM_PITCH_DATE_TO)?.trim() ?? '';
+  const pitchNoStart = parseBool(searchParams.get(URL_PARAM_PITCH_NO_START));
+  const pitchNoEnd = parseBool(searchParams.get(URL_PARAM_PITCH_NO_END));
+
+  let pitchDateFilter: ActivityFilterState['pitchDateFilter'] = {
+    kind: 'any',
+  };
+  if (pitchDateKindParam === 'not_scheduled') {
+    pitchDateFilter = { kind: 'not_scheduled' };
+  } else if (pitchDateKindParam === 'scheduled') {
+    pitchDateFilter = {
+      kind: 'scheduled',
+      dateRange: {
+        startDate: pitchDateFrom,
+        endDate: pitchDateTo,
+        noStartDate: pitchNoStart === true,
+        noEndDate: pitchNoEnd === true,
+      },
+    };
+  }
+
+  const filterState: ActivityFilterState = {
+    dateRange: {
+      startDate: dateFrom,
+      endDate: dateTo,
+      noStartDate: noStart === true,
+      noEndDate: noEnd === true,
+    },
+    categoryNames,
+    activityStatusIds,
+    pitchRequiredStatusNames,
+    pitchDateFilter,
+  };
+
   return {
     sortKey:
       sort && VALID_SORT_KEYS.has(sort) ? sort : DEFAULT_PREFERENCES.sortKey,
@@ -89,6 +177,7 @@ function parseFromSearchParams(
         : DEFAULT_PREFERENCES.showDeleted,
     pageSize: pageSize ?? DEFAULT_PREFERENCES.pageSize,
     searchKeyword,
+    filterState,
   };
 }
 
@@ -131,6 +220,67 @@ function parseFromStorage(
         ? parsed.searchKeyword.trim()
         : DEFAULT_PREFERENCES.searchKeyword;
 
+    const rawFilter = parsed.filterState as Record<string, unknown> | undefined;
+    let filterState: ActivityFilterState = DEFAULT_ACTIVITY_FILTER_STATE;
+    if (rawFilter && typeof rawFilter === 'object') {
+      const dr = rawFilter.dateRange as Record<string, unknown> | undefined;
+      if (dr && typeof dr === 'object') {
+        const pitchRequiredStatusNames = Array.isArray(
+          rawFilter.pitchRequiredStatusNames
+        )
+          ? (rawFilter.pitchRequiredStatusNames as string[]).filter(
+              (s): s is string => typeof s === 'string'
+            )
+          : [];
+        const pdf = rawFilter.pitchDateFilter as
+          | { kind: string; dateRange?: Record<string, unknown> }
+          | undefined;
+        let pitchDateFilter: ActivityFilterState['pitchDateFilter'] = {
+          kind: 'any',
+        };
+        if (pdf && typeof pdf === 'object' && pdf.kind === 'not_scheduled') {
+          pitchDateFilter = { kind: 'not_scheduled' };
+        } else if (
+          pdf &&
+          typeof pdf === 'object' &&
+          pdf.kind === 'scheduled' &&
+          pdf.dateRange &&
+          typeof pdf.dateRange === 'object'
+        ) {
+          const pr = pdf.dateRange;
+          pitchDateFilter = {
+            kind: 'scheduled',
+            dateRange: {
+              startDate: typeof pr.startDate === 'string' ? pr.startDate : '',
+              endDate: typeof pr.endDate === 'string' ? pr.endDate : '',
+              noStartDate: pr.noStartDate === true,
+              noEndDate: pr.noEndDate === true,
+            },
+          };
+        }
+        filterState = {
+          dateRange: {
+            startDate: typeof dr.startDate === 'string' ? dr.startDate : '',
+            endDate: typeof dr.endDate === 'string' ? dr.endDate : '',
+            noStartDate: dr.noStartDate === true,
+            noEndDate: dr.noEndDate === true,
+          },
+          categoryNames: Array.isArray(rawFilter.categoryNames)
+            ? (rawFilter.categoryNames as string[]).filter(
+                (s): s is string => typeof s === 'string'
+              )
+            : [],
+          activityStatusIds: Array.isArray(rawFilter.activityStatusIds)
+            ? (rawFilter.activityStatusIds as number[]).filter(
+                (n): n is number => typeof n === 'number' && Number.isFinite(n)
+              )
+            : [],
+          pitchRequiredStatusNames,
+          pitchDateFilter,
+        };
+      }
+    }
+
     return {
       sortKey,
       sortDirection,
@@ -138,6 +288,7 @@ function parseFromStorage(
       showDeleted,
       pageSize,
       searchKeyword,
+      filterState,
     };
   } catch {
     return null;
@@ -151,7 +302,19 @@ function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
     searchParams.has(URL_PARAM_COMPLETED) ||
     searchParams.has(URL_PARAM_DELETED) ||
     searchParams.has(URL_PARAM_PAGE_SIZE) ||
-    searchParams.has(URL_PARAM_SEARCH)
+    searchParams.has(URL_PARAM_SEARCH) ||
+    searchParams.has(URL_PARAM_DATE_FROM) ||
+    searchParams.has(URL_PARAM_DATE_TO) ||
+    searchParams.has(URL_PARAM_NO_START) ||
+    searchParams.has(URL_PARAM_NO_END) ||
+    searchParams.has(URL_PARAM_CATEGORY) ||
+    searchParams.has(URL_PARAM_STATUS) ||
+    searchParams.has(URL_PARAM_PITCH_STATUS) ||
+    searchParams.has(URL_PARAM_PITCH_DATE_KIND) ||
+    searchParams.has(URL_PARAM_PITCH_DATE_FROM) ||
+    searchParams.has(URL_PARAM_PITCH_DATE_TO) ||
+    searchParams.has(URL_PARAM_PITCH_NO_START) ||
+    searchParams.has(URL_PARAM_PITCH_NO_END)
   );
 }
 
@@ -174,14 +337,31 @@ function getInitialPreferences(
 function preferencesToParams(
   prefs: ActivityTablePreferences
 ): Record<string, string> {
-  return {
+  const f = prefs.filterState;
+  const out: Record<string, string> = {
     [URL_PARAM_SORT]: prefs.sortKey,
     [URL_PARAM_DIR]: prefs.sortDirection,
     [URL_PARAM_COMPLETED]: String(prefs.showCompleted),
     [URL_PARAM_DELETED]: String(prefs.showDeleted),
     [URL_PARAM_PAGE_SIZE]: String(prefs.pageSize),
     [URL_PARAM_SEARCH]: prefs.searchKeyword,
+    [URL_PARAM_DATE_FROM]: f.dateRange.startDate,
+    [URL_PARAM_DATE_TO]: f.dateRange.endDate,
+    [URL_PARAM_NO_START]: String(f.dateRange.noStartDate),
+    [URL_PARAM_NO_END]: String(f.dateRange.noEndDate),
+    [URL_PARAM_CATEGORY]: f.categoryNames.join(','),
+    [URL_PARAM_STATUS]: f.activityStatusIds.join(','),
+    [URL_PARAM_PITCH_STATUS]: f.pitchRequiredStatusNames.join(','),
+    [URL_PARAM_PITCH_DATE_KIND]: f.pitchDateFilter.kind,
   };
+  if (f.pitchDateFilter.kind === 'scheduled') {
+    const dr = f.pitchDateFilter.dateRange;
+    out[URL_PARAM_PITCH_DATE_FROM] = dr.startDate;
+    out[URL_PARAM_PITCH_DATE_TO] = dr.endDate;
+    out[URL_PARAM_PITCH_NO_START] = String(dr.noStartDate);
+    out[URL_PARAM_PITCH_NO_END] = String(dr.noEndDate);
+  }
+  return out;
 }
 
 /**
@@ -230,6 +410,10 @@ export function useActivityTablePreferences(canSeeDeleted: boolean): {
                 ? partial.showDeleted
                 : false
               : prev.showDeleted,
+          filterState:
+            partial.filterState !== undefined
+              ? partial.filterState
+              : prev.filterState,
         };
         return next;
       });
@@ -264,6 +448,8 @@ export function useActivityTablePreferences(canSeeDeleted: boolean): {
       prev.showCompleted === preferences.showCompleted &&
       prev.showDeleted === preferences.showDeleted &&
       prev.pageSize === preferences.pageSize &&
+      JSON.stringify(prev.filterState) ===
+        JSON.stringify(preferences.filterState) &&
       prev.searchKeyword !== preferences.searchKeyword;
 
     if (onlySearchChanged) {

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -8,6 +8,10 @@ const URL_PARAM_DIR = 'dir';
 const URL_PARAM_COMPLETED = 'completed';
 const URL_PARAM_DELETED = 'deleted';
 const URL_PARAM_PAGE_SIZE = 'pageSize';
+const URL_PARAM_SEARCH = 'search';
+
+/** Delay before syncing search keyword to URL so the input keeps focus while typing. */
+const SEARCH_SYNC_DEBOUNCE_MS = 400;
 
 const VALID_SORT_KEYS = new Set([
   'activityId',
@@ -30,6 +34,7 @@ export interface ActivityTablePreferences {
   showCompleted: boolean;
   showDeleted: boolean;
   pageSize: number;
+  searchKeyword: string;
 }
 
 const DEFAULT_PREFERENCES: ActivityTablePreferences = {
@@ -38,6 +43,7 @@ const DEFAULT_PREFERENCES: ActivityTablePreferences = {
   showCompleted: false,
   showDeleted: false,
   pageSize: DEFAULT_PAGE_SIZE,
+  searchKeyword: '',
 };
 
 function parseBool(value: string | null): boolean | null {
@@ -65,6 +71,9 @@ function parseFromSearchParams(
   const completed = parseBool(searchParams.get(URL_PARAM_COMPLETED));
   const deleted = parseBool(searchParams.get(URL_PARAM_DELETED));
   const pageSize = parsePageSize(searchParams.get(URL_PARAM_PAGE_SIZE));
+  const searchParam = searchParams.get(URL_PARAM_SEARCH);
+  const searchKeyword =
+    typeof searchParam === 'string' ? searchParam.trim() : '';
 
   return {
     sortKey:
@@ -79,6 +88,7 @@ function parseFromSearchParams(
         ? deleted
         : DEFAULT_PREFERENCES.showDeleted,
     pageSize: pageSize ?? DEFAULT_PREFERENCES.pageSize,
+    searchKeyword,
   };
 }
 
@@ -116,6 +126,10 @@ function parseFromStorage(
       parsed.pageSize <= MAX_PAGE_SIZE
         ? parsed.pageSize
         : DEFAULT_PREFERENCES.pageSize;
+    const searchKeyword =
+      typeof parsed.searchKeyword === 'string'
+        ? parsed.searchKeyword.trim()
+        : DEFAULT_PREFERENCES.searchKeyword;
 
     return {
       sortKey,
@@ -123,6 +137,7 @@ function parseFromStorage(
       showCompleted,
       showDeleted,
       pageSize,
+      searchKeyword,
     };
   } catch {
     return null;
@@ -135,7 +150,8 @@ function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
     searchParams.has(URL_PARAM_DIR) ||
     searchParams.has(URL_PARAM_COMPLETED) ||
     searchParams.has(URL_PARAM_DELETED) ||
-    searchParams.has(URL_PARAM_PAGE_SIZE)
+    searchParams.has(URL_PARAM_PAGE_SIZE) ||
+    searchParams.has(URL_PARAM_SEARCH)
   );
 }
 
@@ -164,6 +180,7 @@ function preferencesToParams(
     [URL_PARAM_COMPLETED]: String(prefs.showCompleted),
     [URL_PARAM_DELETED]: String(prefs.showDeleted),
     [URL_PARAM_PAGE_SIZE]: String(prefs.pageSize),
+    [URL_PARAM_SEARCH]: prefs.searchKeyword,
   };
 }
 
@@ -193,6 +210,12 @@ export function useActivityTablePreferences(canSeeDeleted: boolean): {
     () => getInitialPreferences(searchParams, canSeeDeleted)
   );
   const hasUserChangedRef = useRef(false);
+  const lastUrlSyncRef = useRef<ActivityTablePreferences | null>(null);
+  const searchSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const preferencesRef = useRef(preferences);
+  preferencesRef.current = preferences;
 
   const setPreferences = useCallback(
     (partial: Partial<ActivityTablePreferences>) => {
@@ -214,17 +237,58 @@ export function useActivityTablePreferences(canSeeDeleted: boolean): {
     [canSeeDeleted]
   );
 
+  const syncToUrl = useCallback(
+    (prefs: ActivityTablePreferences) => {
+      lastUrlSyncRef.current = prefs;
+      setSearchParams(preferencesToParams(prefs), { replace: true });
+    },
+    [setSearchParams]
+  );
+
   useEffect(() => {
     if (!hasUserChangedRef.current) return;
-    setSearchParams(preferencesToParams(preferences), { replace: true });
+
     if (typeof window !== 'undefined') {
       try {
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
       } catch {
-        // ignore storage errors
+        // ignore
       }
     }
-  }, [preferences, setSearchParams]);
+
+    const prev = lastUrlSyncRef.current;
+    const onlySearchChanged =
+      prev !== null &&
+      prev.sortKey === preferences.sortKey &&
+      prev.sortDirection === preferences.sortDirection &&
+      prev.showCompleted === preferences.showCompleted &&
+      prev.showDeleted === preferences.showDeleted &&
+      prev.pageSize === preferences.pageSize &&
+      prev.searchKeyword !== preferences.searchKeyword;
+
+    if (onlySearchChanged) {
+      if (searchSyncTimeoutRef.current != null) {
+        clearTimeout(searchSyncTimeoutRef.current);
+      }
+      searchSyncTimeoutRef.current = setTimeout(() => {
+        searchSyncTimeoutRef.current = null;
+        syncToUrl(preferencesRef.current);
+      }, SEARCH_SYNC_DEBOUNCE_MS);
+    } else {
+      if (searchSyncTimeoutRef.current != null) {
+        clearTimeout(searchSyncTimeoutRef.current);
+        searchSyncTimeoutRef.current = null;
+      }
+      syncToUrl(preferences);
+    }
+
+    return () => {
+      if (searchSyncTimeoutRef.current != null) {
+        clearTimeout(searchSyncTimeoutRef.current);
+        searchSyncTimeoutRef.current = null;
+      }
+    };
+  }, [preferences, syncToUrl]);
 
   return { preferences, setPreferences };
 }

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -28,6 +28,9 @@ const URL_PARAM_PITCH_NO_START = 'pitchNoStart';
 const URL_PARAM_PITCH_NO_END = 'pitchNoEnd';
 const URL_PARAM_LOOK_AHEAD_STATUS = 'lookAheadStatus';
 const URL_PARAM_LOOK_AHEAD_SECTION = 'lookAheadSection';
+const URL_PARAM_DATE_CONFIRMED = 'dateConfirmed';
+const URL_PARAM_TIME_CONFIRMED = 'timeConfirmed';
+const URL_PARAM_TAG = 'tag';
 
 /** Delay before syncing search keyword to URL so the input keeps focus while typing. */
 const SEARCH_SYNC_DEBOUNCE_MS = 400;
@@ -169,6 +172,26 @@ function parseFromSearchParams(
           .filter(Boolean)
       : [];
 
+  const dateConfirmedParam = searchParams.get(URL_PARAM_DATE_CONFIRMED)?.trim();
+  const dateConfirmedFilter: ActivityFilterState['dateConfirmedFilter'] =
+    dateConfirmedParam === 'confirmed' || dateConfirmedParam === 'not_confirmed'
+      ? dateConfirmedParam
+      : 'any';
+  const timeConfirmedParam = searchParams.get(URL_PARAM_TIME_CONFIRMED)?.trim();
+  const timeConfirmedFilter: ActivityFilterState['timeConfirmedFilter'] =
+    timeConfirmedParam === 'confirmed' || timeConfirmedParam === 'not_confirmed'
+      ? timeConfirmedParam
+      : 'any';
+
+  const tagParam = searchParams.get(URL_PARAM_TAG);
+  const tagIds =
+    typeof tagParam === 'string' && tagParam.trim()
+      ? tagParam
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n))
+      : [];
+
   const filterState: ActivityFilterState = {
     dateRange: {
       startDate: dateFrom,
@@ -182,6 +205,9 @@ function parseFromSearchParams(
     pitchDateFilter,
     lookAheadStatusValues,
     lookAheadSectionValues,
+    dateConfirmedFilter,
+    timeConfirmedFilter,
+    tagIds,
   };
 
   return {
@@ -293,6 +319,23 @@ function parseFromStorage(
               (s): s is string => typeof s === 'string'
             )
           : [];
+        const dateConfirmedFilterValue = rawFilter.dateConfirmedFilter;
+        const dateConfirmedFilter: ActivityFilterState['dateConfirmedFilter'] =
+          dateConfirmedFilterValue === 'confirmed' ||
+          dateConfirmedFilterValue === 'not_confirmed'
+            ? dateConfirmedFilterValue
+            : 'any';
+        const timeConfirmedFilterValue = rawFilter.timeConfirmedFilter;
+        const timeConfirmedFilter: ActivityFilterState['timeConfirmedFilter'] =
+          timeConfirmedFilterValue === 'confirmed' ||
+          timeConfirmedFilterValue === 'not_confirmed'
+            ? timeConfirmedFilterValue
+            : 'any';
+        const tagIds = Array.isArray(rawFilter.tagIds)
+          ? (rawFilter.tagIds as number[]).filter(
+              (n): n is number => typeof n === 'number' && Number.isFinite(n)
+            )
+          : [];
         filterState = {
           dateRange: {
             startDate: typeof dr.startDate === 'string' ? dr.startDate : '',
@@ -314,6 +357,9 @@ function parseFromStorage(
           pitchDateFilter,
           lookAheadStatusValues,
           lookAheadSectionValues,
+          dateConfirmedFilter,
+          timeConfirmedFilter,
+          tagIds,
         };
       }
     }
@@ -353,7 +399,10 @@ function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
     searchParams.has(URL_PARAM_PITCH_NO_START) ||
     searchParams.has(URL_PARAM_PITCH_NO_END) ||
     searchParams.has(URL_PARAM_LOOK_AHEAD_STATUS) ||
-    searchParams.has(URL_PARAM_LOOK_AHEAD_SECTION)
+    searchParams.has(URL_PARAM_LOOK_AHEAD_SECTION) ||
+    searchParams.has(URL_PARAM_DATE_CONFIRMED) ||
+    searchParams.has(URL_PARAM_TIME_CONFIRMED) ||
+    searchParams.has(URL_PARAM_TAG)
   );
 }
 
@@ -394,6 +443,11 @@ function preferencesToParams(
     [URL_PARAM_PITCH_DATE_KIND]: f.pitchDateFilter.kind,
     [URL_PARAM_LOOK_AHEAD_STATUS]: f.lookAheadStatusValues.join(','),
     [URL_PARAM_LOOK_AHEAD_SECTION]: f.lookAheadSectionValues.join(','),
+    [URL_PARAM_DATE_CONFIRMED]:
+      f.dateConfirmedFilter === 'any' ? '' : f.dateConfirmedFilter,
+    [URL_PARAM_TIME_CONFIRMED]:
+      f.timeConfirmedFilter === 'any' ? '' : f.timeConfirmedFilter,
+    [URL_PARAM_TAG]: f.tagIds.join(','),
   };
   if (f.pitchDateFilter.kind === 'scheduled') {
     const dr = f.pitchDateFilter.dateRange;

--- a/calendar-ui/src/hooks/useActivityTablePreferences.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.ts
@@ -26,6 +26,8 @@ const URL_PARAM_PITCH_DATE_FROM = 'pitchDateFrom';
 const URL_PARAM_PITCH_DATE_TO = 'pitchDateTo';
 const URL_PARAM_PITCH_NO_START = 'pitchNoStart';
 const URL_PARAM_PITCH_NO_END = 'pitchNoEnd';
+const URL_PARAM_LOOK_AHEAD_STATUS = 'lookAheadStatus';
+const URL_PARAM_LOOK_AHEAD_SECTION = 'lookAheadSection';
 
 /** Delay before syncing search keyword to URL so the input keeps focus while typing. */
 const SEARCH_SYNC_DEBOUNCE_MS = 400;
@@ -150,6 +152,23 @@ function parseFromSearchParams(
     };
   }
 
+  const lookAheadStatusParam = searchParams.get(URL_PARAM_LOOK_AHEAD_STATUS);
+  const lookAheadStatusValues =
+    typeof lookAheadStatusParam === 'string' && lookAheadStatusParam.trim()
+      ? lookAheadStatusParam
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const lookAheadSectionParam = searchParams.get(URL_PARAM_LOOK_AHEAD_SECTION);
+  const lookAheadSectionValues =
+    typeof lookAheadSectionParam === 'string' && lookAheadSectionParam.trim()
+      ? lookAheadSectionParam
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
   const filterState: ActivityFilterState = {
     dateRange: {
       startDate: dateFrom,
@@ -161,6 +180,8 @@ function parseFromSearchParams(
     activityStatusIds,
     pitchRequiredStatusNames,
     pitchDateFilter,
+    lookAheadStatusValues,
+    lookAheadSectionValues,
   };
 
   return {
@@ -258,6 +279,20 @@ function parseFromStorage(
             },
           };
         }
+        const lookAheadStatusValues = Array.isArray(
+          rawFilter.lookAheadStatusValues
+        )
+          ? (rawFilter.lookAheadStatusValues as string[]).filter(
+              (s): s is string => typeof s === 'string'
+            )
+          : [];
+        const lookAheadSectionValues = Array.isArray(
+          rawFilter.lookAheadSectionValues
+        )
+          ? (rawFilter.lookAheadSectionValues as string[]).filter(
+              (s): s is string => typeof s === 'string'
+            )
+          : [];
         filterState = {
           dateRange: {
             startDate: typeof dr.startDate === 'string' ? dr.startDate : '',
@@ -277,6 +312,8 @@ function parseFromStorage(
             : [],
           pitchRequiredStatusNames,
           pitchDateFilter,
+          lookAheadStatusValues,
+          lookAheadSectionValues,
         };
       }
     }
@@ -314,7 +351,9 @@ function hasAnyKnownParam(searchParams: URLSearchParams): boolean {
     searchParams.has(URL_PARAM_PITCH_DATE_FROM) ||
     searchParams.has(URL_PARAM_PITCH_DATE_TO) ||
     searchParams.has(URL_PARAM_PITCH_NO_START) ||
-    searchParams.has(URL_PARAM_PITCH_NO_END)
+    searchParams.has(URL_PARAM_PITCH_NO_END) ||
+    searchParams.has(URL_PARAM_LOOK_AHEAD_STATUS) ||
+    searchParams.has(URL_PARAM_LOOK_AHEAD_SECTION)
   );
 }
 
@@ -353,6 +392,8 @@ function preferencesToParams(
     [URL_PARAM_STATUS]: f.activityStatusIds.join(','),
     [URL_PARAM_PITCH_STATUS]: f.pitchRequiredStatusNames.join(','),
     [URL_PARAM_PITCH_DATE_KIND]: f.pitchDateFilter.kind,
+    [URL_PARAM_LOOK_AHEAD_STATUS]: f.lookAheadStatusValues.join(','),
+    [URL_PARAM_LOOK_AHEAD_SECTION]: f.lookAheadSectionValues.join(','),
   };
   if (f.pitchDateFilter.kind === 'scheduled') {
     const dr = f.pitchDateFilter.dateRange;

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -208,6 +208,88 @@ describe('filterActivityRowsByFilters', () => {
     expect(result.map((r) => r.id)).toEqual([1, 3]);
   });
 
+  it('filters by pitch required status names (case-insensitive)', () => {
+    const rows = [
+      makeRow({ id: 1, pitchRequiredStatus: 'Required' }),
+      makeRow({ id: 2, pitchRequiredStatus: 'Not required' }),
+      makeRow({ id: 3, pitchRequiredStatus: 'TBD' }),
+      makeRow({ id: 4, pitchRequiredStatus: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      pitchRequiredStatusNames: ['required', 'tbd'],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 3]);
+  });
+
+  it('does not filter by pitch status when pitchRequiredStatusNames is empty', () => {
+    const rows = [
+      makeRow({ id: 1, pitchRequiredStatus: 'Required' }),
+      makeRow({ id: 2, pitchRequiredStatus: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      pitchRequiredStatusNames: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by pitch date not_scheduled (row must have no pitch date)', () => {
+    const rows = [
+      makeRow({ id: 1, pitchDate: null }),
+      makeRow({ id: 2, pitchDate: '2025-03-01' }),
+      makeRow({ id: 3, pitchDate: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      pitchDateFilter: { kind: 'not_scheduled' },
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 3]);
+  });
+
+  it('filters by pitch date scheduled with date range', () => {
+    const rows = [
+      makeRow({ id: 1, pitchDate: '2025-02-15' }),
+      makeRow({ id: 2, pitchDate: '2025-01-10' }),
+      makeRow({ id: 3, pitchDate: '2025-03-20' }),
+      makeRow({ id: 4, pitchDate: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      pitchDateFilter: {
+        kind: 'scheduled',
+        dateRange: {
+          startDate: '2025-02-01',
+          endDate: '2025-02-28',
+          noStartDate: false,
+          noEndDate: false,
+        },
+      },
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('pitch date scheduled with empty range includes all rows with pitch date', () => {
+    const rows = [
+      makeRow({ id: 1, pitchDate: '2025-02-15' }),
+      makeRow({ id: 2, pitchDate: '2024-01-01' }),
+      makeRow({ id: 3, pitchDate: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      pitchDateFilter: {
+        kind: 'scheduled',
+        dateRange: {
+          startDate: '',
+          endDate: '',
+          noStartDate: false,
+          noEndDate: false,
+        },
+      },
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
   it('filters by date range (activity start and end must fall within range)', () => {
     const rows = [
       makeRow({

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -60,12 +60,12 @@ describe('normalizeListParams', () => {
     expect(normalizeListParams({})).toEqual({});
   });
 
-  it('includes only excludeCompleted when provided', () => {
-    expect(normalizeListParams({ excludeCompleted: true })).toEqual({
-      excludeCompleted: true,
+  it('includes only includeCompleted when provided', () => {
+    expect(normalizeListParams({ includeCompleted: true })).toEqual({
+      includeCompleted: true,
     });
-    expect(normalizeListParams({ excludeCompleted: false })).toEqual({
-      excludeCompleted: false,
+    expect(normalizeListParams({ includeCompleted: false })).toEqual({
+      includeCompleted: false,
     });
   });
 
@@ -81,30 +81,30 @@ describe('normalizeListParams', () => {
   it('includes both keys when both provided', () => {
     expect(
       normalizeListParams({
-        excludeCompleted: false,
+        includeCompleted: false,
         includeDeleted: true,
       })
-    ).toEqual({ excludeCompleted: false, includeDeleted: true });
+    ).toEqual({ includeCompleted: false, includeDeleted: true });
   });
 
   it('omits keys when value is undefined for stable query key', () => {
     expect(
       normalizeListParams({
-        excludeCompleted: undefined,
+        includeCompleted: undefined,
         includeDeleted: undefined,
       })
     ).toEqual({});
   });
 
-  it('copies only excludeCompleted and includeDeleted when params have extra keys', () => {
+  it('copies only includeCompleted and includeDeleted when params have extra keys', () => {
     const params = {
-      excludeCompleted: true,
+      includeCompleted: true,
       includeDeleted: false,
       page: 1,
       limit: 20,
     } as Parameters<typeof normalizeListParams>[0];
     expect(normalizeListParams(params)).toEqual({
-      excludeCompleted: true,
+      includeCompleted: true,
       includeDeleted: false,
     });
   });
@@ -112,10 +112,10 @@ describe('normalizeListParams', () => {
   it('includes leadTeamId, commsContactLeadUserId, sharedWithTeamId, sharedWithTeamIds when provided', () => {
     expect(
       normalizeListParams({
-        excludeCompleted: true,
+        includeCompleted: true,
         leadTeamId: 5,
       })
-    ).toEqual({ excludeCompleted: true, leadTeamId: 5 });
+    ).toEqual({ includeCompleted: true, leadTeamId: 5 });
     expect(
       normalizeListParams({
         commsContactLeadUserId: 10,
@@ -132,18 +132,14 @@ describe('normalizeListParams', () => {
     ).toEqual({ sharedWithTeamIds: [1, 2, 3] });
   });
 
-  it('includes date and activityStatusId when provided', () => {
+  it('omits date and activityStatusId (filtered client-side)', () => {
     expect(
       normalizeListParams({
         startDateFrom: '2025-01-01',
         startDateTo: '2025-01-31',
         activityStatusId: 2,
-      })
-    ).toEqual({
-      startDateFrom: '2025-01-01',
-      startDateTo: '2025-01-31',
-      activityStatusId: 2,
-    });
+      } as Parameters<typeof normalizeListParams>[0])
+    ).toEqual({});
   });
 });
 
@@ -206,6 +202,92 @@ describe('filterActivityRowsByFilters', () => {
       activityStatusIds: [1, 3],
     });
     expect(result.map((r) => r.id)).toEqual([1, 3]);
+  });
+
+  it('filters by date range (activity start and end must fall within range)', () => {
+    const rows = [
+      makeRow({
+        id: 1,
+        startDate: '2025-01-15',
+        endDate: '2025-01-20',
+      }),
+      makeRow({
+        id: 2,
+        startDate: '2024-12-01',
+        endDate: '2024-12-31',
+      }),
+      makeRow({
+        id: 3,
+        startDate: '2025-02-01',
+        endDate: '2025-02-28',
+      }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateRange: {
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        noStartDate: false,
+        noEndDate: false,
+      },
+      categoryNames: [],
+      activityStatusIds: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('filters by look-ahead status', () => {
+    const rows = [
+      makeRow({ id: 1, lookAheadStatus: 'new', lookAheadSection: 'events' }),
+      makeRow({
+        id: 2,
+        lookAheadStatus: 'changed',
+        lookAheadSection: 'issues',
+      }),
+      makeRow({ id: 3, lookAheadStatus: 'none', lookAheadSection: 'news' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      lookAheadStatusValues: ['new', 'changed'],
+      lookAheadSectionValues: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by look-ahead section', () => {
+    const rows = [
+      makeRow({ id: 1, lookAheadStatus: 'new', lookAheadSection: 'events' }),
+      makeRow({
+        id: 2,
+        lookAheadStatus: 'changed',
+        lookAheadSection: 'issues',
+      }),
+      makeRow({ id: 3, lookAheadStatus: 'none', lookAheadSection: 'news' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      lookAheadStatusValues: [],
+      lookAheadSectionValues: ['events', 'news'],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 3]);
+  });
+
+  it('filters by both look-ahead status and section (AND)', () => {
+    const rows = [
+      makeRow({ id: 1, lookAheadStatus: 'new', lookAheadSection: 'events' }),
+      makeRow({ id: 2, lookAheadStatus: 'new', lookAheadSection: 'issues' }),
+      makeRow({
+        id: 3,
+        lookAheadStatus: 'changed',
+        lookAheadSection: 'events',
+      }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      lookAheadStatusValues: ['new'],
+      lookAheadSectionValues: ['events'],
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
   });
 });
 

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -62,6 +62,29 @@ describe('normalizeListParams', () => {
       includeDeleted: false,
     });
   });
+
+  it('includes leadTeamId, commsContactLeadUserId, sharedWithTeamId, sharedWithTeamIds when provided', () => {
+    expect(
+      normalizeListParams({
+        excludeCompleted: true,
+        leadTeamId: 5,
+      })
+    ).toEqual({ excludeCompleted: true, leadTeamId: 5 });
+    expect(
+      normalizeListParams({
+        commsContactLeadUserId: 10,
+        sharedWithTeamId: 3,
+      })
+    ).toEqual({
+      commsContactLeadUserId: 10,
+      sharedWithTeamId: 3,
+    });
+    expect(
+      normalizeListParams({
+        sharedWithTeamIds: [3, 1, 2],
+      })
+    ).toEqual({ sharedWithTeamIds: [1, 2, 3] });
+  });
 });
 
 describe('buildOptimisticActivity', () => {

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -541,6 +541,68 @@ describe('filterActivityRowsByFilters', () => {
     });
     expect(result.map((r) => r.id)).toEqual([1]);
   });
+
+  it('filters by translationLanguageIds when context provides options', () => {
+    const rows = [
+      makeRow({ id: 1, translationsRequired: ['French', 'Spanish'] }),
+      makeRow({ id: 2, translationsRequired: ['Spanish'] }),
+      makeRow({ id: 3, translationsRequired: [] }),
+      makeRow({ id: 4, translationsRequired: ['fr'] }),
+    ];
+    const context = {
+      translationLanguageOptions: [
+        { value: '10', label: 'French' },
+        { value: '20', label: 'Spanish' },
+        { value: '30', label: 'fr' },
+      ],
+    };
+    const result = filterActivityRowsByFilters(
+      rows,
+      {
+        ...DEFAULT_ACTIVITY_FILTER_STATE,
+        translationLanguageIds: [10, 30],
+      },
+      context
+    );
+    expect(result.map((r) => r.id)).toEqual([1, 4]);
+  });
+
+  it('does not filter by translations when translationLanguageIds is empty', () => {
+    const rows = [
+      makeRow({ id: 1, translationsRequired: ['French'] }),
+      makeRow({ id: 2, translationsRequired: [] }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      translationLanguageIds: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by translationRequiredStatusIds when context provides options', () => {
+    const rows = [
+      makeRow({ id: 1, translationsRequiredStatus: 'Required' }),
+      makeRow({ id: 2, translationsRequiredStatus: 'Pending' }),
+      makeRow({ id: 3, translationsRequiredStatus: null }),
+      makeRow({ id: 4, translationsRequiredStatus: 'Required' }),
+    ];
+    const context = {
+      translationRequiredStatusOptions: [
+        { value: '1', label: 'Pending' },
+        { value: '2', label: 'Required' },
+        { value: '3', label: 'Not required' },
+      ],
+    };
+    const result = filterActivityRowsByFilters(
+      rows,
+      {
+        ...DEFAULT_ACTIVITY_FILTER_STATE,
+        translationRequiredStatusIds: [2],
+      },
+      context
+    );
+    expect(result.map((r) => r.id)).toEqual([1, 4]);
+  });
 });
 
 describe('buildOptimisticActivity', () => {

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -42,6 +42,10 @@ function makeRow(overrides: Partial<ActivityTableRow> = {}): ActivityTableRow {
     commsLeadName: null,
     commsContactsCount: 0,
     eventLead: null,
+    leadMinistryId: null,
+    leadOrgId: null,
+    commsContactLeadUserId: null,
+    eventPlannerLeadId: null,
     translationsRequired: [],
     translationsRequiredStatus: null,
     commsMaterials: [],
@@ -374,6 +378,86 @@ describe('filterActivityRowsByFilters', () => {
       tagIds: [],
     });
     expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by leadMinistryIds', () => {
+    const rows = [
+      makeRow({ id: 1, leadMinistryId: 10 }),
+      makeRow({ id: 2, leadMinistryId: 20 }),
+      makeRow({ id: 3, leadMinistryId: null }),
+      makeRow({ id: 4, leadMinistryId: 10 }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      leadMinistryIds: [10, 30],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 4]);
+  });
+
+  it('filters by leadOrgIds', () => {
+    const rows = [
+      makeRow({ id: 1, leadOrgId: 5 }),
+      makeRow({ id: 2, leadOrgId: 6 }),
+      makeRow({ id: 3, leadOrgId: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      leadOrgIds: [5],
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('filters by commsContactLeadUserIds', () => {
+    const rows = [
+      makeRow({ id: 1, commsContactLeadUserId: 100 }),
+      makeRow({ id: 2, commsContactLeadUserId: 200 }),
+      makeRow({ id: 3, commsContactLeadUserId: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      commsContactLeadUserIds: [100, 300],
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('filters by eventPlannerLeadIds', () => {
+    const rows = [
+      makeRow({ id: 1, eventPlannerLeadId: 1 }),
+      makeRow({ id: 2, eventPlannerLeadId: 2 }),
+      makeRow({ id: 3, eventPlannerLeadId: null }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      eventPlannerLeadIds: [2],
+    });
+    expect(result.map((r) => r.id)).toEqual([2]);
+  });
+
+  it('applies AND across lead types when multiple lead filters are set', () => {
+    const rows = [
+      makeRow({
+        id: 1,
+        leadMinistryId: 10,
+        leadOrgId: 5,
+        commsContactLeadUserId: 100,
+        eventPlannerLeadId: 1,
+      }),
+      makeRow({
+        id: 2,
+        leadMinistryId: 10,
+        leadOrgId: 99,
+        commsContactLeadUserId: 100,
+        eventPlannerLeadId: 1,
+      }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      leadMinistryIds: [10],
+      leadOrgIds: [5],
+      commsContactLeadUserIds: [100],
+      eventPlannerLeadIds: [1],
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
   });
 });
 

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -2,11 +2,54 @@ import { describe, expect, it } from 'vitest';
 
 import type { ActivityResponse } from '@corpcal/shared/api/types';
 import type { UpdateActivityRequest } from '@corpcal/shared/schemas';
+import type { ActivityTableRow } from '@/components/ActivityTable/activityTableRow';
 
 import {
   buildOptimisticActivity,
+  filterActivityRowsByKeyword,
   normalizeListParams,
 } from './activity-query-utils';
+
+function makeRow(overrides: Partial<ActivityTableRow> = {}): ActivityTableRow {
+  return {
+    id: 1,
+    displayId: null,
+    title: '',
+    activityCategories: [],
+    pitchDate: null,
+    pitchRequiredStatus: null,
+    isConfidential: false,
+    isIssue: false,
+    summary: '',
+    tags: [],
+    lookAheadStatus: null,
+    lookAheadSection: null,
+    allDay: false,
+    startDate: null,
+    endDate: null,
+    dateStatus: '',
+    startTime: null,
+    endTime: null,
+    timeStatus: '',
+    venue: null,
+    premierRequested: null,
+    activityRepresentatives: [],
+    leadOrg: null,
+    leadMinistry: null,
+    leadMinistryAbbreviation: null,
+    commsLeadName: null,
+    commsContactsCount: 0,
+    eventLead: null,
+    translationsRequired: [],
+    translationsRequiredStatus: null,
+    commsMaterials: [],
+    activityStatus: '',
+    lastUpdatedDateTime: '',
+    lastUpdatedBy: 0,
+    createdDateTime: '',
+    ...overrides,
+  };
+}
 
 describe('normalizeListParams', () => {
   it('returns empty object for no input', () => {
@@ -158,5 +201,63 @@ describe('buildOptimisticActivity', () => {
     const result = buildOptimisticActivity(minimalExisting, update);
     expect(result).toEqual(minimalExisting);
     expect(result).not.toBe(minimalExisting);
+  });
+});
+
+describe('filterActivityRowsByKeyword', () => {
+  it('returns all rows when keyword is empty', () => {
+    const rows = [
+      makeRow({ id: 1, title: 'Alpha' }),
+      makeRow({ id: 2, title: 'Beta' }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, '')).toEqual(rows);
+    expect(filterActivityRowsByKeyword(rows, '   ')).toEqual(rows);
+  });
+
+  it('matches in title (case-insensitive)', () => {
+    const rows = [
+      makeRow({ id: 1, title: 'Alpha Event' }),
+      makeRow({ id: 2, title: 'Beta Event' }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, 'alpha')).toEqual([rows[0]]);
+    expect(filterActivityRowsByKeyword(rows, 'ALPHA')).toEqual([rows[0]]);
+  });
+
+  it('matches in summary', () => {
+    const rows = [
+      makeRow({ id: 1, summary: 'First activity summary' }),
+      makeRow({ id: 2, summary: 'Second activity' }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, 'summary')).toEqual([rows[0]]);
+  });
+
+  it('matches in displayId', () => {
+    const rows = [
+      makeRow({ id: 1, displayId: 'AG-000123' }),
+      makeRow({ id: 2, displayId: 'HLTH-456' }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, 'AG-000123')).toEqual([rows[0]]);
+    expect(filterActivityRowsByKeyword(rows, '000123')).toEqual([rows[0]]);
+  });
+
+  it('returns empty array when no row matches', () => {
+    const rows = [
+      makeRow({ id: 1, title: 'Alpha', summary: 'One' }),
+      makeRow({ id: 2, title: 'Beta', summary: 'Two' }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, 'gamma')).toEqual([]);
+  });
+
+  it('matches in tags and activityCategories', () => {
+    const rows = [
+      makeRow({
+        id: 1,
+        title: 'X',
+        tags: [{ id: 1, text: 'environment' }],
+        activityCategories: ['Event'],
+      }),
+    ];
+    expect(filterActivityRowsByKeyword(rows, 'environment')).toEqual(rows);
+    expect(filterActivityRowsByKeyword(rows, 'Event')).toEqual(rows);
   });
 });

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import type { ActivityResponse } from '@corpcal/shared/api/types';
 import type { UpdateActivityRequest } from '@corpcal/shared/schemas';
+import { DEFAULT_ACTIVITY_FILTER_STATE } from '@/components/ActivityTable/activityFilterState';
 import type { ActivityTableRow } from '@/components/ActivityTable/activityTableRow';
 
 import {
   buildOptimisticActivity,
+  filterActivityRowsByFilters,
   filterActivityRowsByKeyword,
   normalizeListParams,
 } from './activity-query-utils';
@@ -44,6 +46,7 @@ function makeRow(overrides: Partial<ActivityTableRow> = {}): ActivityTableRow {
     translationsRequiredStatus: null,
     commsMaterials: [],
     activityStatus: '',
+    activityStatusId: 0,
     lastUpdatedDateTime: '',
     lastUpdatedBy: 0,
     createdDateTime: '',
@@ -127,6 +130,82 @@ describe('normalizeListParams', () => {
         sharedWithTeamIds: [3, 1, 2],
       })
     ).toEqual({ sharedWithTeamIds: [1, 2, 3] });
+  });
+
+  it('includes date and activityStatusId when provided', () => {
+    expect(
+      normalizeListParams({
+        startDateFrom: '2025-01-01',
+        startDateTo: '2025-01-31',
+        activityStatusId: 2,
+      })
+    ).toEqual({
+      startDateFrom: '2025-01-01',
+      startDateTo: '2025-01-31',
+      activityStatusId: 2,
+    });
+  });
+});
+
+describe('filterActivityRowsByFilters', () => {
+  it('returns all rows when filter state is empty', () => {
+    const rows = [
+      makeRow({ id: 1, activityCategories: ['Event'], activityStatusId: 1 }),
+      makeRow({ id: 2, activityCategories: ['Release'], activityStatusId: 2 }),
+    ];
+    expect(
+      filterActivityRowsByFilters(rows, {
+        ...DEFAULT_ACTIVITY_FILTER_STATE,
+        dateRange: {
+          startDate: '',
+          endDate: '',
+          noStartDate: false,
+          noEndDate: false,
+        },
+        categoryNames: [],
+        activityStatusIds: [],
+      })
+    ).toEqual(rows);
+  });
+
+  it('filters by category names', () => {
+    const rows = [
+      makeRow({ id: 1, activityCategories: ['Event', 'Release'] }),
+      makeRow({ id: 2, activityCategories: ['FYI'] }),
+      makeRow({ id: 3, activityCategories: [] }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateRange: {
+        startDate: '',
+        endDate: '',
+        noStartDate: false,
+        noEndDate: false,
+      },
+      categoryNames: ['Event', 'FYI'],
+      activityStatusIds: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by activity status IDs', () => {
+    const rows = [
+      makeRow({ id: 1, activityStatusId: 1 }),
+      makeRow({ id: 2, activityStatusId: 2 }),
+      makeRow({ id: 3, activityStatusId: 3 }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateRange: {
+        startDate: '',
+        endDate: '',
+        noStartDate: false,
+        noEndDate: false,
+      },
+      categoryNames: [],
+      activityStatusIds: [1, 3],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 3]);
   });
 });
 

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -289,6 +289,92 @@ describe('filterActivityRowsByFilters', () => {
     });
     expect(result.map((r) => r.id)).toEqual([1]);
   });
+
+  it('filters by date confirmed only', () => {
+    const rows = [
+      makeRow({ id: 1, dateStatus: 'Confirmed', timeStatus: 'unknown' }),
+      makeRow({ id: 2, dateStatus: 'unknown', timeStatus: 'unknown' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateConfirmedFilter: 'confirmed',
+      timeConfirmedFilter: 'any',
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('filters by time not_confirmed only', () => {
+    const rows = [
+      makeRow({ id: 1, dateStatus: 'Confirmed', timeStatus: 'Confirmed' }),
+      makeRow({ id: 2, dateStatus: 'Confirmed', timeStatus: 'Not confirmed' }),
+      makeRow({ id: 3, dateStatus: 'unknown', timeStatus: 'unknown' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateConfirmedFilter: 'any',
+      timeConfirmedFilter: 'not_confirmed',
+    });
+    expect(result.map((r) => r.id)).toEqual([2, 3]);
+  });
+
+  it('filters by both date and time confirmed (AND)', () => {
+    const rows = [
+      makeRow({ id: 1, dateStatus: 'Confirmed', timeStatus: 'Confirmed' }),
+      makeRow({ id: 2, dateStatus: 'confirmed', timeStatus: 'Not confirmed' }),
+      makeRow({ id: 3, dateStatus: 'unknown', timeStatus: 'unknown' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateConfirmedFilter: 'confirmed',
+      timeConfirmedFilter: 'confirmed',
+    });
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('does not filter by confirmation when both are any', () => {
+    const rows = [
+      makeRow({ id: 1, dateStatus: 'Confirmed', timeStatus: 'Confirmed' }),
+      makeRow({ id: 2, dateStatus: 'unknown', timeStatus: 'unknown' }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      dateConfirmedFilter: 'any',
+      timeConfirmedFilter: 'any',
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('filters by tagIds (row must have at least one matching tag)', () => {
+    const rows = [
+      makeRow({
+        id: 1,
+        tags: [
+          { id: 10, text: 'env' },
+          { id: 20, text: 'health' },
+        ],
+      }),
+      makeRow({ id: 2, tags: [{ id: 20, text: 'health' }] }),
+      makeRow({ id: 3, tags: [{ id: 30, text: 'other' }] }),
+      makeRow({ id: 4, tags: [] }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      tagIds: [20, 40],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('does not filter by tags when tagIds is empty', () => {
+    const rows = [
+      makeRow({ id: 1, tags: [{ id: 10, text: 'a' }] }),
+      makeRow({ id: 2, tags: [] }),
+    ];
+    const result = filterActivityRowsByFilters(rows, {
+      ...DEFAULT_ACTIVITY_FILTER_STATE,
+      tagIds: [],
+    });
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
 });
 
 describe('buildOptimisticActivity', () => {

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -58,14 +58,41 @@ function isDateInRange(
 }
 
 /**
- * Client-side filter by category (names), status (IDs), and pitch (status names + date).
- * Date filtering is done server-side via query params.
+ * Client-side filter by date range, category (names), status (IDs), and pitch (status names + date).
+ * Same semantics as backend: activity start and end must fall within the filter range.
  */
 export function filterActivityRowsByFilters(
   rows: ActivityTableRow[],
   filterState: ActivityFilterState
 ): ActivityTableRow[] {
   let result = rows;
+
+  const dr = filterState.dateRange;
+  const dateRangeActive =
+    dr.startDate !== '' || dr.endDate !== '' || dr.noStartDate || dr.noEndDate;
+  if (dateRangeActive) {
+    result = result.filter((row) => {
+      const start = row.startDate ?? '';
+      const end = row.endDate ?? '';
+      if (start === '' || end === '') return false;
+      return (
+        isDateInRange(
+          start,
+          dr.startDate,
+          dr.endDate,
+          dr.noStartDate,
+          dr.noEndDate
+        ) &&
+        isDateInRange(
+          end,
+          dr.startDate,
+          dr.endDate,
+          dr.noStartDate,
+          dr.noEndDate
+        )
+      );
+    });
+  }
 
   if (filterState.categoryNames.length > 0) {
     const set = new Set(
@@ -114,24 +141,35 @@ export function filterActivityRowsByFilters(
     });
   }
 
+  if (filterState.lookAheadStatusValues.length > 0) {
+    const statusSet = new Set(filterState.lookAheadStatusValues);
+    result = result.filter((row) => {
+      const status = row.lookAheadStatus ?? null;
+      return status !== null && statusSet.has(status);
+    });
+  }
+
+  if (filterState.lookAheadSectionValues.length > 0) {
+    const sectionSet = new Set(filterState.lookAheadSectionValues);
+    result = result.filter((row) => {
+      const section = row.lookAheadSection ?? null;
+      return section !== null && sectionSet.has(section);
+    });
+  }
+
   return result;
 }
 
-/** Params for activity list query. */
+/** Params for activity list query (archive + context only; date/status filtered client-side). */
 export type ActivityListQueryParams = Partial<
   Pick<
     FilterActivitiesQueryParams,
-    | 'excludeCompleted'
+    | 'includeCompleted'
     | 'includeDeleted'
     | 'leadTeamId'
     | 'commsContactLeadUserId'
     | 'sharedWithTeamId'
     | 'sharedWithTeamIds'
-    | 'startDateFrom'
-    | 'startDateTo'
-    | 'endDateFrom'
-    | 'endDateTo'
-    | 'activityStatusId'
   >
 >;
 
@@ -140,20 +178,15 @@ export function normalizeListParams(
   params: ActivityListQueryParams = {}
 ): ActivityListQueryParams {
   const {
-    excludeCompleted,
+    includeCompleted,
     includeDeleted,
     leadTeamId,
     commsContactLeadUserId,
     sharedWithTeamId,
     sharedWithTeamIds,
-    startDateFrom,
-    startDateTo,
-    endDateFrom,
-    endDateTo,
-    activityStatusId,
   } = params;
   const out: ActivityListQueryParams = {};
-  if (excludeCompleted !== undefined) out.excludeCompleted = excludeCompleted;
+  if (includeCompleted !== undefined) out.includeCompleted = includeCompleted;
   if (includeDeleted !== undefined) out.includeDeleted = includeDeleted;
   if (leadTeamId !== undefined) out.leadTeamId = leadTeamId;
   if (commsContactLeadUserId !== undefined)
@@ -161,14 +194,6 @@ export function normalizeListParams(
   if (sharedWithTeamId !== undefined) out.sharedWithTeamId = sharedWithTeamId;
   if (sharedWithTeamIds !== undefined && sharedWithTeamIds.length > 0)
     out.sharedWithTeamIds = [...sharedWithTeamIds].sort((a, b) => a - b);
-  if (startDateFrom !== undefined && startDateFrom !== '')
-    out.startDateFrom = startDateFrom;
-  if (startDateTo !== undefined && startDateTo !== '')
-    out.startDateTo = startDateTo;
-  if (endDateFrom !== undefined && endDateFrom !== '')
-    out.endDateFrom = endDateFrom;
-  if (endDateTo !== undefined && endDateTo !== '') out.endDateTo = endDateTo;
-  if (activityStatusId !== undefined) out.activityStatusId = activityStatusId;
   return out;
 }
 

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -3,6 +3,7 @@ import type {
   FilterActivitiesQueryParams,
   UpdateActivityRequest,
 } from '@corpcal/shared/schemas';
+import type { ActivityFilterState } from '@/components/ActivityTable/activityFilterState';
 import type { ActivityTableRow } from '@/components/ActivityTable/activityTableRow';
 
 /**
@@ -39,7 +40,84 @@ export function filterActivityRowsByKeyword(
   });
 }
 
-/** Params for activity list query; extend with sort, search, etc. later. */
+/**
+ * Returns true when a single ISO date string falls within the given range.
+ * noStartDate = no lower bound; noEndDate = no upper bound.
+ */
+function isDateInRange(
+  isoDate: string,
+  startDate: string,
+  endDate: string,
+  noStartDate: boolean,
+  noEndDate: boolean
+): boolean {
+  const d = isoDate.slice(0, 10);
+  if (!noStartDate && startDate !== '' && d < startDate) return false;
+  if (!noEndDate && endDate !== '' && d > endDate) return false;
+  return true;
+}
+
+/**
+ * Client-side filter by category (names), status (IDs), and pitch (status names + date).
+ * Date filtering is done server-side via query params.
+ */
+export function filterActivityRowsByFilters(
+  rows: ActivityTableRow[],
+  filterState: ActivityFilterState
+): ActivityTableRow[] {
+  let result = rows;
+
+  if (filterState.categoryNames.length > 0) {
+    const set = new Set(
+      filterState.categoryNames.map((n) => n.toLowerCase().trim())
+    );
+    result = result.filter((row) =>
+      row.activityCategories.some((c) => set.has(c.toLowerCase().trim()))
+    );
+  }
+
+  if (filterState.activityStatusIds.length > 0) {
+    const statusSet = new Set(filterState.activityStatusIds);
+    result = result.filter((row) => statusSet.has(row.activityStatusId));
+  }
+
+  if (filterState.pitchRequiredStatusNames.length > 0) {
+    const pitchSet = new Set(
+      filterState.pitchRequiredStatusNames.map((n) => n.trim().toLowerCase())
+    );
+    result = result.filter((row) => {
+      const status = row.pitchRequiredStatus?.trim().toLowerCase() ?? '';
+      return status !== '' && pitchSet.has(status);
+    });
+  }
+
+  const pdf = filterState.pitchDateFilter;
+  if (pdf.kind === 'not_scheduled') {
+    result = result.filter((row) => row.pitchDate == null);
+  } else if (pdf.kind === 'scheduled') {
+    result = result.filter((row) => {
+      if (row.pitchDate == null) return false;
+      const dr = pdf.dateRange;
+      const rangeActive =
+        dr.startDate !== '' ||
+        dr.endDate !== '' ||
+        dr.noStartDate ||
+        dr.noEndDate;
+      if (!rangeActive) return true;
+      return isDateInRange(
+        row.pitchDate,
+        dr.startDate,
+        dr.endDate,
+        dr.noStartDate,
+        dr.noEndDate
+      );
+    });
+  }
+
+  return result;
+}
+
+/** Params for activity list query. */
 export type ActivityListQueryParams = Partial<
   Pick<
     FilterActivitiesQueryParams,
@@ -49,6 +127,11 @@ export type ActivityListQueryParams = Partial<
     | 'commsContactLeadUserId'
     | 'sharedWithTeamId'
     | 'sharedWithTeamIds'
+    | 'startDateFrom'
+    | 'startDateTo'
+    | 'endDateFrom'
+    | 'endDateTo'
+    | 'activityStatusId'
   >
 >;
 
@@ -63,6 +146,11 @@ export function normalizeListParams(
     commsContactLeadUserId,
     sharedWithTeamId,
     sharedWithTeamIds,
+    startDateFrom,
+    startDateTo,
+    endDateFrom,
+    endDateTo,
+    activityStatusId,
   } = params;
   const out: ActivityListQueryParams = {};
   if (excludeCompleted !== undefined) out.excludeCompleted = excludeCompleted;
@@ -73,6 +161,14 @@ export function normalizeListParams(
   if (sharedWithTeamId !== undefined) out.sharedWithTeamId = sharedWithTeamId;
   if (sharedWithTeamIds !== undefined && sharedWithTeamIds.length > 0)
     out.sharedWithTeamIds = [...sharedWithTeamIds].sort((a, b) => a - b);
+  if (startDateFrom !== undefined && startDateFrom !== '')
+    out.startDateFrom = startDateFrom;
+  if (startDateTo !== undefined && startDateTo !== '')
+    out.startDateTo = startDateTo;
+  if (endDateFrom !== undefined && endDateFrom !== '')
+    out.endDateFrom = endDateFrom;
+  if (endDateTo !== undefined && endDateTo !== '') out.endDateTo = endDateTo;
+  if (activityStatusId !== undefined) out.activityStatusId = activityStatusId;
   return out;
 }
 

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -5,6 +5,7 @@ import type {
 } from '@corpcal/shared/schemas';
 import type { ActivityFilterState } from '@/components/ActivityTable/activityFilterState';
 import type { ActivityTableRow } from '@/components/ActivityTable/activityTableRow';
+import { CONFIRMED_STATUS_NAMES } from '@/lib/datetime-utils';
 
 /**
  * Client-side keyword filter for activity table rows.
@@ -155,6 +156,28 @@ export function filterActivityRowsByFilters(
       const section = row.lookAheadSection ?? null;
       return section !== null && sectionSet.has(section);
     });
+  }
+
+  const isStatusConfirmed = (s: string) =>
+    CONFIRMED_STATUS_NAMES.includes((s ?? '').trim().toLowerCase());
+  if (filterState.dateConfirmedFilter !== 'any') {
+    if (filterState.dateConfirmedFilter === 'confirmed') {
+      result = result.filter((row) => isStatusConfirmed(row.dateStatus));
+    } else {
+      result = result.filter((row) => !isStatusConfirmed(row.dateStatus));
+    }
+  }
+  if (filterState.timeConfirmedFilter !== 'any') {
+    if (filterState.timeConfirmedFilter === 'confirmed') {
+      result = result.filter((row) => isStatusConfirmed(row.timeStatus));
+    } else {
+      result = result.filter((row) => !isStatusConfirmed(row.timeStatus));
+    }
+  }
+
+  if (filterState.tagIds.length > 0) {
+    const tagIdSet = new Set(filterState.tagIds);
+    result = result.filter((row) => row.tags.some((t) => tagIdSet.has(t.id)));
   }
 
   return result;

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -180,6 +180,34 @@ export function filterActivityRowsByFilters(
     result = result.filter((row) => row.tags.some((t) => tagIdSet.has(t.id)));
   }
 
+  if (filterState.leadMinistryIds.length > 0) {
+    const ministrySet = new Set(filterState.leadMinistryIds);
+    result = result.filter(
+      (row) => row.leadMinistryId != null && ministrySet.has(row.leadMinistryId)
+    );
+  }
+  if (filterState.leadOrgIds.length > 0) {
+    const orgSet = new Set(filterState.leadOrgIds);
+    result = result.filter(
+      (row) => row.leadOrgId != null && orgSet.has(row.leadOrgId)
+    );
+  }
+  if (filterState.commsContactLeadUserIds.length > 0) {
+    const commsSet = new Set(filterState.commsContactLeadUserIds);
+    result = result.filter(
+      (row) =>
+        row.commsContactLeadUserId != null &&
+        commsSet.has(row.commsContactLeadUserId)
+    );
+  }
+  if (filterState.eventPlannerLeadIds.length > 0) {
+    const plannerSet = new Set(filterState.eventPlannerLeadIds);
+    result = result.filter(
+      (row) =>
+        row.eventPlannerLeadId != null && plannerSet.has(row.eventPlannerLeadId)
+    );
+  }
+
   return result;
 }
 

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -58,13 +58,23 @@ function isDateInRange(
   return true;
 }
 
+/** Optional context for filterActivityRowsByFilters (e.g. lookup options to resolve IDs to labels). */
+export interface FilterActivityRowsContext {
+  /** Options for translation required statuses (value = id, label = displayName matching row.translationsRequiredStatus). */
+  translationRequiredStatusOptions?: Array<{ value: string; label: string }>;
+  /** Options for translation languages (value = id, label = string that appears in row.translationsRequired). */
+  translationLanguageOptions?: Array<{ value: string; label: string }>;
+}
+
 /**
- * Client-side filter by date range, category (names), status (IDs), and pitch (status names + date).
- * Same semantics as backend: activity start and end must fall within the filter range.
+ * Client-side filter by date range, category (names), status (IDs), pitch, tags, leads, translations, etc.
+ * Same semantics as backend where applicable.
+ * Optional context provides lookup options to resolve filter IDs to labels (e.g. for translation languages).
  */
 export function filterActivityRowsByFilters(
   rows: ActivityTableRow[],
-  filterState: ActivityFilterState
+  filterState: ActivityFilterState,
+  context?: FilterActivityRowsContext
 ): ActivityTableRow[] {
   let result = rows;
 
@@ -205,6 +215,38 @@ export function filterActivityRowsByFilters(
     result = result.filter(
       (row) =>
         row.eventPlannerLeadId != null && plannerSet.has(row.eventPlannerLeadId)
+    );
+  }
+
+  if (
+    filterState.translationRequiredStatusIds.length > 0 &&
+    context?.translationRequiredStatusOptions
+  ) {
+    const idSet = new Set(filterState.translationRequiredStatusIds);
+    const statusLabelSet = new Set(
+      context.translationRequiredStatusOptions
+        .filter((opt) => idSet.has(parseInt(opt.value, 10)))
+        .map((opt) => opt.label)
+    );
+    result = result.filter(
+      (row) =>
+        row.translationsRequiredStatus != null &&
+        statusLabelSet.has(row.translationsRequiredStatus)
+    );
+  }
+
+  if (
+    filterState.translationLanguageIds.length > 0 &&
+    context?.translationLanguageOptions
+  ) {
+    const idSet = new Set(filterState.translationLanguageIds);
+    const labelSet = new Set(
+      context.translationLanguageOptions
+        .filter((opt) => idSet.has(parseInt(opt.value, 10)))
+        .map((opt) => opt.label)
+    );
+    result = result.filter((row) =>
+      row.translationsRequired.some((t) => labelSet.has(t))
     );
   }
 

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -3,6 +3,41 @@ import type {
   FilterActivitiesQueryParams,
   UpdateActivityRequest,
 } from '@corpcal/shared/schemas';
+import type { ActivityTableRow } from '@/components/ActivityTable/activityTableRow';
+
+/**
+ * Client-side keyword filter for activity table rows.
+ * Matches when the trimmed keyword appears (case-insensitive) in any searchable field.
+ * Returns all rows when keyword is empty.
+ */
+export function filterActivityRowsByKeyword(
+  rows: ActivityTableRow[],
+  keyword: string
+): ActivityTableRow[] {
+  const term = keyword.trim();
+  if (term === '') return rows;
+  const lower = term.toLowerCase();
+  return rows.filter((row) => {
+    const searchableValues: string[] = [
+      row.title,
+      row.displayId ?? '',
+      row.summary,
+      row.activityCategories.join(' '),
+      row.tags.map((t) => t.text).join(' '),
+      row.lookAheadStatus ?? '',
+      row.lookAheadSection ?? '',
+      row.venue ?? '',
+      row.leadOrg ?? '',
+      row.leadMinistryAbbreviation ?? '',
+      row.leadMinistry ?? '',
+      row.commsLeadName ?? '',
+      row.eventLead ?? '',
+      row.activityStatus,
+      row.activityRepresentatives.join(' '),
+    ];
+    return searchableValues.some((v) => v.toLowerCase().includes(lower));
+  });
+}
 
 /** Params for activity list query; extend with sort, search, etc. later. */
 export type ActivityListQueryParams = Partial<

--- a/calendar-ui/src/lib/activity-query-utils.ts
+++ b/calendar-ui/src/lib/activity-query-utils.ts
@@ -6,17 +6,38 @@ import type {
 
 /** Params for activity list query; extend with sort, search, etc. later. */
 export type ActivityListQueryParams = Partial<
-  Pick<FilterActivitiesQueryParams, 'excludeCompleted' | 'includeDeleted'>
+  Pick<
+    FilterActivitiesQueryParams,
+    | 'excludeCompleted'
+    | 'includeDeleted'
+    | 'leadTeamId'
+    | 'commsContactLeadUserId'
+    | 'sharedWithTeamId'
+    | 'sharedWithTeamIds'
+  >
 >;
 
 /** Normalize filters so the same logical view produces a stable query key. */
 export function normalizeListParams(
   params: ActivityListQueryParams = {}
 ): ActivityListQueryParams {
-  const { excludeCompleted, includeDeleted } = params;
+  const {
+    excludeCompleted,
+    includeDeleted,
+    leadTeamId,
+    commsContactLeadUserId,
+    sharedWithTeamId,
+    sharedWithTeamIds,
+  } = params;
   const out: ActivityListQueryParams = {};
   if (excludeCompleted !== undefined) out.excludeCompleted = excludeCompleted;
   if (includeDeleted !== undefined) out.includeDeleted = includeDeleted;
+  if (leadTeamId !== undefined) out.leadTeamId = leadTeamId;
+  if (commsContactLeadUserId !== undefined)
+    out.commsContactLeadUserId = commsContactLeadUserId;
+  if (sharedWithTeamId !== undefined) out.sharedWithTeamId = sharedWithTeamId;
+  if (sharedWithTeamIds !== undefined && sharedWithTeamIds.length > 0)
+    out.sharedWithTeamIds = [...sharedWithTeamIds].sort((a, b) => a - b);
   return out;
 }
 

--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Plus } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
 import type { TeamListItem } from '@corpcal/shared/api/types';
@@ -17,12 +17,45 @@ import { useLeadTeamOptions } from '@/hooks/useLeadTeamOptions';
 import { useMinistries } from '@/hooks/useLookups';
 import { cn } from '@/lib/utils';
 
+const ACTIVITY_LIST_TAB_STORAGE_KEY = 'activityListTab';
+
 type ActivityListTabValue =
   | 'all'
   | 'ministry'
   | 'my-activities'
   | 'recent'
   | 'shared-with-me';
+
+const ACTIVITY_LIST_TAB_VALUES: readonly ActivityListTabValue[] = [
+  'all',
+  'ministry',
+  'my-activities',
+  'recent',
+  'shared-with-me',
+];
+
+function getStoredActivityListTab(): ActivityListTabValue | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(ACTIVITY_LIST_TAB_STORAGE_KEY);
+    if (!raw) return null;
+    if (ACTIVITY_LIST_TAB_VALUES.includes(raw as ActivityListTabValue)) {
+      return raw as ActivityListTabValue;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredActivityListTab(tab: ActivityListTabValue): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(ACTIVITY_LIST_TAB_STORAGE_KEY, tab);
+  } catch {
+    // ignore
+  }
+}
 
 /**
  * Activity list. Rendered inside Layout, which wraps content with
@@ -34,6 +67,7 @@ export const ActivityListPage = () => {
   const canCreateActivity = hasPermission(PERMISSIONS.ACTIVITIES.CREATE);
 
   const [activeTab, setActiveTab] = useState<ActivityListTabValue>('all');
+  const initialTabAppliedRef = useRef(false);
   const [selectedLeadTeamId, setSelectedLeadTeamId] = useState<number | null>(
     null
   );
@@ -53,6 +87,30 @@ export const ActivityListPage = () => {
       ),
     [userTeams]
   );
+
+  const showMinistryTab = teamsWithMinistry.length > 0;
+
+  useEffect(() => {
+    if (initialTabAppliedRef.current) return;
+    initialTabAppliedRef.current = true;
+
+    const stored = getStoredActivityListTab();
+    if (stored !== null) {
+      if (stored === 'ministry' && !showMinistryTab) {
+        setActiveTab('all');
+        setStoredActivityListTab('all');
+      } else {
+        setActiveTab(stored);
+      }
+      return;
+    }
+
+    const defaultTab: ActivityListTabValue = showMinistryTab
+      ? 'my-activities'
+      : 'all';
+    setActiveTab(defaultTab);
+    setStoredActivityListTab(defaultTab);
+  }, [showMinistryTab]);
 
   const ministryAbbreviationByMinistryId = useMemo(() => {
     const map = new Map<number, string>();
@@ -74,7 +132,6 @@ export const ActivityListPage = () => {
       'Ministry')
     : 'Ministry';
 
-  const showMinistryTab = teamsWithMinistry.length > 0;
   const hasMultipleTeamsWithMinistry = teamsWithMinistry.length > 1;
 
   const tableProps = useMemo(() => {
@@ -120,7 +177,11 @@ export const ActivityListPage = () => {
 
       <Tabs
         value={activeTab}
-        onValueChange={(v) => setActiveTab(v as ActivityListTabValue)}
+        onValueChange={(v) => {
+          const tab = v as ActivityListTabValue;
+          setActiveTab(tab);
+          setStoredActivityListTab(tab);
+        }}
       >
         <div className="mb-0">
           <TabsList className="mb-0" variant="line" size="med">

--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -41,7 +41,7 @@ export const ActivityListPage = () => {
   const { data: leadTeamOptions = [] } = useLeadTeamOptions(true);
   const { data: ministries = [] } = useMinistries();
 
-  const userTeamIds = user?.teamIds ?? [];
+  const userTeamIds = useMemo(() => user?.teamIds ?? [], [user?.teamIds]);
   const userTeams = useMemo(
     () => leadTeamOptions.filter((t) => userTeamIds.includes(t.id)),
     [leadTeamOptions, userTeamIds]

--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -1,18 +1,100 @@
-import { Plus } from 'lucide-react';
+import { ChevronDown, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
+import type { TeamListItem } from '@corpcal/shared/api/types';
 import { ActivityTable } from '@/components/ActivityTable';
 import { PageHeader } from '@/components/PageHeader';
 import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/hooks/useAuth';
+import { useLeadTeamOptions } from '@/hooks/useLeadTeamOptions';
+import { useMinistries } from '@/hooks/useLookups';
+import { cn } from '@/lib/utils';
+
+type ActivityListTabValue =
+  | 'all'
+  | 'ministry'
+  | 'my-activities'
+  | 'recent'
+  | 'shared-with-me';
 
 /**
  * Activity list. Rendered inside Layout, which wraps content with
  * the shared PageContainer (max-width, padding) so this page fits viewport width.
+ * Tabs filter the list: All, ministry lead team, My activities, Recent (disabled), Shared with me.
  */
 export const ActivityListPage = () => {
-  const { hasPermission } = useAuth();
+  const { user, hasPermission } = useAuth();
   const canCreateActivity = hasPermission(PERMISSIONS.ACTIVITIES.CREATE);
+
+  const [activeTab, setActiveTab] = useState<ActivityListTabValue>('all');
+  const [selectedLeadTeamId, setSelectedLeadTeamId] = useState<number | null>(
+    null
+  );
+
+  const { data: leadTeamOptions = [] } = useLeadTeamOptions(true);
+  const { data: ministries = [] } = useMinistries();
+
+  const userTeamIds = user?.teamIds ?? [];
+  const userTeams = useMemo(
+    () => leadTeamOptions.filter((t) => userTeamIds.includes(t.id)),
+    [leadTeamOptions, userTeamIds]
+  );
+  const teamsWithMinistry = useMemo(
+    () =>
+      userTeams.filter(
+        (t): t is TeamListItem & { ministryId: number } => t.ministryId != null
+      ),
+    [userTeams]
+  );
+
+  const ministryAbbreviationByMinistryId = useMemo(() => {
+    const map = new Map<number, string>();
+    ministries.forEach((m) => {
+      if (m.abbreviation != null) map.set(m.id, m.abbreviation);
+    });
+    return map;
+  }, [ministries]);
+
+  const selectedLeadTeam =
+    selectedLeadTeamId != null
+      ? teamsWithMinistry.find((t) => t.id === selectedLeadTeamId)
+      : (teamsWithMinistry[0] ?? null);
+  const effectiveLeadTeamId = selectedLeadTeam?.id ?? selectedLeadTeamId;
+  const ministryTabLabel = selectedLeadTeam
+    ? (ministryAbbreviationByMinistryId.get(selectedLeadTeam.ministryId) ??
+      selectedLeadTeam.displayName ??
+      selectedLeadTeam.name ??
+      'Ministry')
+    : 'Ministry';
+
+  const showMinistryTab = teamsWithMinistry.length > 0;
+  const hasMultipleTeamsWithMinistry = teamsWithMinistry.length > 1;
+
+  const tableProps = useMemo(() => {
+    switch (activeTab) {
+      case 'all':
+        return {};
+      case 'ministry':
+        return effectiveLeadTeamId != null
+          ? { leadTeamId: effectiveLeadTeamId }
+          : {};
+      case 'my-activities':
+        return user?.id != null ? { commsContactLeadUserId: user.id } : {};
+      case 'recent':
+        return {};
+      case 'shared-with-me':
+        return userTeamIds.length > 0 ? { sharedWithTeamIds: userTeamIds } : {};
+      default:
+        return {};
+    }
+  }, [activeTab, effectiveLeadTeamId, user?.id, userTeamIds]);
 
   return (
     <>
@@ -35,9 +117,95 @@ export const ActivityListPage = () => {
           </Button>
         }
       />
-      <div className="min-w-0">
-        <ActivityTable />
-      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as ActivityListTabValue)}
+      >
+        <div className="mb-0">
+          <TabsList className="mb-0" variant="line" size="med">
+            <TabsTrigger value="all">All</TabsTrigger>
+            {showMinistryTab && (
+              <TabsTrigger value="ministry" className="gap-2">
+                {ministryTabLabel}
+                {hasMultipleTeamsWithMinistry && (
+                  <Popover>
+                    <PopoverTrigger
+                      asChild
+                      onClick={(e) => e.stopPropagation()}
+                      onPointerDown={(e) => e.stopPropagation()}
+                    >
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        className="hover:bg-muted rounded p-0.5"
+                        aria-label="Choose team"
+                      >
+                        <ChevronDown className="h-4 w-4" />
+                      </span>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-56 p-2">
+                      <ul className="space-y-0.5">
+                        {teamsWithMinistry.map((team) => (
+                          <li key={team.id}>
+                            <button
+                              type="button"
+                              className={cn(
+                                'hover:bg-muted w-full rounded-md px-2 py-1.5 text-left text-sm',
+                                effectiveLeadTeamId === team.id &&
+                                  'bg-muted font-medium'
+                              )}
+                              onClick={() => {
+                                setSelectedLeadTeamId(team.id);
+                              }}
+                            >
+                              {ministryAbbreviationByMinistryId.get(
+                                team.ministryId
+                              ) ??
+                                team.displayName ??
+                                team.name}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </PopoverContent>
+                  </Popover>
+                )}
+              </TabsTrigger>
+            )}
+            <TabsTrigger value="my-activities">My activities</TabsTrigger>
+            <TabsTrigger value="shared-with-me">Shared with me</TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="all" className="mt-0">
+          <div className="min-w-0">
+            <ActivityTable {...tableProps} />
+          </div>
+        </TabsContent>
+        {showMinistryTab && (
+          <TabsContent value="ministry" className="mt-0">
+            <div className="min-w-0">
+              <ActivityTable {...tableProps} />
+            </div>
+          </TabsContent>
+        )}
+        <TabsContent value="my-activities" className="mt-0">
+          <div className="min-w-0">
+            <ActivityTable {...tableProps} />
+          </div>
+        </TabsContent>
+        <TabsContent value="recent" className="mt-0">
+          <div className="min-w-0">
+            <ActivityTable />
+          </div>
+        </TabsContent>
+        <TabsContent value="shared-with-me" className="mt-0">
+          <div className="min-w-0">
+            <ActivityTable {...tableProps} />
+          </div>
+        </TabsContent>
+      </Tabs>
     </>
   );
 };

--- a/calendar-ui/src/pages/ActivityPage.test.tsx
+++ b/calendar-ui/src/pages/ActivityPage.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -140,7 +140,7 @@ describe('ActivityPage form readiness (view mode)', () => {
     mockUseFormLookups.mockReturnValue(mockLookupsReady);
   });
 
-  it('renders Lead team field (combobox) even when lead team options have not been fetched yet', () => {
+  it('renders Lead team field (combobox) even when lead team options have not been fetched yet', async () => {
     mockUseLeadTeamOptions.mockReturnValue({
       data: [],
       isFetched: false,
@@ -148,7 +148,7 @@ describe('ActivityPage form readiness (view mode)', () => {
 
     renderActivityPage();
 
-    expect(screen.getByText(/Lead team/)).toBeInTheDocument();
+    await expect(screen.findByText(/Lead team/)).resolves.toBeInTheDocument();
     const comboboxes = screen.getAllByRole('combobox');
     const leadTeamCombobox = comboboxes.find((el) =>
       el.textContent?.includes('Select lead team')
@@ -156,7 +156,7 @@ describe('ActivityPage form readiness (view mode)', () => {
     expect(leadTeamCombobox).toBeDefined();
   });
 
-  it('renders form body with Lead team when lead team options have been fetched', () => {
+  it('renders form body with Lead team when lead team options have been fetched', async () => {
     mockUseLeadTeamOptions.mockReturnValue({
       data: [
         {
@@ -173,10 +173,10 @@ describe('ActivityPage form readiness (view mode)', () => {
 
     renderActivityPage();
 
-    expect(screen.getByText(/Lead team/)).toBeInTheDocument();
+    await expect(screen.findByText(/Lead team/)).resolves.toBeInTheDocument();
   });
 
-  it('renders form body when activity has no leadTeamId even if lead options not fetched', () => {
+  it('renders form body when activity has no leadTeamId even if lead options not fetched', async () => {
     mockUseLeadTeamOptions.mockReturnValue({
       data: [],
       isFetched: false,
@@ -189,7 +189,7 @@ describe('ActivityPage form readiness (view mode)', () => {
       },
     });
 
-    expect(screen.getByText(/Lead team/)).toBeInTheDocument();
+    await expect(screen.findByText(/Lead team/)).resolves.toBeInTheDocument();
   });
 });
 
@@ -211,7 +211,7 @@ describe('ActivityPage restore button visibility (view mode)', () => {
     });
   });
 
-  it('shows Restore when status is deleted and user has DELETE_ANY', () => {
+  it('shows Restore when status is deleted and user has DELETE_ANY', async () => {
     mockUseAuth.mockReturnValue({
       hasPermission: (key: string) => key === PERMISSIONS.ACTIVITIES.DELETE_ANY,
       user: { id: 1, roleName: 'Admin', teamIds: [] },
@@ -224,12 +224,12 @@ describe('ActivityPage restore button visibility (view mode)', () => {
       },
     });
 
-    expect(
-      screen.getByRole('button', { name: /Restore/i })
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByRole('button', { name: /Restore/i })
+    ).resolves.toBeInTheDocument();
   });
 
-  it('does not show Restore when status is deleted and user lacks DELETE_ANY', () => {
+  it('does not show Restore when status is deleted and user lacks DELETE_ANY', async () => {
     mockUseAuth.mockReturnValue({
       hasPermission: (key: string) => key !== PERMISSIONS.ACTIVITIES.DELETE_ANY,
       user: { id: 1, roleName: 'Editor', teamIds: [5] },
@@ -242,12 +242,13 @@ describe('ActivityPage restore button visibility (view mode)', () => {
       },
     });
 
+    await screen.findByText(/Lead team/);
     expect(
       screen.queryByRole('button', { name: /Restore/i })
     ).not.toBeInTheDocument();
   });
 
-  it('shows Restore when status is delete_requested and user has REQUEST_DELETE and is lead-team member', () => {
+  it('shows Restore when status is delete_requested and user has REQUEST_DELETE and is lead-team member', async () => {
     mockUseAuth.mockReturnValue({
       hasPermission: (key: string) =>
         key === PERMISSIONS.ACTIVITIES.REQUEST_DELETE,
@@ -261,9 +262,9 @@ describe('ActivityPage restore button visibility (view mode)', () => {
       },
     });
 
-    expect(
-      screen.getByRole('button', { name: /Restore/i })
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByRole('button', { name: /Restore/i })
+    ).resolves.toBeInTheDocument();
   });
 });
 
@@ -291,10 +292,12 @@ describe('ActivityPage edit mode', () => {
     });
   });
 
-  it('renders Update and Cancel when route is /activity/1/edit', () => {
+  it('renders Update and Cancel when route is /activity/1/edit', async () => {
     renderActivityPage({ initialRoute: '/activity/1/edit' });
 
-    expect(screen.getByRole('button', { name: /Update/i })).toBeInTheDocument();
+    await expect(
+      screen.findByRole('button', { name: /Update/i })
+    ).resolves.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
   });
 
@@ -302,13 +305,14 @@ describe('ActivityPage edit mode', () => {
     const user = userEvent.setup();
     renderActivityPage({ initialRoute: '/activity/1/edit' });
 
-    await user.click(screen.getByRole('button', { name: /Cancel/i }));
+    const cancelButton = await screen.findByRole('button', { name: /Cancel/i });
+    await user.click(cancelButton);
 
     expect(mockRelease).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/activity/1', { replace: true });
   });
 
-  it('redirects to view when user lacks EDIT permission and route is edit', () => {
+  it('redirects to view when user lacks EDIT permission and route is edit', async () => {
     mockUseAuth.mockReturnValue({
       hasPermission: (key: string) => key !== PERMISSIONS.ACTIVITIES.EDIT,
       user: { id: 1, roleName: 'Viewer', teamIds: [5] },
@@ -316,10 +320,14 @@ describe('ActivityPage edit mode', () => {
 
     renderActivityPage({ initialRoute: '/activity/1/edit' });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/activity/1', { replace: true });
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/activity/1', {
+        replace: true,
+      })
+    );
   });
 
-  it('redirects to view when user has EDIT permission but activity canEdit is false', () => {
+  it('redirects to view when user has EDIT permission but activity canEdit is false', async () => {
     const activityViewOnly = createMockActivityResponse({
       id: 1,
       displayId: 'ACT-1',
@@ -334,6 +342,10 @@ describe('ActivityPage edit mode', () => {
       initialRoute: '/activity/1/edit',
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/activity/1', { replace: true });
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/activity/1', {
+        replace: true,
+      })
+    );
   });
 });

--- a/calendar-ui/src/styles/globals.css
+++ b/calendar-ui/src/styles/globals.css
@@ -303,6 +303,17 @@
   }
 }
 
+/* Hide scrollbar while keeping scroll; works in Firefox, Chrome, Safari, Edge */
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/packages/shared/src/schemas/query-params.schema.spec.ts
+++ b/packages/shared/src/schemas/query-params.schema.spec.ts
@@ -171,20 +171,20 @@ describe('filterActivitiesQuerySchema', () => {
     expect(filterActivitiesQuerySchema.parse({ limit: '100' }).limit).toBe(100);
   });
 
-  it('omits excludeCompleted and includeDeleted when not sent', () => {
+  it('omits includeCompleted and includeDeleted when not sent', () => {
     const result = filterActivitiesQuerySchema.parse({});
-    expect(result.excludeCompleted).toBeUndefined();
+    expect(result.includeCompleted).toBeUndefined();
     expect(result.includeDeleted).toBeUndefined();
   });
 
-  it('parses excludeCompleted and includeDeleted from query strings', () => {
+  it('parses includeCompleted and includeDeleted from query strings', () => {
     expect(
-      filterActivitiesQuerySchema.parse({ excludeCompleted: 'true' })
-        .excludeCompleted
+      filterActivitiesQuerySchema.parse({ includeCompleted: 'true' })
+        .includeCompleted
     ).toBe(true);
     expect(
-      filterActivitiesQuerySchema.parse({ excludeCompleted: 'false' })
-        .excludeCompleted
+      filterActivitiesQuerySchema.parse({ includeCompleted: 'false' })
+        .includeCompleted
     ).toBe(false);
     expect(
       filterActivitiesQuerySchema.parse({ includeDeleted: 'true' })

--- a/packages/shared/src/schemas/query-params.schema.spec.ts
+++ b/packages/shared/src/schemas/query-params.schema.spec.ts
@@ -130,6 +130,28 @@ describe('filterActivitiesQuerySchema', () => {
     ).toThrow();
   });
 
+  it('parses commsContactLeadUserId and sharedWithTeamId from query strings', () => {
+    expect(
+      filterActivitiesQuerySchema.parse({ commsContactLeadUserId: '7' })
+        .commsContactLeadUserId
+    ).toBe(7);
+    expect(
+      filterActivitiesQuerySchema.parse({ sharedWithTeamId: '12' })
+        .sharedWithTeamId
+    ).toBe(12);
+  });
+
+  it('parses sharedWithTeamIds from comma-separated string', () => {
+    expect(
+      filterActivitiesQuerySchema.parse({ sharedWithTeamIds: '1,2,3' })
+        .sharedWithTeamIds
+    ).toEqual([1, 2, 3]);
+    expect(
+      filterActivitiesQuerySchema.parse({ sharedWithTeamIds: '5' })
+        .sharedWithTeamIds
+    ).toEqual([5]);
+  });
+
   it('rejects non-integer activityStatusId', () => {
     expect(() =>
       filterActivitiesQuerySchema.parse({ activityStatusId: 'x' })

--- a/packages/shared/src/schemas/query-params.schema.ts
+++ b/packages/shared/src/schemas/query-params.schema.ts
@@ -67,6 +67,40 @@ export const filterActivitiesQuerySchema = z.object({
     .pipe(z.number().int())
     .optional(),
   leadTeamId: z.string().transform(Number).pipe(z.number().int()).optional(),
+  /**
+   * Restrict to activities where this user is the comms contact lead (isLead = true).
+   */
+  commsContactLeadUserId: z
+    .string()
+    .transform(Number)
+    .pipe(z.number().int())
+    .optional(),
+  /**
+   * Restrict to activities shared with this team (in activity_shared_with_teams).
+   */
+  sharedWithTeamId: z
+    .string()
+    .transform(Number)
+    .pipe(z.number().int())
+    .optional(),
+  /**
+   * Restrict to activities shared with any of these teams (in activity_shared_with_teams).
+   * Comma-separated team IDs in query string.
+   */
+  sharedWithTeamIds: z
+    .union([
+      z.array(z.string().transform(Number).pipe(z.number().int())),
+      z.string().transform((val) =>
+        val
+          .split(',')
+          .map((id) => parseInt(id.trim(), 10))
+          .filter((id) => !isNaN(id))
+      ),
+    ])
+    .optional()
+    .transform((val) =>
+      val == null || (Array.isArray(val) && val.length === 0) ? undefined : val
+    ),
   lookAheadSection: z.enum(LOOK_AHEAD_SECTION).optional(),
   city: z.string().optional(),
   isIssue: z

--- a/packages/shared/src/schemas/query-params.schema.ts
+++ b/packages/shared/src/schemas/query-params.schema.ts
@@ -109,9 +109,9 @@ export const filterActivitiesQuerySchema = z.object({
     .pipe(z.boolean())
     .optional(),
   /**
-   * When true, exclude activities with status 'completed'. Omit to include completed (e.g. calendar). Set to true for list views to reduce payload.
+   * When true, include activities with status 'completed'. Omit or false for list default (exclude completed).
    */
-  excludeCompleted: z
+  includeCompleted: z
     .string()
     .optional()
     .transform((val): boolean | undefined =>


### PR DESCRIPTION
## Summary

This PR updates existing filtering and keyword search for activities: scheduled date range, category, status, pitch (status + date), look-ahead, date/time confirmed, tags, leads (ministry, org, comms, event planner), and translations. All of these filters plus sort, page size, and search are persisted to URL and sessionStorage so state survives navigation and is shareable. Filtering remains client-side over the cached list (except for `Deleted` and `Completed`, which are not part of the default view). Keyword search is debounced for URL sync to avoid input focus issues.

**Important**

- **Persistence:** URL wins when it has any known params; otherwise sessionStorage is used. See `ACTIVITY_FILTER_PERSIST.md` and `ACTIVITY_LIST_SEARCH.md` for behavior and adding new filters.
- **Scale:** Client-side filtering is intended for current scale (~1–1.5k active rows); docs note when to consider server-side filters.

## Changes

- **Activity table (calendar-ui):** New `ActivityTableFilters` with sections for scheduled date, category, status, pitch (status + date range), look-ahead (status/section), date/time confirmed, tags, leads (ministry, org, comms lead, event planner), and translations (required status + language). Shared `ResponsiveFilterRow`, `FilterTrigger`, `FilterSectionLabel`, and `FilterSearchableList`; per-filter components: `ScheduledDateFilter`, `ConfirmedFilter`, `LeadsFilter`, `PitchFilter`, `LookAheadFilter`, `TagsFilter`, `TranslationsFilter`. `ActivityTable` refactored to consume filter state and apply client-side filtering/sorting/pagination; summary bar and layout updated.
- **Preferences and URL (calendar-ui):** `useActivityTablePreferences` extended with full `ActivityFilterState`, URL params for all filters and search, sessionStorage sync, and debounced search-to-URL (400ms). `activityFilterState` and `activityTableRow` types updated for new filter dimensions.
- **Filter logic (calendar-ui):** `activity-query-utils` gains `filterActivityRowsByKeyword` and `filterActivityRowsByFilters` (date range, category, status, pitch, look-ahead, confirmed, tags, leads, translations) with optional context for ID-to-label resolution; comprehensive unit tests added.
- **Shared (packages/shared):** `query-params.schema` and filter activities schema extended for new filter params where needed; specs updated.
- **Docs:** `ACTIVITY_FILTER_PERSIST.md` updated for new filters; `ACTIVITY_LIST_SEARCH.md` added for search and filter strategy.
- **Other:** User/team management filter components (`FilterTrigger`, `FilterCheckboxDropdown`) reused or aligned; `ActivityListPage` and related tests updated.

## Testing

- **Unit tests (calendar-ui):** `useActivityTablePreferences.test.ts` and `activity-query-utils.spec.ts` expanded for new preferences, URL/sessionStorage, and filter logic; `ActivityPage.test.tsx` updated.
- **Unit tests (packages/shared):** `query-params.schema.spec.ts` updated for schema changes.
- Manual verification of filters, search, persistence (URL and sessionStorage), and responsive filter row on the activity list.

## Future work

- The ResponsiveFilterRow component still requires additional refinement.
- Some filters still require UI/UX polish, but functionality is working as expected.
- All filters modal (or other UI) and saved filters are still todo.