### PR TITLE
feat(user): create new user ui and endpoint

### DIFF
--- a/calendar-service/src/lookups/lookups.controller.ts
+++ b/calendar-service/src/lookups/lookups.controller.ts
@@ -221,7 +221,7 @@ export class LookupsController {
   @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
   async getRoles(): Promise<{
     success: boolean;
-    data: { id: number; name: string }[];
+    data: { id: number; name: string; description: string | null }[];
   }> {
     const data = await this.lookupsService.getRoles();
     return { success: true, data };

--- a/calendar-service/src/lookups/lookups.service.ts
+++ b/calendar-service/src/lookups/lookups.service.ts
@@ -113,11 +113,21 @@ export class LookupsService {
   }
 
   /**
-   * Get all active roles (id, name) for dropdowns
+   * Get all active roles (id, name, description) for dropdowns
    */
-  async getRoles(): Promise<{ id: number; name: string }[]> {
+  async getRoles(): Promise<
+    {
+      id: number;
+      name: string;
+      description: string | null;
+    }[]
+  > {
     const results = await this.databaseService.db
-      .select({ id: roles.id, name: roles.name })
+      .select({
+        id: roles.id,
+        name: roles.name,
+        description: roles.description,
+      })
       .from(roles)
       .where(eq(roles.isActive, true))
       .orderBy(roles.name);

--- a/calendar-service/src/users/dto/users.dto.ts
+++ b/calendar-service/src/users/dto/users.dto.ts
@@ -5,6 +5,7 @@ import {
   addUserToTeamBodySchema,
   createArrayResponseWrapperSchema,
   createResponseWrapperSchema,
+  createUserBodySchema,
   transferActivitiesBodySchema,
   transferActivitiesResponseSchema,
   updateUserBodySchema,
@@ -13,6 +14,11 @@ import {
   userHistoryEntrySchema,
   userListItemSchema,
 } from '@corpcal/shared/schemas';
+
+/**
+ * Request DTO for POST /users - Create a new user (admin).
+ */
+export class CreateUserDto extends createZodDto(createUserBodySchema) {}
 
 /**
  * Request DTO for PATCH /users/:id - Update user role, active status, or notes.

--- a/calendar-service/src/users/users.controller.spec.ts
+++ b/calendar-service/src/users/users.controller.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import type { AuthUser } from '@corpcal/shared';
@@ -31,6 +32,7 @@ describe('UsersController', () => {
     findAll: vi.fn(),
     findOne: vi.fn(),
     update: vi.fn(),
+    create: vi.fn(),
     getActivitiesForUser: vi.fn(),
     addUserToTeam: vi.fn(),
     removeUserFromTeam: vi.fn(),
@@ -80,6 +82,41 @@ describe('UsersController', () => {
       await controller.findAll('john');
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith('john', [], []);
+    });
+  });
+
+  describe('create', () => {
+    it('should create user and return 201 with data', async () => {
+      const dto = {
+        email: 'newuser@example.gov.bc.ca',
+        roleId: 2,
+        displayName: 'New User',
+      };
+      const created = createMockUserDetail({
+        id: 99,
+        adEmail: 'newuser@example.gov.bc.ca',
+        roleId: 2,
+        adDisplayName: 'New User',
+      });
+      mockUsersService.create.mockResolvedValue(created);
+
+      const result = await controller.create(dto, mockUser);
+
+      expect(result).toEqual({ success: true, data: created });
+      expect(mockUsersService.create).toHaveBeenCalledWith(dto, mockUser.id);
+      expect(mockUsersService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when service throws ConflictException for duplicate email', async () => {
+      const dto = { email: 'existing@example.com', roleId: 1 };
+      mockUsersService.create.mockRejectedValue(
+        new ConflictException('A user with this email already exists.')
+      );
+
+      await expect(controller.create(dto, mockUser)).rejects.toThrow(
+        'A user with this email already exists'
+      );
+      expect(mockUsersService.create).toHaveBeenCalledWith(dto, mockUser.id);
     });
   });
 

--- a/calendar-service/src/users/users.controller.ts
+++ b/calendar-service/src/users/users.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Patch,
@@ -26,6 +28,7 @@ import type {
 } from '@corpcal/shared/api/types';
 import {
   addUserToTeamBodySchema,
+  createUserBodySchema,
   transferActivitiesBodySchema,
   updateUserBodySchema,
   updateUserTeamRoleBodySchema,
@@ -37,6 +40,7 @@ import { parseCommaSeparatedIds } from '../common/utils/parse-query-ids';
 import { RequirePermission } from '../policy/decorators/require-permission.decorator';
 import {
   AddUserToTeamDto,
+  CreateUserDto,
   TransferActivitiesDto,
   TransferActivitiesResponseDto,
   UpdateUserDto,
@@ -88,6 +92,33 @@ export class UsersController {
     const teamIds = parseCommaSeparatedIds(teamIdsParam);
     const roleIds = parseCommaSeparatedIds(roleIdsParam);
     const data = await this.usersService.findAll(search, teamIds, roleIds);
+    return { success: true, data };
+  }
+
+  @ApiOperation({
+    summary: 'Create user',
+    description:
+      'Create a new user (email and role required). Email is used to match the user when they first sign in with Azure AD. Optional display name and initial team assignments.',
+  })
+  @ApiBody({ type: CreateUserDto })
+  @ApiResponse({
+    status: 201,
+    description: 'User created',
+    type: UserDetailResponseWrapperDto,
+  })
+  @ApiResponse({ status: 400, description: 'Validation error or invalid role' })
+  @ApiResponse({
+    status: 409,
+    description: 'A user with this email already exists',
+  })
+  @RequirePermission(PERMISSIONS.USERS.CREATE)
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body(new ZodValidationPipe(createUserBodySchema)) dto: CreateUserDto,
+    @CurrentUser() currentUser: AuthUser
+  ): Promise<{ success: boolean; data: UserDetail }> {
+    const data = await this.usersService.create(dto, currentUser.id);
     return { success: true, data };
   }
 

--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -73,6 +73,82 @@ describe('UsersService', () => {
     vi.clearAllMocks();
   });
 
+  describe('create', () => {
+    it('should throw ConflictException when email already exists', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ id: 1 }], 'limit'));
+
+      await expect(
+        service.create({ email: 'existing@example.com', roleId: 1 }, 1)
+      ).rejects.toThrow(ConflictException);
+      expect(mockDatabaseService.db.insert).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when roleId is invalid', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([], 'limit'))
+        .mockReturnValueOnce(createChain([], 'limit'));
+
+      await expect(
+        service.create({ email: 'new@example.com', roleId: 999 }, 1)
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDatabaseService.db.insert).not.toHaveBeenCalled();
+    });
+
+    it('should create user and return UserDetail', async () => {
+      const userRow = {
+        id: 1,
+        adUsername: null,
+        adDisplayName: 'New User',
+        adEmail: 'newuser@example.com',
+        roleId: 2,
+        isActive: true,
+        notes: null,
+      };
+      const roleRow = [{ name: 'Editor' }];
+      const teamRows: { teamId: number; role: string }[] = [];
+      const teamNameRows: { id: number; name: string }[] = [];
+
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([], 'limit'))
+        .mockReturnValueOnce(createChain([{ id: 2 }], 'limit'))
+        .mockReturnValueOnce(createChain([userRow], 'limit'))
+        .mockReturnValueOnce(createChain(roleRow, 'limit'))
+        .mockReturnValueOnce(createChain(teamRows, 'where'))
+        .mockReturnValueOnce(createChain(teamNameRows, 'where'));
+
+      mockDatabaseService.db.insert = vi
+        .fn()
+        .mockImplementationOnce(() => ({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 1 }]),
+          }),
+        }))
+        .mockImplementationOnce(() => ({
+          values: vi.fn().mockResolvedValue(undefined),
+        }))
+        .mockReturnThis();
+
+      const result = await service.create(
+        {
+          email: 'newuser@example.com',
+          roleId: 2,
+          displayName: 'New User',
+        },
+        1
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.id).toBe(1);
+      expect(result.adEmail).toBe('newuser@example.com');
+      expect(result.roleId).toBe(2);
+      expect(mockDatabaseService.db.insert).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('findAll', () => {
     it('should return list with teams per user', async () => {
       const userRows = [

--- a/calendar-service/src/users/users.service.ts
+++ b/calendar-service/src/users/users.service.ts
@@ -19,6 +19,7 @@ import {
 import type { ActivityStatusName } from '@corpcal/shared';
 import type {
   AddUserToTeamBody,
+  CreateUserBody,
   HistoryChange,
   TransferActivitiesBody,
   UpdateUserBody,
@@ -48,6 +49,85 @@ export class UsersService {
       changes: changes ? (changes as unknown) : null,
       notes: notes ?? null,
     });
+  }
+
+  async create(
+    dto: CreateUserBody,
+    createdByUserId: number
+  ): Promise<UserDetail> {
+    const normalizedEmail = dto.email.trim().toLowerCase();
+
+    const [existingByEmail] = await this.databaseService.db
+      .select({ id: users.id })
+      .from(users)
+      .where(
+        and(
+          sql`lower(${users.adEmail}) = ${normalizedEmail}`,
+          eq(users.isActive, true)
+        )
+      )
+      .limit(1);
+
+    if (existingByEmail) {
+      throw new ConflictException('A user with this email already exists.');
+    }
+
+    const [roleRow] = await this.databaseService.db
+      .select({ id: roles.id })
+      .from(roles)
+      .where(eq(roles.id, dto.roleId))
+      .limit(1);
+
+    if (!roleRow) {
+      throw new BadRequestException('Invalid role');
+    }
+
+    const [inserted] = await this.databaseService.db
+      .insert(users)
+      .values({
+        roleId: dto.roleId,
+        adEmail: normalizedEmail,
+        adDisplayName: dto.displayName?.trim() || null,
+        isActive: true,
+        createdBy: createdByUserId,
+        createdDateTime: new Date(),
+      })
+      .returning({ id: users.id });
+
+    const userId = inserted.id;
+
+    await this.recordUserHistory(userId, createdByUserId, 'created', [
+      { field: 'roleId', oldValue: null, newValue: dto.roleId },
+    ]);
+
+    if (dto.teams && dto.teams.length > 0) {
+      const uniqueTeams = Array.from(
+        new Map(dto.teams.map((t) => [t.teamId, t])).values()
+      );
+      const teamIds = uniqueTeams.map((t) => t.teamId);
+      const existingTeams = await this.databaseService.db
+        .select({ id: teams.id })
+        .from(teams)
+        .where(inArray(teams.id, teamIds));
+      const existingTeamIds = new Set(existingTeams.map((t) => t.id));
+      const missing = teamIds.filter((id) => !existingTeamIds.has(id));
+      if (missing.length > 0) {
+        throw new BadRequestException(
+          `Invalid team ID(s): ${missing.join(', ')}`
+        );
+      }
+      for (const teamEntry of uniqueTeams) {
+        await this.addUserToTeam(
+          userId,
+          { teamId: teamEntry.teamId, role: teamEntry.role },
+          createdByUserId
+        );
+      }
+    }
+
+    const created = await this.findOne(userId);
+    if (!created) throw new NotFoundException('User not found');
+    return created;
   }
 
   async findAll(

--- a/calendar-ui/.env.example
+++ b/calendar-ui/.env.example
@@ -1,9 +1,10 @@
 # API Configuration
 
-# Base URL for the NestJS backend API
-# For local development, this is typically http://localhost:3001
-# For production, this should be your production API URL
-VITE_API_BASE_URL=http://localhost:3001
+# Base URL for the NestJS backend API.
+# For local development with the Vite dev server: leave unset so requests use /api and are proxied to the backend.
+# To call the backend directly (e.g. backend on another port): set to http://localhost:3001
+# For production: set to your production API URL
+# VITE_API_BASE_URL=http://localhost:3001
 DATABASE_URL=postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
 
 # Logging (optional)

--- a/calendar-ui/package.json
+++ b/calendar-ui/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@base-ui/react": "^1.3.0",
     "@corpcal/shared": "*",
     "@fluentui/react": "^8.123.0",
     "@fluentui/react-components": "^9.64.1",

--- a/calendar-ui/src/api/axios.ts
+++ b/calendar-ui/src/api/axios.ts
@@ -3,8 +3,6 @@ import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { createApiError } from './errors';
 
 const api = axios.create({
-  // Use /api prefix to go through Vite's proxy in development
-  // In production, set VITE_API_BASE_URL in your environment
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   timeout: 30000, // 30 seconds - increased to handle complex operations
   withCredentials: true, // Include httpOnly cookies in requests

--- a/calendar-ui/src/api/errors.ts
+++ b/calendar-ui/src/api/errors.ts
@@ -176,17 +176,25 @@ export function parseErrorResponse(error: unknown): ProblemDetails | null {
   // Fallback: construct Problem Details from standard error response
   const statusCode =
     getNumber(response, 'statusCode', 0) || getNumber(response, 'status', 500);
-  if (!isRecord(data) || !hasKeys(data, 'message') || !statusCode) return null;
-
-  const messageStr = getString(data, 'message', 'An error occurred');
   const headers = isRecord(response.headers) ? response.headers : {};
   const config = isRecord(error.config) ? error.config : {};
 
+  let detail: string;
+  if (isRecord(data) && hasKeys(data, 'message')) {
+    detail = getString(data, 'message', 'An error occurred');
+  } else if (typeof data === 'string' && data.trim() !== '') {
+    detail = data.trim();
+  } else if (statusCode >= 400) {
+    detail = `Request failed with status ${statusCode}`;
+  } else {
+    return null;
+  }
+
   return {
     type: `https://api.example.com/errors/${statusCode}`,
-    title: messageStr,
+    title: detail,
     status: statusCode,
-    detail: messageStr,
+    detail,
     instance: getString(config, 'url', ''),
     correlationId: getString(headers, 'x-correlation-id', 'unknown'),
   };

--- a/calendar-ui/src/api/usersApi.ts
+++ b/calendar-ui/src/api/usersApi.ts
@@ -3,6 +3,7 @@
  */
 import type {
   AddUserToTeamBody,
+  CreateUserBody,
   RoleOption,
   TeamListItem,
   TransferActivitiesBody,
@@ -47,6 +48,14 @@ export async function fetchUser(id: number): Promise<UserDetail | null> {
     success: boolean;
     data: UserDetail | null;
   }>(`/users/${id}`);
+  return response.data.data;
+}
+
+export async function createUser(body: CreateUserBody): Promise<UserDetail> {
+  const response = await api.post<{ success: boolean; data: UserDetail }>(
+    '/users',
+    body
+  );
   return response.data.data;
 }
 

--- a/calendar-ui/src/components/ActivityFormSections/ActivityEventSection.tsx
+++ b/calendar-ui/src/components/ActivityFormSections/ActivityEventSection.tsx
@@ -13,7 +13,18 @@ import {
   type AddressData,
 } from '../ui/address-autocomplete';
 import { Badge } from '../ui/badge';
-import { Combobox } from '../ui/combobox';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '../ui/combobox';
 import {
   FormControl,
   FormDescription,
@@ -97,6 +108,7 @@ export const ActivityEventSection: React.FC<ActivityEventSectionProps> = ({
 }) => {
   const form = useFormContext<ActivityFormData>();
   const [isVenueTbd, setIsVenueTbd] = useState(false);
+  const representativesAnchorRef = useComboboxAnchor();
 
   const { data: fixedQuickPicks = [] } = useQuery({
     queryKey: ['venueQuickPicks'],
@@ -159,38 +171,56 @@ export const ActivityEventSection: React.FC<ActivityEventSectionProps> = ({
           const selectedValues = representatives
             .filter((rep) => rep.representativeId !== undefined)
             .map((rep) => rep.representativeId!.toString());
+          const selectedOptions = representativeComboboxOptions.filter((o) =>
+            selectedValues.includes(o.value)
+          );
 
           return (
             <FormItem>
               <FormLabel>Representatives</FormLabel>
               <FormControl data-field={field.name}>
                 <Combobox
-                  disabled={readOnly}
-                  options={representativeComboboxOptions}
-                  selectedValues={selectedValues}
-                  onSelect={(value) => {
-                    const representativeId = parseInt(value, 10);
-                    const current = representatives || [];
-                    const exists = current.some(
-                      (r) => r.representativeId === representativeId
+                  items={representativeComboboxOptions}
+                  multiple
+                  value={selectedOptions}
+                  onValueChange={(selected) => {
+                    field.onChange(
+                      selected.map((o) => ({
+                        representativeId: parseInt(o.value, 10),
+                      }))
                     );
-
-                    if (exists) {
-                      // Remove if already selected
-                      field.onChange(
-                        current.filter(
-                          (r) => r.representativeId !== representativeId
-                        )
-                      );
-                    } else {
-                      // Add if not selected
-                      field.onChange([...current, { representativeId }]);
-                    }
                   }}
-                  placeholder="Select representatives"
-                  searchPlaceholder="Search representatives..."
-                  emptyMessage="No representatives found."
-                />
+                  itemToStringValue={(o) => o.label}
+                  disabled={readOnly}
+                >
+                  <ComboboxChips
+                    ref={representativesAnchorRef}
+                    className="w-full"
+                  >
+                    <ComboboxValue>
+                      {(values: Array<{ value: string; label: string }>) => (
+                        <>
+                          {values.map((option) => (
+                            <ComboboxChip key={option.value}>
+                              {option.label}
+                            </ComboboxChip>
+                          ))}
+                          <ComboboxChipsInput placeholder="Add representatives" />
+                        </>
+                      )}
+                    </ComboboxValue>
+                  </ComboboxChips>
+                  <ComboboxContent anchor={representativesAnchorRef}>
+                    <ComboboxEmpty>No representatives found.</ComboboxEmpty>
+                    <ComboboxList>
+                      {(option: { value: string; label: string }) => (
+                        <ComboboxItem key={option.value} value={option}>
+                          {option.label}
+                        </ComboboxItem>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/calendar-ui/src/components/ActivityFormSections/ActivitySharingSection.tsx
+++ b/calendar-ui/src/components/ActivityFormSections/ActivitySharingSection.tsx
@@ -8,7 +8,18 @@ import {
 import type { ActivityFormData } from '@corpcal/shared/schemas';
 
 import { getActivityFormSectionLabel } from '../../lib/activity-form-section-labels';
-import { Combobox } from '../ui/combobox';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '../ui/combobox';
 import {
   FormControl,
   FormDescription,
@@ -36,6 +47,7 @@ export const ActivitySharingSection: React.FC<ActivitySharingSectionProps> = ({
   readOnly = false,
 }) => {
   const form = useFormContext<ActivityFormData>();
+  const sharedWithAnchorRef = useComboboxAnchor();
   return (
     <ActivityFormSection title={getActivityFormSectionLabel('sharing')}>
       <FormField
@@ -84,29 +96,48 @@ export const ActivitySharingSection: React.FC<ActivitySharingSectionProps> = ({
                 .filter((v): v is number => typeof v === 'number')
                 .map((v) => String(v))
             : [];
+          const selectedOptions = sharedWithTeamOptions.filter((o) =>
+            currentValues.includes(o.value)
+          );
           return (
             <FormItem>
               <FormLabel>Shared With Teams</FormLabel>
               <FormControl data-field={field.name}>
                 <Combobox
-                  disabled={readOnly}
-                  options={sharedWithTeamOptions}
-                  selectedValues={currentValues}
-                  onSelect={(value) => {
-                    const teamId = parseInt(value);
-                    const current = Array.isArray(field.value)
-                      ? field.value
-                      : [];
-                    if (current.includes(teamId)) {
-                      field.onChange(current.filter((id) => id !== teamId));
-                    } else {
-                      field.onChange([...current, teamId]);
-                    }
+                  items={sharedWithTeamOptions}
+                  multiple
+                  value={selectedOptions}
+                  onValueChange={(selected) => {
+                    field.onChange(selected.map((o) => parseInt(o.value, 10)));
                   }}
-                  placeholder="Select teams"
-                  searchPlaceholder="Search teams..."
-                  emptyMessage="No teams found."
-                />
+                  itemToStringValue={(o) => o.label}
+                  disabled={readOnly}
+                >
+                  <ComboboxChips ref={sharedWithAnchorRef} className="w-full">
+                    <ComboboxValue>
+                      {(values: Array<{ value: string; label: string }>) => (
+                        <>
+                          {values.map((option) => (
+                            <ComboboxChip key={option.value}>
+                              {option.label}
+                            </ComboboxChip>
+                          ))}
+                          <ComboboxChipsInput placeholder="Add teams" />
+                        </>
+                      )}
+                    </ComboboxValue>
+                  </ComboboxChips>
+                  <ComboboxContent anchor={sharedWithAnchorRef}>
+                    <ComboboxEmpty>No teams found.</ComboboxEmpty>
+                    <ComboboxList>
+                      {(option: { value: string; label: string }) => (
+                        <ComboboxItem key={option.value} value={option}>
+                          {option.label}
+                        </ComboboxItem>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
               </FormControl>
               <FormDescription>
                 These teams can see this activity and it will be marked as

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -7,7 +7,14 @@ import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
 import { fetchMinistries } from '@/api/lookupsApi';
 import { createTeam, fetchTeamById, updateTeam } from '@/api/teamsApi';
 import { Button } from '@/components/ui/button';
-import { Combobox } from '@/components/ui/combobox';
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
@@ -149,9 +156,9 @@ export function TeamEditModal({
     }
   };
 
-  const handleMinistrySelect = (value: string) => {
-    setMinistryId((prev) => (prev === value ? null : value));
-  };
+  const selectedMinistry = ministryId
+    ? (ministryOptions.find((m) => m.value === ministryId) ?? null)
+    : null;
 
   const isLoading = !isCreate && isLoadingDetail;
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
@@ -213,13 +220,25 @@ export function TeamEditModal({
             <div className="space-y-2">
               <Label>Ministry</Label>
               <Combobox
-                options={ministryOptions}
-                selectedValues={ministryId ? [ministryId] : []}
-                onSelect={handleMinistrySelect}
-                placeholder="Select ministry..."
-                searchPlaceholder="Search ministries..."
-                emptyMessage="No ministries found."
-              />
+                items={ministryOptions}
+                value={selectedMinistry}
+                onValueChange={(option) =>
+                  setMinistryId(option ? option.value : null)
+                }
+                itemToStringValue={(o) => o.label}
+              >
+                <ComboboxInput placeholder="Select ministry..." />
+                <ComboboxContent>
+                  <ComboboxEmpty>No ministries found.</ComboboxEmpty>
+                  <ComboboxList>
+                    {(option: { value: string; label: string }) => (
+                      <ComboboxItem key={option.value} value={option}>
+                        {option.label}
+                      </ComboboxItem>
+                    )}
+                  </ComboboxList>
+                </ComboboxContent>
+              </Combobox>
             </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={onClose}>

--- a/calendar-ui/src/components/ui/button.tsx
+++ b/calendar-ui/src/components/ui/button.tsx
@@ -1,29 +1,34 @@
-import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40',
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'text-white hover:opacity-90',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-link underline-offset-4 hover:underline',
+        ghost:
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
@@ -33,30 +38,27 @@ const buttonVariants = cva(
   }
 );
 
-export interface ButtonProps
-  extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-}
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : 'button';
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        style={{
-          backgroundColor:
-            variant === 'default' || !variant ? '#0F6CBD' : undefined,
-          ...props.style,
-        }}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Button.displayName = 'Button';
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
 
 export { Button, buttonVariants };

--- a/calendar-ui/src/components/ui/combobox.tsx
+++ b/calendar-ui/src/components/ui/combobox.tsx
@@ -1,133 +1,316 @@
-import { Check, ChevronsUpDown, X } from 'lucide-react';
+'use client';
+
+import { Combobox as ComboboxPrimitive } from '@base-ui/react';
+import { CheckIcon, ChevronDownIcon, XIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
-import { Badge } from './badge';
-import { Button } from './button';
+import { Button } from '@/components/ui/button';
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from './command';
-import { Popover, PopoverContent, PopoverTrigger } from './popover';
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group';
+import { cn } from '@/lib/utils';
 
-export interface ComboboxOption {
-  value: string;
-  label: string;
+const Combobox = ComboboxPrimitive.Root;
+
+function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />;
 }
 
-export interface ComboboxProps {
-  options: ComboboxOption[];
-  selectedValues: string[];
-  onSelect: (value: string) => void;
-  placeholder?: string;
-  searchPlaceholder?: string;
-  emptyMessage?: string;
-  className?: string;
-  disabled?: boolean;
-}
-
-export function Combobox({
-  options,
-  selectedValues,
-  onSelect,
-  placeholder = 'Select options...',
-  searchPlaceholder = 'Search...',
-  emptyMessage = 'No results found.',
+function ComboboxTrigger({
   className,
-  disabled = false,
-}: ComboboxProps) {
-  const [open, setOpen] = React.useState(false);
-  const [search, setSearch] = React.useState('');
-
-  const filteredOptions = React.useMemo(() => {
-    if (!search) return options;
-    return options.filter((option) =>
-      option.label.toLowerCase().includes(search.toLowerCase())
-    );
-  }, [options, search]);
-
-  const selectedOptions = React.useMemo(() => {
-    return options.filter((option) => selectedValues.includes(option.value));
-  }, [options, selectedValues]);
-
-  const handleSelect = (value: string) => {
-    onSelect(value);
-    setSearch('');
-  };
-
+  children,
+  ...props
+}: ComboboxPrimitive.Trigger.Props) {
   return (
-    <div className={cn('space-y-2', className)}>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className="w-full justify-between"
-            disabled={disabled}
-          >
-            {selectedOptions.length > 0
-              ? `${selectedOptions.length} selected`
-              : placeholder}
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          className="p-0"
-          style={{ width: 'var(--radix-popover-trigger-width)' }}
-          align="start"
-        >
-          <Command>
-            <CommandInput
-              placeholder={searchPlaceholder}
-              value={search}
-              onValueChange={setSearch}
-            />
-            <CommandList>
-              <CommandEmpty>{emptyMessage}</CommandEmpty>
-              <CommandGroup>
-                {filteredOptions.map((option) => {
-                  const isSelected = selectedValues.includes(option.value);
-                  return (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      onSelect={() => handleSelect(option.value)}
-                    >
-                      <Check
-                        className={cn(
-                          'mr-2 h-4 w-4',
-                          isSelected ? 'opacity-100' : 'opacity-0'
-                        )}
-                      />
-                      {option.label}
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-      {selectedOptions.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {selectedOptions.map((option) => (
-            <Badge
-              key={option.value}
-              variant="default"
-              className="cursor-pointer px-3 py-1 text-sm"
-              onClick={() => onSelect(option.value)}
-            >
-              {option.label}
-              <X className="ml-2 h-3 w-3" />
-            </Badge>
-          ))}
-        </div>
-      )}
-    </div>
+    <ComboboxPrimitive.Trigger
+      data-slot="combobox-trigger"
+      className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon
+        data-slot="combobox-trigger-icon"
+        className="text-muted-foreground pointer-events-none size-4"
+      />
+    </ComboboxPrimitive.Trigger>
   );
 }
+
+function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+  return (
+    <ComboboxPrimitive.Clear
+      data-slot="combobox-clear"
+      render={<InputGroupButton variant="ghost" size="icon-xs" />}
+      className={cn(className)}
+      {...props}
+    >
+      <XIcon className="pointer-events-none" />
+    </ComboboxPrimitive.Clear>
+  );
+}
+
+function ComboboxInput({
+  className,
+  children,
+  disabled = false,
+  showTrigger = true,
+  showClear = false,
+  ...props
+}: ComboboxPrimitive.Input.Props & {
+  showTrigger?: boolean;
+  showClear?: boolean;
+}) {
+  return (
+    <InputGroup className={cn('w-auto', className)}>
+      <ComboboxPrimitive.Input
+        render={<InputGroupInput disabled={disabled} />}
+        {...props}
+      />
+      <InputGroupAddon align="inline-end">
+        {showTrigger && (
+          <InputGroupButton
+            size="icon-xs"
+            variant="ghost"
+            asChild
+            data-slot="input-group-button"
+            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+            disabled={disabled}
+          >
+            <ComboboxTrigger />
+          </InputGroupButton>
+        )}
+        {showClear && <ComboboxClear disabled={disabled} />}
+      </InputGroupAddon>
+      {children}
+    </InputGroup>
+  );
+}
+
+function ComboboxContent({
+  className,
+  side = 'bottom',
+  sideOffset = 6,
+  align = 'start',
+  alignOffset = 0,
+  anchor,
+  container,
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    'side' | 'align' | 'sideOffset' | 'alignOffset' | 'anchor'
+  > & {
+    /** Render portal into this element (e.g. dialog content) to fix focus/click inside dialogs */
+    container?: React.ComponentPropsWithoutRef<
+      typeof ComboboxPrimitive.Portal
+    >['container'];
+  }) {
+  return (
+    <ComboboxPrimitive.Portal container={container}>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className="isolate z-50"
+      >
+        <ComboboxPrimitive.Popup
+          data-slot="combobox-content"
+          data-chips={!!anchor}
+          className={cn(
+            'group/combobox-content bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 relative max-h-96 w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-md shadow-md ring-1 duration-100 data-[chips=true]:min-w-(--anchor-width) *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none',
+            className
+          )}
+          {...props}
+        />
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+}
+
+function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      data-slot="combobox-list"
+      className={cn(
+        'max-h-[min(calc(--spacing(96)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot="combobox-item"
+      className={cn(
+        "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator
+        data-slot="combobox-item-indicator"
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none size-4 pointer-coarse:size-5" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  );
+}
+
+function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+  return (
+    <ComboboxPrimitive.Group
+      data-slot="combobox-group"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxLabel({
+  className,
+  ...props
+}: ComboboxPrimitive.GroupLabel.Props) {
+  return (
+    <ComboboxPrimitive.GroupLabel
+      data-slot="combobox-label"
+      className={cn(
+        'text-muted-foreground px-2 py-1.5 text-xs pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+  return (
+    <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
+  );
+}
+
+function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      data-slot="combobox-empty"
+      className={cn(
+        'text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxSeparator({
+  className,
+  ...props
+}: ComboboxPrimitive.Separator.Props) {
+  return (
+    <ComboboxPrimitive.Separator
+      data-slot="combobox-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> &
+  ComboboxPrimitive.Chips.Props) {
+  return (
+    <ComboboxPrimitive.Chips
+      data-slot="combobox-chips"
+      className={cn(
+        'border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-destructive/20 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40 flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:ring-[3px] has-aria-invalid:ring-[3px] has-data-[slot=combobox-chip]:px-1.5',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChip({
+  className,
+  children,
+  showRemove = true,
+  ...props
+}: ComboboxPrimitive.Chip.Props & {
+  showRemove?: boolean;
+}) {
+  return (
+    <ComboboxPrimitive.Chip
+      data-slot="combobox-chip"
+      className={cn(
+        'bg-muted text-foreground flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showRemove && (
+        <ComboboxPrimitive.ChipRemove
+          render={<Button variant="ghost" size="icon-xs" />}
+          className="-ml-1 opacity-50 hover:opacity-100"
+          data-slot="combobox-chip-remove"
+        >
+          <XIcon className="pointer-events-none" />
+        </ComboboxPrimitive.ChipRemove>
+      )}
+    </ComboboxPrimitive.Chip>
+  );
+}
+
+function ComboboxChipsInput({
+  className,
+  children: _children,
+  ...props
+}: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      data-slot="combobox-chip-input"
+      className={cn('min-w-16 flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+function useComboboxAnchor() {
+  return React.useRef<HTMLDivElement | null>(null);
+}
+
+export {
+  Combobox,
+  ComboboxInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxLabel,
+  ComboboxCollection,
+  ComboboxEmpty,
+  ComboboxSeparator,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxChipsInput,
+  ComboboxTrigger,
+  ComboboxValue,
+  useComboboxAnchor,
+};

--- a/calendar-ui/src/components/ui/form.tsx
+++ b/calendar-ui/src/components/ui/form.tsx
@@ -90,8 +90,10 @@ FormItem.displayName = 'FormItem';
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & {
+    showDirtyIndicator?: boolean;
+  }
+>(({ className, children, showDirtyIndicator = true, ...props }, ref) => {
   const { error, formItemId, isDirty } = useFormField();
 
   return (
@@ -106,7 +108,7 @@ const FormLabel = React.forwardRef<
       {...props}
     >
       <span className="inline-flex items-center">{children}</span>
-      {isDirty && (
+      {showDirtyIndicator && isDirty && (
         <Badge variant="warning" className="ml-2">
           Changed
         </Badge>

--- a/calendar-ui/src/components/ui/input-group.tsx
+++ b/calendar-ui/src/components/ui/input-group.tsx
@@ -1,0 +1,168 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
+        'h-9 min-w-0 has-[>textarea]:h-auto',
+
+        // Variants based on alignment.
+        'has-[>[data-align=inline-start]]:[&>input]:pl-2',
+        'has-[>[data-align=inline-end]]:[&>input]:pr-2',
+        'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
+        'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
+
+        // Focus state.
+        'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
+
+        // Error state.
+        'has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
+
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        'inline-start':
+          'order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]',
+        'inline-end':
+          'order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]',
+        'block-start':
+          'order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3',
+        'block-end':
+          'order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3',
+      },
+    },
+    defaultVariants: {
+      align: 'inline-start',
+    },
+  }
+);
+
+function InputGroupAddon({
+  className,
+  align = 'inline-start',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('button')) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector('input')?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  'flex items-center gap-2 text-sm shadow-none',
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: 'h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5',
+        'icon-xs':
+          'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+        'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
+      },
+    },
+    defaultVariants: {
+      size: 'xs',
+    },
+  }
+);
+
+function InputGroupButton({
+  className,
+  type = 'button',
+  variant = 'ghost',
+  size = 'xs',
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, 'size'> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      className={cn(
+        "text-muted-foreground flex items-center gap-2 text-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<'input'>) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<'textarea'>) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+};

--- a/calendar-ui/src/components/ui/input.tsx
+++ b/calendar-ui/src/components/ui/input.tsx
@@ -1,25 +1,21 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          'border-input bg-background ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Input.displayName = 'Input';
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'border-input selection:bg-primary selection:text-primary-foreground file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Input };

--- a/calendar-ui/src/components/ui/textarea.tsx
+++ b/calendar-ui/src/components/ui/textarea.tsx
@@ -1,24 +1,18 @@
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
-
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Textarea.displayName = 'Textarea';
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Textarea };

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -1,12 +1,26 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
+import { useForm, type Resolver } from 'react-hook-form';
 import { toast } from 'sonner';
-import { useCallback, useState } from 'react';
+import { z } from 'zod';
+import { useEffect, useRef, useState } from 'react';
 
 import type { CreateUserBody } from '@corpcal/shared/api/types';
 import { createUser, fetchRoles, fetchTeams } from '@/api/usersApi';
 import { Button } from '@/components/ui/button';
-import { Combobox } from '@/components/ui/combobox';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
@@ -15,8 +29,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -24,6 +45,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+
+const createUserFormSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required')
+    .email('Invalid email format'),
+  roleId: z.string().min(1, 'Role is required'),
+  displayName: z.string().trim().default(''),
+  teamIds: z.array(z.number().int()).default([]),
+});
+
+type CreateUserFormData = z.infer<typeof createUserFormSchema>;
+
+const defaultValues: CreateUserFormData = {
+  email: '',
+  roleId: '',
+  displayName: '',
+  teamIds: [],
+};
 
 interface UserCreateModalProps {
   open: boolean;
@@ -40,12 +81,18 @@ export function UserCreateModal({
   onClose,
   onSaved,
 }: UserCreateModalProps) {
-  const [email, setEmail] = useState('');
-  const [roleId, setRoleId] = useState<string>('');
-  const [displayName, setDisplayName] = useState('');
-  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
-
+  const teamsAnchorRef = useComboboxAnchor();
+  const dialogContentRef = useRef<HTMLDivElement>(null);
+  const [isTeamsComboboxOpen, setIsTeamsComboboxOpen] = useState(false);
   const queryClient = useQueryClient();
+
+  const form = useForm<CreateUserFormData>({
+    defaultValues,
+
+    resolver: zodResolver(
+      createUserFormSchema as any
+    ) as Resolver<CreateUserFormData>,
+  });
 
   const { data: roles = [] } = useQuery({
     queryKey: ['roles'],
@@ -67,12 +114,9 @@ export function UserCreateModal({
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['users'] });
       toast.success('User created');
+      form.reset(defaultValues);
       onSaved?.();
       onClose();
-      setEmail('');
-      setRoleId('');
-      setDisplayName('');
-      setSelectedTeamIds([]);
     },
     onError: (err: Error & { response?: { status?: number } }) => {
       const status = err.response?.status;
@@ -84,51 +128,55 @@ export function UserCreateModal({
     },
   });
 
-  const handleTeamToggle = useCallback((value: string) => {
-    setSelectedTeamIds((prev) =>
-      prev.includes(value)
-        ? prev.filter((id) => id !== value)
-        : [...prev, value]
-    );
-  }, []);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const trimmedEmail = email.trim();
-    if (!trimmedEmail) {
-      toast.error('Email is required');
-      return;
+  useEffect(() => {
+    if (!open) {
+      form.reset(defaultValues);
     }
-    const parsedRoleId = parseInt(roleId, 10);
-    if (Number.isNaN(parsedRoleId)) {
-      toast.error('Role is required');
-      return;
-    }
-    const body: CreateUserBody = {
-      email: trimmedEmail,
-      roleId: parsedRoleId,
-      ...(displayName.trim() && { displayName: displayName.trim() }),
-      ...(selectedTeamIds.length > 0 && {
-        teams: selectedTeamIds.map((id) => ({
-          teamId: parseInt(id, 10),
-          role: 'member',
-        })),
-      }),
-    };
-    createMutation.mutate(body);
-  };
+  }, [open, form]);
 
   const teamOptions = teams.map((t) => ({
     value: String(t.id),
     label: t.displayName ?? t.name ?? `Team ${t.id}`,
   }));
 
-  const selectedRole = roles.find((r) => String(r.id) === roleId);
-  const roleDescription = selectedRole?.description?.trim();
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      form.reset(defaultValues);
+      onClose();
+    }
+  };
+
+  const onSubmit = (data: CreateUserFormData) => {
+    const parsedRoleId = parseInt(data.roleId, 10);
+    if (Number.isNaN(parsedRoleId)) {
+      form.setError('roleId', { message: 'Role is required' });
+      return;
+    }
+    const body: CreateUserBody = {
+      email: data.email.trim(),
+      roleId: parsedRoleId,
+      ...(data.displayName?.trim() && {
+        displayName: data.displayName.trim(),
+      }),
+      ...(data.teamIds &&
+        data.teamIds.length > 0 && {
+          teams: data.teamIds.map((teamId) => ({
+            teamId,
+            role: 'member' as const,
+          })),
+        }),
+    };
+    createMutation.mutate(body);
+  };
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        ref={dialogContentRef}
+        onEscapeKeyDown={(e) => {
+          if (isTeamsComboboxOpen) e.preventDefault();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Add user</DialogTitle>
           <DialogDescription>
@@ -136,76 +184,160 @@ export function UserCreateModal({
             account.
           </DialogDescription>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="create-user-email">
-              Email <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="create-user-email"
-              type="email"
-              required
-              placeholder="user@example.gov.bc.ca"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              autoComplete="email"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="create-user-role">
-              Role <span className="text-destructive">*</span>
-            </Label>
-            <Select value={roleId} onValueChange={setRoleId} required>
-              <SelectTrigger id="create-user-role">
-                <SelectValue placeholder="Select role" />
-              </SelectTrigger>
-              <SelectContent>
-                {roles.map((r) => (
-                  <SelectItem key={r.id} value={String(r.id)}>
-                    {r.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {roleDescription && (
-              <div className="bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm">
-                {roleDescription}
-              </div>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="create-user-display-name">Display name</Label>
-            <Input
-              id="create-user-display-name"
-              type="text"
-              placeholder="Optional"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Teams</Label>
-            <Combobox
-              options={teamOptions}
-              selectedValues={selectedTeamIds}
-              onSelect={handleTeamToggle}
-              placeholder="Select teams..."
-              searchPlaceholder="Search teams..."
-              emptyMessage="No teams found."
-            />
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={createMutation.isPending}>
-              {createMutation.isPending && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        <Form {...form}>
+          <form
+            onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel showDirtyIndicator={false}>
+                    Email <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="example@gov.bc.ca"
+                      autoComplete="email"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-              Create user
-            </Button>
-          </DialogFooter>
-        </form>
+            />
+            <FormField
+              control={form.control}
+              name="displayName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel showDirtyIndicator={false}>Display name</FormLabel>
+                  <FormControl>
+                    <Input type="text" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="roleId"
+              render={({ field }) => {
+                const selectedRole = roles.find(
+                  (r) => String(r.id) === field.value
+                );
+                const roleDescription = selectedRole?.description?.trim();
+                return (
+                  <FormItem>
+                    <FormLabel showDirtyIndicator={false}>
+                      Role <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl data-field={field.name}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select role" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {roles.map((r) => (
+                          <SelectItem key={r.id} value={String(r.id)}>
+                            {r.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {roleDescription && (
+                      <div className="bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm">
+                        {roleDescription}
+                      </div>
+                    )}
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
+            />
+            <FormField
+              control={form.control}
+              name="teamIds"
+              render={({ field }) => {
+                const currentValues = Array.isArray(field.value)
+                  ? field.value.map((v) => String(v))
+                  : [];
+                const selectedOptions = teamOptions.filter((o) =>
+                  currentValues.includes(o.value)
+                );
+                return (
+                  <FormItem>
+                    <FormLabel showDirtyIndicator={false}>Teams</FormLabel>
+                    <FormControl data-field={field.name}>
+                      <Combobox
+                        items={teamOptions}
+                        multiple
+                        value={selectedOptions}
+                        onValueChange={(selected) => {
+                          field.onChange(
+                            selected.map((o) => parseInt(o.value, 10))
+                          );
+                        }}
+                        itemToStringValue={(o) => o.label}
+                        onOpenChange={(open) => setIsTeamsComboboxOpen(open)}
+                      >
+                        <ComboboxChips ref={teamsAnchorRef} className="w-full">
+                          <ComboboxValue>
+                            {(
+                              values: Array<{
+                                value: string;
+                                label: string;
+                              }>
+                            ) => (
+                              <>
+                                {values.map((option) => (
+                                  <ComboboxChip key={option.value}>
+                                    {option.label}
+                                  </ComboboxChip>
+                                ))}
+                                <ComboboxChipsInput placeholder="Select teams..." />
+                              </>
+                            )}
+                          </ComboboxValue>
+                        </ComboboxChips>
+                        <ComboboxContent
+                          anchor={teamsAnchorRef}
+                          container={dialogContentRef}
+                          className="max-h-72"
+                        >
+                          <ComboboxEmpty>No teams found.</ComboboxEmpty>
+                          <ComboboxList>
+                            {(option: { value: string; label: string }) => (
+                              <ComboboxItem key={option.value} value={option}>
+                                {option.label}
+                              </ComboboxItem>
+                            )}
+                          </ComboboxList>
+                        </ComboboxContent>
+                      </Combobox>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
+            />
+            <DialogFooter className="mt-8">
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Create user
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -1,36 +1,211 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useCallback, useState } from 'react';
+
+import type { CreateUserBody } from '@corpcal/shared/api/types';
+import { createUser, fetchRoles, fetchTeams } from '@/api/usersApi';
 import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 interface UserCreateModalProps {
   open: boolean;
   onClose: () => void;
+  onSaved?: () => void;
 }
 
 /**
- * Modal for the "Add user" flow. User creation is not yet supported by the API;
- * users are added when they first sign in. This modal explains that and can be
- * extended when a create-user endpoint is available.
+ * Modal for the "Add user" flow. Creates a local user (email + role required)
+ * so they can sign in with Azure AD; optional display name and initial teams.
  */
-export function UserCreateModal({ open, onClose }: UserCreateModalProps) {
+export function UserCreateModal({
+  open,
+  onClose,
+  onSaved,
+}: UserCreateModalProps) {
+  const [email, setEmail] = useState('');
+  const [roleId, setRoleId] = useState<string>('');
+  const [displayName, setDisplayName] = useState('');
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+
+  const queryClient = useQueryClient();
+
+  const { data: roles = [] } = useQuery({
+    queryKey: ['roles'],
+    queryFn: async () => {
+      const res = await fetchRoles();
+      return res;
+    },
+    enabled: open,
+  });
+
+  const { data: teams = [] } = useQuery({
+    queryKey: ['teams'],
+    queryFn: fetchTeams,
+    enabled: open,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (body: CreateUserBody) => createUser(body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      toast.success('User created');
+      onSaved?.();
+      onClose();
+      setEmail('');
+      setRoleId('');
+      setDisplayName('');
+      setSelectedTeamIds([]);
+    },
+    onError: (err: Error & { response?: { status?: number } }) => {
+      const status = err.response?.status;
+      const message =
+        status === 409
+          ? 'A user with this email already exists.'
+          : err.message || 'Create failed';
+      toast.error(message);
+    },
+  });
+
+  const handleTeamToggle = useCallback((value: string) => {
+    setSelectedTeamIds((prev) =>
+      prev.includes(value)
+        ? prev.filter((id) => id !== value)
+        : [...prev, value]
+    );
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      toast.error('Email is required');
+      return;
+    }
+    const parsedRoleId = parseInt(roleId, 10);
+    if (Number.isNaN(parsedRoleId)) {
+      toast.error('Role is required');
+      return;
+    }
+    const body: CreateUserBody = {
+      email: trimmedEmail,
+      roleId: parsedRoleId,
+      ...(displayName.trim() && { displayName: displayName.trim() }),
+      ...(selectedTeamIds.length > 0 && {
+        teams: selectedTeamIds.map((id) => ({
+          teamId: parseInt(id, 10),
+          role: 'member',
+        })),
+      }),
+    };
+    createMutation.mutate(body);
+  };
+
+  const teamOptions = teams.map((t) => ({
+    value: String(t.id),
+    label: t.displayName ?? t.name ?? `Team ${t.id}`,
+  }));
+
+  const selectedRole = roles.find((r) => String(r.id) === roleId);
+  const roleDescription = selectedRole?.description?.trim();
+
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Add user</DialogTitle>
+          <DialogDescription>
+            Create a new user. Users can sign in with their email and Microsoft
+            account.
+          </DialogDescription>
         </DialogHeader>
-        <p className="text-sm text-slate-600">
-          User creation is not yet available. Users are added to the system when
-          they first sign in to the application.
-        </p>
-        <DialogFooter>
-          <Button onClick={onClose}>Close</Button>
-        </DialogFooter>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="create-user-email">
+              Email <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="create-user-email"
+              type="email"
+              required
+              placeholder="user@example.gov.bc.ca"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="create-user-role">
+              Role <span className="text-destructive">*</span>
+            </Label>
+            <Select value={roleId} onValueChange={setRoleId} required>
+              <SelectTrigger id="create-user-role">
+                <SelectValue placeholder="Select role" />
+              </SelectTrigger>
+              <SelectContent>
+                {roles.map((r) => (
+                  <SelectItem key={r.id} value={String(r.id)}>
+                    {r.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {roleDescription && (
+              <div className="bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm">
+                {roleDescription}
+              </div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="create-user-display-name">Display name</Label>
+            <Input
+              id="create-user-display-name"
+              type="text"
+              placeholder="Optional"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Teams</Label>
+            <Combobox
+              options={teamOptions}
+              selectedValues={selectedTeamIds}
+              onSelect={handleTeamToggle}
+              placeholder="Select teams..."
+              searchPlaceholder="Search teams..."
+              emptyMessage="No teams found."
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Create user
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/calendar-ui/src/styles/globals.css
+++ b/calendar-ui/src/styles/globals.css
@@ -169,7 +169,7 @@
     --fluent-primary: #0f6cbd;
     /* BCSDS semantic tokens */
     --sidebar-foreground-active: var(--fluent-primary);
-    --bcsds-button-primary-background: var(--bcsds-bc-blue-95);
+    --bcsds-button-primary-background: var(--fluent-primary);
     --bcsds-button-primary-foreground: var(--bcsds-white-00);
     --bcsds-button-primary-hover-background: var(--bcsds-bc-blue-90);
 

--- a/docs/AUTH_AND_RBAC.md
+++ b/docs/AUTH_AND_RBAC.md
@@ -589,6 +589,10 @@ When `AUTH_STRATEGY=azure`:
 
 If no active local account can be linked, login is denied with `azure_no_account`.
 
+### Adding users
+
+Admins with the `users.create` permission can add users via **Add user** on the User Management page. They provide the user's **email** (required), role, and optionally display name and initial team(s). A local account is created; email is required so the user can be matched when they first sign in with Microsoft. When that person signs in with Azure AD, they are matched by email and their identity is linked. No separate invite email is sent; the user must use the same email address when signing in.
+
 ## Active Directory Integration (Production)
 
 When `AUTH_STRATEGY=ad`, the `ad.strategy.ts` file remains the extension point for direct AD credential validation flows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
     "calendar-ui": {
       "version": "1.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.3.0",
         "@corpcal/shared": "*",
         "@fluentui/react": "^8.123.0",
         "@fluentui/react-components": "^9.64.1",
@@ -707,6 +708,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@base-ui/utils": "0.2.6",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.4.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
+      "integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -18738,6 +18792,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
@@ -20176,6 +20236,12 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tabster": {
       "version": "8.7.0",

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -29,6 +29,7 @@ export type {
   UserListItem,
   UserDetail,
   RoleOption,
+  CreateUserBody,
   UpdateUserBody,
   AddUserToTeamBody,
   UpdateUserTeamRoleBody,

--- a/packages/shared/src/schemas/user.schema.spec.ts
+++ b/packages/shared/src/schemas/user.schema.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   addUserToTeamBodySchema,
+  createUserBodySchema,
   TEAM_ROLES,
   transferActivitiesBodySchema,
   updateUserTeamRoleBodySchema,
@@ -39,6 +40,60 @@ describe('userListItemSchema', () => {
     });
     expect(result.adUsername).toBeNull();
     expect(result.teams).toEqual([]);
+  });
+});
+
+describe('createUserBodySchema', () => {
+  it('accepts valid body with email and roleId', () => {
+    const result = createUserBodySchema.parse({
+      email: 'user@example.gov.bc.ca',
+      roleId: 1,
+    });
+    expect(result.email).toBe('user@example.gov.bc.ca');
+    expect(result.roleId).toBe(1);
+    expect(result.displayName).toBeUndefined();
+    expect(result.teams).toBeUndefined();
+  });
+
+  it('accepts optional displayName and teams', () => {
+    const result = createUserBodySchema.parse({
+      email: 'user@example.com',
+      roleId: 2,
+      displayName: 'Jane Doe',
+      teams: [
+        { teamId: 1, role: 'member' },
+        { teamId: 2, role: 'owner' },
+      ],
+    });
+    expect(result.displayName).toBe('Jane Doe');
+    expect(result.teams).toHaveLength(2);
+    expect(result.teams?.[0].role).toBe('member');
+    expect(result.teams?.[1].role).toBe('owner');
+  });
+
+  it('rejects missing email', () => {
+    expect(() => createUserBodySchema.parse({ roleId: 1 })).toThrow();
+  });
+
+  it('rejects missing roleId', () => {
+    expect(() =>
+      createUserBodySchema.parse({ email: 'u@example.com' })
+    ).toThrow();
+  });
+
+  it('rejects invalid email format', () => {
+    expect(() =>
+      createUserBodySchema.parse({
+        email: 'not-an-email',
+        roleId: 1,
+      })
+    ).toThrow();
+  });
+
+  it('rejects empty email', () => {
+    expect(() =>
+      createUserBodySchema.parse({ email: '   ', roleId: 1 })
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -65,6 +65,7 @@ export type UserDetail = z.infer<typeof userDetailSchema>;
 export const roleOptionSchema = z.object({
   id: z.number().int(),
   name: z.string(),
+  description: z.string().nullable(),
 });
 
 export type RoleOption = z.infer<typeof roleOptionSchema>;
@@ -72,6 +73,29 @@ export type RoleOption = z.infer<typeof roleOptionSchema>;
 // ============================================
 // Request Body Schemas
 // ============================================
+
+/**
+ * POST /users - Create a new user (admin). Email is required for Azure AD match on first sign-in.
+ */
+export const createUserBodySchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required')
+    .email('Invalid email format'),
+  roleId: z.number().int(),
+  displayName: z.string().trim().optional(),
+  teams: z
+    .array(
+      z.object({
+        teamId: z.number().int(),
+        role: z.enum(TEAM_ROLES),
+      })
+    )
+    .optional(),
+});
+
+export type CreateUserBody = z.infer<typeof createUserBodySchema>;
 
 /**
  * PATCH /users/:id - Update a user's role, active status, or notes.


### PR DESCRIPTION
## Summary

Scaffolds a basic create user modal that allows admin to create a new user, give them a role, and add them to teams.

- add scaffold create new user modal to users management page
- add create user to users.controller users.service
- add create to frontend api
<img width="559" height="535" alt="Screenshot 2026-03-12 at 9 44 40 AM" src="https://github.com/user-attachments/assets/20b6fa1d-438b-4faf-a8b4-96b988642b54" />


## Testing
- Manually tested create action successfully
- Updated tests for users.service and users.controller; all tests passing