### PR TITLE
Proxy API requests to calendar-service backend

### DIFF
--- a/calendar-ui/nginx.conf
+++ b/calendar-ui/nginx.conf
@@ -32,5 +32,16 @@ server {
         add_header Pragma "no-cache";
         add_header Expires "0";
     }
+
+    # Proxy API requests to calendar-service backend
+    # Strips /api prefix before forwarding (mirrors the Vite dev proxy)
+    location /api/ {
+        proxy_pass http://calendar-service:3001/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }
 


### PR DESCRIPTION
 This is for redirects when the user is trying to authenticate
 
 location /api/ {
        proxy_pass http://calendar-service:3001/;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;