### PR TITLE
fix(typecheck): fix imports and type errors

### DIFF
--- a/calendar-service/test/banner.api-permissions.spec.ts
+++ b/calendar-service/test/banner.api-permissions.spec.ts
@@ -1,34 +1,56 @@
-import request from 'supertest';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 
-import { getAuthTokenForRole, startTestServer } from '../test/utils';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { createAuthRequest, e2eLogin } from './test-helpers';
 
-// This test file assumes test helpers exist to start the server and obtain tokens.
 describe('Banner API permissions', () => {
-  let app: any;
+  let app: INestApplication;
+  let nonAdminToken: string;
+  let systemAdminToken: string;
+
+  const upsertBody = {
+    isActive: true,
+    content: '<p>test</p>',
+    backgroundColor: '#ffffff',
+    textColor: '#000000',
+    isDismissible: true,
+    startDateTime: null,
+    endDateTime: null,
+  };
 
   beforeAll(async () => {
-    app = await startTestServer();
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    nonAdminToken = await e2eLogin(app, 'thomas.garcia');
+    systemAdminToken = await e2eLogin(app, 'daniel.robinson');
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   it('forbids non-admin users from updating banner', async () => {
-    const token = await getAuthTokenForRole('user');
-    const res = await request(app)
-      .post('/api/admin/banner')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ content: '<p>test</p>' });
-
-    expect(res.status).toBe(403);
+    await createAuthRequest(app, nonAdminToken)
+      .put('/banner/settings')
+      .send(upsertBody)
+      .expect(403);
   });
 
   it('allows system admins to update banner', async () => {
-    const token = await getAuthTokenForRole('system-admin');
-    const res = await request(app)
-      .post('/api/admin/banner')
-      .set('Authorization', `Bearer ${token}`)
-      .send({ content: '<p>test</p>' });
+    const res = await createAuthRequest(app, systemAdminToken)
+      .put('/banner/settings')
+      .send(upsertBody)
+      .expect(200);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
   });
 });

--- a/calendar-service/test/test-helpers.ts
+++ b/calendar-service/test/test-helpers.ts
@@ -41,7 +41,7 @@ export async function e2eLogin(
 
 /**
  * Returns a supertest-like object that sends Authorization: Bearer <token> on every request.
- * In supertest v7, request(server) only has .get/.post/etc.; .set() is on the result of those.
+ * In supertest v7, request(server) only has .get/.post/.put/etc.; .set() is on the result of those.
  */
 export function createAuthRequest(app: INestApplication, accessToken: string) {
   const server = app.getHttpServer();
@@ -49,6 +49,7 @@ export function createAuthRequest(app: INestApplication, accessToken: string) {
   return {
     get: (path: string) => request(server).get(path).set(authHeader),
     post: (path: string) => request(server).post(path).set(authHeader),
+    put: (path: string) => request(server).put(path).set(authHeader),
     patch: (path: string) => request(server).patch(path).set(authHeader),
     delete: (path: string) => request(server).delete(path).set(authHeader),
   };

--- a/calendar-ui/src/lib/report-pdf-export.ts
+++ b/calendar-ui/src/lib/report-pdf-export.ts
@@ -60,7 +60,7 @@ function formatTime(dateStr: string | null, timeStr: string | null): string {
   return '–';
 }
 
-function statusLabel(status: string | null): string {
+function statusLabel(status: string | null | undefined): string {
   if (!status || status === 'none') return '–';
   return status === 'new' ? 'NEW' : 'CHANGED';
 }


### PR DESCRIPTION
## Summary

Patch to fix type errors and import paths.

- refactor banner permission tests to Nest TestingModule and PUT /banner/settings
- add put() to createAuthRequest for authenticated PUT requests
- accept undefined in statusLabel in report-pdf-export for stricter types