### PR TITLE
refactor(service): remove unnecessary type assertion

### DIFF
--- a/calendar-service/src/activities/activities.controller.ts
+++ b/calendar-service/src/activities/activities.controller.ts
@@ -271,7 +271,7 @@ export class ActivitiesController {
         page: parsedPage,
         pageSize: parsedPageSize,
         query,
-        order: order as 'asc' | 'desc' | undefined,
+        order: order,
       },
       ctx
     );


### PR DESCRIPTION
- activitiesService.getGlobalHistoryPaged typecast result.order
- order already had the identical type, causing a linter error
- removed typecast