### PR TITLE
fix(nginx): forward WebSocket upgrade headers to enable Socket.IO in …

### DIFF
--- a/calendar-ui/nginx.conf
+++ b/calendar-ui/nginx.conf
@@ -58,6 +58,12 @@ server {
         proxy_pass ${API_PROXY_UPSTREAM}/;
         proxy_http_version 1.1;
 
+        # Forward WebSocket upgrade headers so Socket.IO can upgrade from HTTP
+        # polling to a true WebSocket connection. Without these, nginx drops the
+        # hop-by-hop Upgrade header and the handshake never completes.
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/calendar-ui/nginx.main.conf
+++ b/calendar-ui/nginx.main.conf
@@ -13,5 +13,13 @@ http {
   sendfile on;
   keepalive_timeout 65;
 
+  # Required for WebSocket proxying: set Connection header based on whether the
+  # client is requesting an upgrade (WebSocket). Without this, nginx strips the
+  # Upgrade header and Socket.IO falls back to HTTP long-polling indefinitely.
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
   include /tmp/default.conf;
 }


### PR DESCRIPTION
…OpenShift

Without proxy_set_header Upgrade and Connection headers, nginx drops the hop-by-hop Upgrade header on proxied requests. Socket.IO never completes the WebSocket handshake and falls back to HTTP long-polling indefinitely. Add a  map in nginx.main.conf and the two required proxy headers in the /api/ location block.

No configuration points need to be set for this. It should just work as is.