### PR TITLE
fix(service): add activityhistoryservice to usersservice test module

### DIFF
--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { ActivityHistoryService } from '../activities/services/activity-history.service';
 import {
   createMockAddUserToTeamBody,
   createMockTransferActivitiesBody,
@@ -60,6 +61,10 @@ describe('UsersService', () => {
     },
   };
 
+  const mockActivityHistoryService = {
+    recordChange: vi.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,6 +72,10 @@ describe('UsersService', () => {
         {
           provide: DatabaseService,
           useValue: mockDatabaseService,
+        },
+        {
+          provide: ActivityHistoryService,
+          useValue: mockActivityHistoryService,
         },
       ],
     }).compile();
@@ -558,6 +567,7 @@ describe('UsersService', () => {
             'where'
           )
         )
+        .mockReturnValueOnce(createChain([], 'where'))
         .mockReturnValueOnce(createChain([], 'limit'))
         .mockReturnValueOnce(createChain([], 'limit'));
 
@@ -583,6 +593,7 @@ describe('UsersService', () => {
 
       expect(result).toEqual({ transferredCount: 2 });
       expect(mockDatabaseService.db.transaction).toHaveBeenCalledTimes(1);
+      expect(mockActivityHistoryService.recordChange).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Tests for users.service were failing because ActivityHistoryService hadn't been provided to the mocks. This PR adds ActivityHistoryService to the users.service.spec.

## Changes

- Import ActivityHistoryService, add mockActivityHistoryService
- Adjust transferActivities mocks: second select uses 'where'
- add a fourth mockReturnValueOnce with 'limit' so both in-transaction tx.select…limit(1) calls are covered
- register mockActivityHistoryService in test providers

## Testing

- Failing tests now pass