### PR TITLE
refactor/corpcal-215 update new status behaviour

### DIFF
--- a/calendar-service/docs/ACTIVITY_REVIEW_SNAPSHOT.md
+++ b/calendar-service/docs/ACTIVITY_REVIEW_SNAPSHOT.md
@@ -17,7 +17,7 @@ Two columns on the `activities` table:
 | `reviewed_field_snapshot`         | `jsonb`   | Yes      | `NULL`  | Canonical form-data snapshot at last Reviewed transition |
 | `reviewed_field_snapshot_version` | `integer` | No       | `1`     | Schema version of the snapshot shape (see Versioning)    |
 
-When `reviewed_field_snapshot` is `NULL`, the baseline is the **canonical empty form** (all fields at their default/empty values). This means New activities that have never been Reviewed will show all populated fields as "changed since last review."
+When `reviewed_field_snapshot` is `NULL`, the baseline for diff purposes is the **canonical empty form** (all fields at their default/empty values). Activities in **New** status never show review-diff badges: `changedFieldsSinceReview` is an empty list for reviewers until the activity has left **New** (there is no "last review" yet). For **Changed** or **Reviewed** rows with a null snapshot (e.g. after restore from **Deleted**), the empty-form baseline applies and non-empty fields may appear in the diff.
 
 ## Baseline Definition
 
@@ -27,16 +27,17 @@ When no snapshot exists (never Reviewed, or cleared by Deleted), the baseline is
 
 ## Status Lifecycle Rules
 
-| Status Transition                 | Snapshot Behaviour                                  |
-| --------------------------------- | --------------------------------------------------- |
-| **Create as New**                 | No snapshot written; `NULL` baseline (empty form)   |
-| **Create as Reviewed**            | Snapshot written from the created activity state    |
-| **Update to Reviewed**            | Snapshot replaced with the post-update state        |
-| **Update to Changed**             | Snapshot unchanged (baseline remains last Reviewed) |
-| **Delete requested**              | Snapshot unchanged                                  |
-| **Soft delete (Deleted)**         | Snapshot cleared (`NULL`), version reset            |
-| **Restore from Deleted**          | Snapshot remains `NULL` (cleared state persists)    |
-| **Restore from Delete requested** | Snapshot unchanged                                  |
+| Status Transition                 | Snapshot Behaviour                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------ |
+| **Create as New**                 | No snapshot written; `NULL` baseline (empty form)                                    |
+| **Update while New**              | Status stays **New** until reviewed; no snapshot; reviewers get no review-diff paths |
+| **Create as Reviewed**            | Snapshot written from the created activity state                                     |
+| **Update to Reviewed**            | Snapshot replaced with the post-update state                                         |
+| **Update to Changed**             | Snapshot unchanged (baseline remains last Reviewed)                                  |
+| **Delete requested**              | Snapshot unchanged                                                                   |
+| **Soft delete (Deleted)**         | Snapshot cleared (`NULL`), version reset                                             |
+| **Restore from Deleted**          | Snapshot remains `NULL` (cleared state persists)                                     |
+| **Restore from Delete requested** | Snapshot unchanged                                                                   |
 
 ## API Response
 
@@ -48,7 +49,8 @@ changedFieldsSinceReview?: string[]
 
 - **Included** only when the requesting user has `activities.review` permission.
 - **Omitted** for non-reviewers (not present on the response object).
-- Contains dotted field paths matching RHF form field names (e.g. `title`, `venueAddress.city`, `categoryIds`).
+- For activities in **New** status, included as an **empty** array (no "changed since last review" until the first **Reviewed** transition).
+- Otherwise contains dotted field paths matching RHF form field names (e.g. `title`, `venueAddress.city`, `categoryIds`).
 
 ## UI Indicators
 

--- a/calendar-service/docs/ACTIVITY_STATUS_FLOW.md
+++ b/calendar-service/docs/ACTIVITY_STATUS_FLOW.md
@@ -8,15 +8,15 @@ For general edit permission (who may PATCH an activity, UI read-only rules, and 
 
 ## Statuses
 
-| Status               | Description                                                                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **New**              | Initial state when an activity is created (non-admin).                                                                                   |
-| **Changed**          | Set after any edit unless an admin marks as reviewed.                                                                                    |
-| **Reviewed**         | Set when a user with `activities.review` marks an activity reviewed (create confirm, or edit **Review** / update with `markAsReviewed`). |
-| **Delete requested** | Set when a Comms contact or a member of the activity's lead team requests deletion (notes required).                                     |
-| **Deleted**          | Soft delete; set when an admin/sysAdmin performs "Soft delete" (notes required).                                                         |
-| **Completed**        | Set by a scheduled job a fixed delay after the activity end time (or after midnight for all-day activities).                             |
-| **On hold**          | Not yet implemented; reserved for future use.                                                                                            |
+| Status               | Description                                                                                                                                                                       |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **New**              | Initial state when an activity is created (non-admin). Stays **New** on ordinary saves until someone with `activities.review` marks it **Reviewed**.                              |
+| **Changed**          | Set when an activity that was already **Reviewed** is saved again without being marked reviewed (or via restore fallback). Not used merely because a **New** activity was edited. |
+| **Reviewed**         | Set when a user with `activities.review` marks an activity reviewed (create confirm, or edit **Review** / update with `markAsReviewed`).                                          |
+| **Delete requested** | Set when a Comms contact or a member of the activity's lead team requests deletion (notes required).                                                                              |
+| **Deleted**          | Soft delete; set when an admin/sysAdmin performs "Soft delete" (notes required).                                                                                                  |
+| **Completed**        | Set by a scheduled job a fixed delay after the activity end time (or after midnight for all-day activities).                                                                      |
+| **On hold**          | Not yet implemented; reserved for future use.                                                                                                                                     |
 
 Status is not user-editable on the activity form; it is set by the system based on the action and the user's role.
 
@@ -29,7 +29,7 @@ Status is not user-editable on the activity form; it is set by the system based 
 ## How Status Is Set
 
 - **Create**: New activity is set to **New**. If the user has `activities.review` and submits with "Mark as reviewed" checked on the create confirmation dialog, status is set to **Reviewed**.
-- **Update**: If current status is **Delete requested** or **Deleted**, updates are rejected. Otherwise: users **without** `activities.review` always set status to **Changed** on save. Users **with** `activities.review` set **Reviewed** when they either use the **Review** action on the activity edit page (or save with pending changes via that flow) or send `markAsReviewed: true` on PATCH; saving changes with **Update** alone (without marking reviewed) sets **Changed**.
+- **Update**: If current status is **Delete requested** or **Deleted**, updates are rejected. Otherwise: while status is **New**, any successful save (with or without `activities.review`) keeps **New** unless the user has `activities.review` and submits with **Review** / `markAsReviewed: true`, in which case status becomes **Reviewed**. Once status is **Reviewed**, a later save without marking reviewed sets **Changed**; users with `activities.review` set **Reviewed** when they use **Review** / `markAsReviewed: true` on PATCH.
 - **Request delete**: Sets status to **Delete requested**. Notes are required. Comms contacts on the activity or members of the activity's lead team may call this.
 - **Soft delete**: Sets status to **Deleted**. Notes (reason) are required.
 - **Hard delete**: A note is required. The delete and the identity of who deleted are recorded in activity history before the activity row is removed.

--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -9,7 +9,7 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 
 import type { Activity } from '@corpcal/database/types';
-import { PERMISSIONS } from '@corpcal/shared';
+import { PERMISSIONS, REVIEW_SNAPSHOT_VERSION } from '@corpcal/shared';
 import {
   activityResponseSchema,
   type UpdateActivityRequest,
@@ -18,6 +18,7 @@ import {
 import {
   createMockActivity,
   createMockActivityRequest,
+  createMockActivityResponse,
   createMockUpdateRequest,
 } from '../common/test-utils';
 import { DatabaseService } from '../database/database.service';
@@ -1194,6 +1195,198 @@ describe('ActivitiesService', () => {
       expect(
         mockLocksService.completeHandoffAfterHolderSaveIfPending
       ).not.toHaveBeenCalled();
+    });
+
+    it('keeps New on update when current status is New and user does not mark reviewed', async () => {
+      const newStatusId = 7;
+      const existingActivity = createMockActivity({
+        id: 1,
+        activityStatusId: newStatusId,
+      });
+      const updatedActivity = createMockActivity({
+        id: 1,
+        title: 'Updated Activity',
+        activityStatusId: newStatusId,
+      });
+
+      mockDatabaseService.db.transaction = vi.fn(async (callback) => {
+        const tx = {
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            returning: vi.fn().mockResolvedValue([updatedActivity]),
+          }),
+          select: vi.fn().mockReturnValue(createMockQueryChain([])),
+          delete: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        };
+        return await callback(tx);
+      });
+
+      let noArgsCallCount = 0;
+      mockDatabaseService.db.select = vi.fn((...args) => {
+        if (args.length === 0) {
+          noArgsCallCount++;
+          return createMockQueryChain(
+            noArgsCallCount === 1 ? [existingActivity] : [updatedActivity]
+          );
+        }
+        const selectArg = args[0];
+        const isStatusNameQuery =
+          selectArg && typeof selectArg === 'object' && 'name' in selectArg;
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi
+            .fn()
+            .mockResolvedValue(
+              isStatusNameQuery ? [{ name: 'new' }] : [{ id: newStatusId }]
+            ),
+        };
+      });
+
+      const updateDto = createMockUpdateRequest({ title: 'Updated Activity' });
+      const result = await service.update(1, updateDto, 1, {
+        permissions: ['activities.edit'],
+        roleName: 'Editor',
+      });
+
+      expect(result.activityStatusId).toBe(newStatusId);
+      expect(
+        mockActivityHistoryService.recordChange.mock.calls.at(-1)?.[2]
+      ).toBe('updated');
+    });
+
+    it('keeps New when user has activities.review but does not send markAsReviewed', async () => {
+      const newStatusId = 7;
+      const existingActivity = createMockActivity({
+        id: 1,
+        activityStatusId: newStatusId,
+      });
+      const updatedActivity = createMockActivity({
+        id: 1,
+        title: 'Touched',
+        activityStatusId: newStatusId,
+      });
+
+      mockDatabaseService.db.transaction = vi.fn(async (callback) => {
+        const tx = {
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            returning: vi.fn().mockResolvedValue([updatedActivity]),
+          }),
+          select: vi.fn().mockReturnValue(createMockQueryChain([])),
+          delete: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        };
+        return await callback(tx);
+      });
+
+      let noArgsCallCount = 0;
+      mockDatabaseService.db.select = vi.fn((...args) => {
+        if (args.length === 0) {
+          noArgsCallCount++;
+          return createMockQueryChain(
+            noArgsCallCount === 1 ? [existingActivity] : [updatedActivity]
+          );
+        }
+        const selectArg = args[0];
+        const isStatusNameQuery =
+          selectArg && typeof selectArg === 'object' && 'name' in selectArg;
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi
+            .fn()
+            .mockResolvedValue(
+              isStatusNameQuery ? [{ name: 'new' }] : [{ id: newStatusId }]
+            ),
+        };
+      });
+
+      const result = await service.update(
+        1,
+        createMockUpdateRequest({ title: 'Touched' }),
+        1,
+        {
+          permissions: ['activities.review', 'activities.edit'],
+          roleName: 'Admin',
+        }
+      );
+
+      expect(result.activityStatusId).toBe(newStatusId);
+    });
+
+    it('sets Reviewed when activity is New and reviewer sends markAsReviewed', async () => {
+      const newStatusId = 7;
+      const reviewedStatusId = 2;
+      const existingActivity = createMockActivity({
+        id: 1,
+        activityStatusId: newStatusId,
+      });
+      const updatedActivity = createMockActivity({
+        id: 1,
+        title: 'Updated Activity',
+        activityStatusId: reviewedStatusId,
+      });
+
+      mockDatabaseService.db.transaction = vi.fn(async (callback) => {
+        const tx = {
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            returning: vi.fn().mockResolvedValue([updatedActivity]),
+          }),
+          select: vi.fn().mockReturnValue(createMockQueryChain([])),
+          delete: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        };
+        return await callback(tx);
+      });
+
+      let noArgsCallCount = 0;
+      mockDatabaseService.db.select = vi.fn((...args) => {
+        if (args.length === 0) {
+          noArgsCallCount++;
+          return createMockQueryChain(
+            noArgsCallCount === 1 ? [existingActivity] : [updatedActivity]
+          );
+        }
+        const selectArg = args[0];
+        const isStatusNameQuery =
+          selectArg && typeof selectArg === 'object' && 'name' in selectArg;
+        if (isStatusNameQuery) {
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue([{ name: 'new' }]),
+          };
+        }
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([{ id: reviewedStatusId }]),
+        };
+      });
+
+      const result = await service.update(
+        1,
+        createMockUpdateRequest({ markAsReviewed: true }),
+        1,
+        {
+          permissions: ['activities.review'],
+          roleName: 'Admin',
+        }
+      );
+
+      expect(result.activityStatusId).toBe(reviewedStatusId);
+      expect(
+        mockActivityHistoryService.recordChange.mock.calls.at(-1)?.[2]
+      ).toBe('reviewed');
     });
 
     it('should set status to reviewed on update when user has activities.review and markAsReviewed is true', async () => {
@@ -2470,6 +2663,43 @@ describe('ActivitiesService', () => {
       ).rejects.toThrow('STOP: validation passed');
 
       expect(mockTeamsService.getEligibleCommsUserIds).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('computeChangedFieldsSinceReview', () => {
+    it('returns empty array when activity status is New (display label)', () => {
+      const response = createMockActivityResponse({ activityStatus: 'New' });
+      const paths = service.computeChangedFieldsSinceReview(
+        response,
+        null,
+        REVIEW_SNAPSHOT_VERSION
+      );
+      expect(paths).toEqual([]);
+    });
+
+    it('diffs against empty baseline when not New and snapshot is null', () => {
+      const response = createMockActivityResponse({
+        activityStatus: 'Reviewed',
+        title: 'Filled title',
+      });
+      const paths = service.computeChangedFieldsSinceReview(
+        response,
+        null,
+        REVIEW_SNAPSHOT_VERSION
+      );
+      expect(paths).toContain('title');
+    });
+
+    it('returns undefined when snapshot version mismatches', () => {
+      const response = createMockActivityResponse({
+        activityStatus: 'Changed',
+      });
+      const paths = service.computeChangedFieldsSinceReview(
+        response,
+        null,
+        REVIEW_SNAPSHOT_VERSION + 1
+      );
+      expect(paths).toBeUndefined();
     });
   });
 });

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -42,6 +42,7 @@ import {
 } from '@corpcal/database/schema';
 import type { Activity, Category } from '@corpcal/database/types';
 import {
+  normalizeActivityStatusLabel,
   PERMISSIONS,
   PITCH_TRANSLATION_PENDING_LOOKUP_NAME,
   REVIEW_SNAPSHOT_VERSION,
@@ -246,7 +247,8 @@ export class ActivitiesService {
 
   /**
    * Compute changedFieldsSinceReview from the stored snapshot vs current response.
-   * Returns the diff paths array, or undefined when snapshot is absent / version mismatch.
+   * Returns undefined when snapshot version mismatches; [] when status is New (not yet reviewed);
+   * otherwise the diff paths vs last Reviewed snapshot (empty baseline when snapshot is null).
    */
   computeChangedFieldsSinceReview(
     response: ActivityResponse,
@@ -256,6 +258,9 @@ export class ActivitiesService {
   ): string[] | undefined {
     if (snapshotVersion !== REVIEW_SNAPSHOT_VERSION) {
       return undefined;
+    }
+    if (normalizeActivityStatusLabel(response.activityStatus) === 'new') {
+      return [];
     }
     const currentFormData = mapResponseToFormData(response, lookups);
     const baseline = snapshot
@@ -1741,11 +1746,17 @@ export class ActivitiesService {
       ...activityUpdateData
     } = dto;
 
-    // Compute new status: user with activities.review and markAsReviewed -> reviewed, else changed. Do not use DTO activityStatusId.
+    // Compute new status. Do not use DTO activityStatusId.
     const canReview =
       context?.permissions?.includes(PERMISSIONS.ACTIVITIES.REVIEW) ?? false;
-    const newStatusName: ActivityStatusName =
-      canReview && dto.markAsReviewed === true ? 'reviewed' : 'changed';
+    let newStatusName: ActivityStatusName;
+    if (canReview && dto.markAsReviewed === true) {
+      newStatusName = 'reviewed';
+    } else if (currentStatusName === 'new') {
+      newStatusName = 'new';
+    } else {
+      newStatusName = 'changed';
+    }
     const computedStatusId =
       await this.getActivityStatusIdByName(newStatusName);
 

--- a/calendar-ui/src/components/ui/badge.tsx
+++ b/calendar-ui/src/components/ui/badge.tsx
@@ -1,5 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import * as React from 'react';
+import type { HTMLAttributes } from 'react';
+
+import { normalizeActivityStatusLabel } from '@corpcal/shared';
 
 import { cn } from '../../lib/utils';
 
@@ -65,7 +67,7 @@ export type ActivityStatusBadgeVariant =
  * lookup name (e.g. "delete_requested") or displayName (e.g. "Delete requested").
  */
 export function normalizeActivityStatus(status: string): string {
-  return status.toLowerCase().trim().replace(/\s+/g, '_');
+  return normalizeActivityStatusLabel(status);
 }
 
 export function getActivityStatusBadgeVariant(
@@ -93,9 +95,7 @@ export function getActivityStatusBadgeVariant(
 }
 
 export interface BadgeProps
-  extends
-    React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/packages/shared/src/constants/constants.test.ts
+++ b/packages/shared/src/constants/constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeActivityStatusLabel } from './constants';
+
+describe('normalizeActivityStatusLabel', () => {
+  it('normalizes display names and internal names consistently', () => {
+    expect(normalizeActivityStatusLabel('New')).toBe('new');
+    expect(normalizeActivityStatusLabel('Delete requested')).toBe(
+      'delete_requested'
+    );
+    expect(normalizeActivityStatusLabel('  Reviewed  ')).toBe('reviewed');
+    expect(normalizeActivityStatusLabel('delete_requested')).toBe(
+      'delete_requested'
+    );
+  });
+});

--- a/packages/shared/src/constants/constants.ts
+++ b/packages/shared/src/constants/constants.ts
@@ -73,6 +73,15 @@ export const ACTIVITY_STATUS = [
 export type ActivityStatusName = (typeof ACTIVITY_STATUS)[number];
 
 /**
+ * Normalize activity status for comparison. Accepts API/lookup display strings
+ * (e.g. "New", "Delete requested") or internal names (e.g. "new", "delete_requested").
+ * Matches calendar-ui badge normalization for consistent behavior across client and server.
+ */
+export function normalizeActivityStatusLabel(status: string): string {
+  return status.toLowerCase().trim().replace(/\s+/g, '_');
+}
+
+/**
  * Default activity status for new entries
  */
 export const DEFAULT_ACTIVITY_STATUS: ActivityStatusName = 'new';


### PR DESCRIPTION
## Summary

This PR updates the behaviour of `New` status activities to match user feedback.

1. New status is preserved until an activity is first reviewed (e.g. it no longer progresses to`Changed` status if there are additional edits after the activity is first created and before it is first reviewed by admins)
2. New activities no longer use an empty formstate as the reference for Reviewed snapshot; this means that New activities will not show any `Review` badges.

## Changes

- preserve New on PATCH unless reviewer sends markAsReviewed or status was already past New
- return empty changedFieldsSinceReview for New; undefined still on snapshot version mismatch
- diff non-New activities with null snapshot against the empty-form baseline
- add normalizeActivityStatusLabel in shared; use in ActivitiesService and status badge
- refresh review snapshot and status flow docs; extend calendar-service and shared tests

## Testing

- smoke test by creating a new activity and making changes to it; the activity should maintain a `New` status unless explicitly set to `Reviewed` by an admin role
- New activities should not show `Review` badges (they will still show `Changed` badges following any edits to fields after the activity is initially created 