### PR TITLE
fix(pagination): default 50 results per page in histroy pagination

### DIFF
--- a/calendar-ui/src/pages/GlobalHistory.tsx
+++ b/calendar-ui/src/pages/GlobalHistory.tsx
@@ -357,7 +357,7 @@ export function GlobalHistory() {
     () => new Set()
   );
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(50);
   const tableScrollRef = useRef<HTMLDivElement>(null);
 
   // Reset to page 1 whenever any filter changes


### PR DESCRIPTION
Apparently it should be 50 results per page (default), not 10.