### PR TITLE
fix(websocket): proxy /socket.io/ in nginx and fix Socket.IO client URL

### DIFF
--- a/calendar-ui/nginx.conf
+++ b/calendar-ui/nginx.conf
@@ -53,6 +53,22 @@ server {
         return 200 'ok';
     }
 
+    # Socket.IO proxy — Engine.IO uses /socket.io/ by default, not /api/socket.io/.
+    # Must be a dedicated location; without it the SPA catch-all serves index.html
+    # for every polling/WS request and the handshake never completes.
+    location /socket.io/ {
+        proxy_pass ${API_PROXY_UPSTREAM}/socket.io/;
+        proxy_http_version 1.1;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
     # API proxy (rendered via envsubst)
     location /api/ {
         proxy_pass ${API_PROXY_UPSTREAM}/;

--- a/calendar-ui/src/lib/calendar-socket.ts
+++ b/calendar-ui/src/lib/calendar-socket.ts
@@ -1,10 +1,23 @@
 import type { ManagerOptions, SocketOptions } from 'socket.io-client';
 
 /**
- * Base URL for Socket.IO (same host as REST API). Matches axios base URL usage.
+ * Base URL for Socket.IO connections.
+ *
+ * VITE_API_BASE_URL is shared with axios (REST), but Socket.IO interprets a
+ * string that starts with '/' as a namespace, not a base path. When the value
+ * is a relative URL (e.g. '/api' in OpenShift), return window.location.origin
+ * so the socket connects to the page host where nginx proxies /socket.io/ to
+ * the calendar-service. Absolute URLs (local dev: 'http://localhost:3001') are
+ * passed through unchanged because Socket.IO handles them correctly.
  */
 export function getCalendarSocketUrl(): string {
-  return import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+  const base = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+  // Relative path → use current origin so Engine.IO hits /socket.io/ on the
+  // nginx host, which now has a dedicated proxy block for that path.
+  if (base.startsWith('/')) {
+    return window.location.origin;
+  }
+  return base;
 }
 
 /**


### PR DESCRIPTION
Socket.IO's Engine.IO layer uses /socket.io/ by default. Without a dedicated nginx location, those requests fell through to the SPA catch-all and were served index.html, so the handshake never completed and the client polled forever.

Two fixes:
- nginx.conf: add location /socket.io/ that proxy_passes to API_PROXY_UPSTREAM with WebSocket upgrade headers
- calendar-socket.ts: when VITE_API_BASE_URL is a relative path (e.g. /api), return window.location.origin instead; Socket.IO v4 treats a leading-slash string as a namespace, not a base URL, causing it to connect to the wrong namespace on the UI host