### PR TITLE
fix/corpcal-000 reduce logger noise

### DIFF
--- a/calendar-service/src/common/logger/logger.service.ts
+++ b/calendar-service/src/common/logger/logger.service.ts
@@ -21,7 +21,12 @@ export class AppLogger extends Logger {
    */
   debug(message: string, context?: string, correlationId?: string): void {
     if (process.env.NODE_ENV !== 'production') {
-      super.debug(this.formatMessage(message, correlationId), context);
+      const formatted = this.formatMessage(message, correlationId);
+      if (context !== undefined) {
+        super.debug(formatted, context);
+      } else {
+        super.debug(formatted);
+      }
     }
   }
 
@@ -29,14 +34,24 @@ export class AppLogger extends Logger {
    * Log an info message
    */
   log(message: string, context?: string, correlationId?: string): void {
-    super.log(this.formatMessage(message, correlationId), context);
+    const formatted = this.formatMessage(message, correlationId);
+    if (context !== undefined) {
+      super.log(formatted, context);
+    } else {
+      super.log(formatted);
+    }
   }
 
   /**
    * Log a warning message
    */
   warn(message: string, context?: string, correlationId?: string): void {
-    super.warn(this.formatMessage(message, correlationId), context);
+    const formatted = this.formatMessage(message, correlationId);
+    if (context !== undefined) {
+      super.warn(formatted, context);
+    } else {
+      super.warn(formatted);
+    }
   }
 
   /**
@@ -48,7 +63,18 @@ export class AppLogger extends Logger {
     context?: string,
     correlationId?: string
   ): void {
-    super.error(this.formatMessage(message, correlationId), trace, context);
+    const formatted = this.formatMessage(message, correlationId);
+    if (trace !== undefined) {
+      if (context !== undefined) {
+        super.error(formatted, trace, context);
+      } else {
+        super.error(formatted, trace);
+      }
+    } else if (context !== undefined) {
+      super.error(formatted, context);
+    } else {
+      super.error(formatted);
+    }
   }
 
   /**
@@ -56,7 +82,12 @@ export class AppLogger extends Logger {
    */
   verbose(message: string, context?: string, correlationId?: string): void {
     if (process.env.NODE_ENV !== 'production') {
-      super.verbose(this.formatMessage(message, correlationId), context);
+      const formatted = this.formatMessage(message, correlationId);
+      if (context !== undefined) {
+        super.verbose(formatted, context);
+      } else {
+        super.verbose(formatted);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR improves handling of optional context arg when using the service AppLogger. Previously we would see several `undefined` lines (e.g. for ActivityGateway). They came from a bug in **`AppLogger`**, not from `ActivitiesGateway` itself.

`AppLogger` wraps Nest’s `Logger` like this:

```31:33:calendar-service/src/common/logger/logger.service.ts
  log(message: string, context?: string, correlationId?: string): void {
    const formatted = this.formatMessage(message, correlationId);
    // ... only pass `context` to super when it is defined
```

**Before the fix**, it always called `super.log(formattedMessage, context)`. For normal call sites (e.g. `this.logger.log('Client connected...')`), `context` was **`undefined`**, but it was still passed as an **explicit** argument.

`LOG [ActivitiesGateway] undefined`

## Changes

`AppLogger` now calls `super.log` / `super.debug` / etc. **with only the message** when `context` is omitted, and only adds the second argument when a caller **actually** passes a context string. The same idea is applied to `warn`, `verbose`, and `error` so optional args are not forwarded as explicit `undefined`.

## Testing

App still logs as expected without the constant undefined logs.