### PR TITLE
Feat/corpcal 222 ministry groups

### DIFF
--- a/calendar-service/src/common/dto/lookup.dto.ts
+++ b/calendar-service/src/common/dto/lookup.dto.ts
@@ -11,6 +11,7 @@ import {
   createCityRequestSchema,
   createCommsMaterialRequestSchema,
   createGovernmentRepresentativeRequestSchema,
+  createMinistryGroupRequestSchema,
   createMinistryRequestSchema,
   createResponseWrapperSchema,
   createTagRequestSchema,
@@ -18,6 +19,7 @@ import {
   createVenuePresetRequestSchema,
   governmentRepresentativeResponseSchema,
   lookupItemSchema,
+  ministryGroupResponseSchema,
   ministryResponseSchema,
   tagResponseSchema,
   themeResponseSchema,
@@ -26,6 +28,7 @@ import {
   updateCityRequestSchema,
   updateCommsMaterialRequestSchema,
   updateGovernmentRepresentativeRequestSchema,
+  updateMinistryGroupRequestSchema,
   updateMinistryRequestSchema,
   updateTagRequestSchema,
   updateThemeRequestSchema,
@@ -157,6 +160,31 @@ export class MinistryResponseDto extends createZodDto(ministryResponseSchema) {}
  */
 export class MinistryResponseWrapperDto extends createZodDto(
   createResponseWrapperSchema(ministryResponseSchema)
+) {}
+
+// ============================================
+// Ministry group DTOs
+// ============================================
+
+export class CreateMinistryGroupDto extends createZodDto(
+  createMinistryGroupRequestSchema
+) {}
+
+export class UpdateMinistryGroupDto extends createZodDto(
+  updateMinistryGroupRequestSchema
+) {}
+
+export class MinistryGroupResponseDto extends createZodDto(
+  ministryGroupResponseSchema
+) {}
+
+export class MinistryGroupResponseWrapperDto extends createZodDto(
+  createResponseWrapperSchema(ministryGroupResponseSchema)
+) {}
+
+/** Wrapped list: `{ success: true, data: MinistryGroupResponse[] }` */
+export class MinistryGroupArrayResponseWrapperDto extends createZodDto(
+  createArrayResponseWrapperSchema(ministryGroupResponseSchema)
 ) {}
 
 // ============================================

--- a/calendar-service/src/lookups/lookups.controller.spec.ts
+++ b/calendar-service/src/lookups/lookups.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import type { AuthUser } from '@corpcal/shared';
 import type { LookupItem, VenuePresetItem } from '@corpcal/shared/api/types';
+import type { TeamListItem } from '@corpcal/shared/schemas';
 
 import { TeamsService } from '../teams/teams.service';
 import { LookupsController } from './lookups.controller';
@@ -78,6 +79,74 @@ describe('LookupsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getActivityTeamSharing', () => {
+    const mockTeams: TeamListItem[] = [
+      {
+        id: 1,
+        name: 'Team A',
+        displayName: 'Team A',
+        description: null,
+        sortOrder: 0,
+        isActive: true,
+        roleId: null,
+        memberCount: 2,
+        ministryId: 5,
+        ministryName: 'M1',
+      },
+    ];
+
+    it('returns teams and quick share groups', async () => {
+      mockTeamsService.findAll.mockResolvedValue(mockTeams);
+      mockLookupsService.getActivityTeamSharingQuickShare.mockResolvedValue({
+        groups: [
+          {
+            id: 1,
+            name: 'Social',
+            sortOrder: 0,
+            ministryIds: [5],
+          },
+        ],
+      });
+
+      const result = await controller.getActivityTeamSharing();
+
+      expect(result).toEqual({
+        success: true,
+        data: {
+          teams: mockTeams,
+          quickShare: {
+            groups: [
+              {
+                id: 1,
+                name: 'Social',
+                sortOrder: 0,
+                ministryIds: [5],
+              },
+            ],
+          },
+        },
+      });
+      expect(mockTeamsService.findAll).toHaveBeenCalledWith(true);
+      expect(
+        mockLookupsService.getActivityTeamSharingQuickShare
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns quickShare null when there are no ministry groups', async () => {
+      mockTeamsService.findAll.mockResolvedValue([]);
+      mockLookupsService.getActivityTeamSharingQuickShare.mockResolvedValue(
+        null
+      );
+
+      const result = await controller.getActivityTeamSharing();
+
+      expect(result).toEqual({
+        success: true,
+        data: { teams: [], quickShare: null },
+      });
+    });
   });
 
   describe('getCategories', () => {

--- a/calendar-service/src/lookups/lookups.controller.spec.ts
+++ b/calendar-service/src/lookups/lookups.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { AuthUser } from '@corpcal/shared';
 import type { LookupItem, VenuePresetItem } from '@corpcal/shared/api/types';
 
+import { TeamsService } from '../teams/teams.service';
 import { LookupsController } from './lookups.controller';
 import { LookupsService } from './lookups.service';
 
@@ -46,6 +47,11 @@ describe('LookupsController', () => {
     createVenuePreset: vi.fn(),
     updateVenuePreset: vi.fn(),
     deleteVenuePreset: vi.fn(),
+    getActivityTeamSharingQuickShare: vi.fn(),
+  };
+
+  const mockTeamsService = {
+    findAll: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -55,6 +61,10 @@ describe('LookupsController', () => {
         {
           provide: LookupsService,
           useValue: mockLookupsService,
+        },
+        {
+          provide: TeamsService,
+          useValue: mockTeamsService,
         },
       ],
     }).compile();

--- a/calendar-service/src/lookups/lookups.controller.ts
+++ b/calendar-service/src/lookups/lookups.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Header,
+  NotFoundException,
   Param,
   Patch,
   Post,
@@ -22,9 +23,11 @@ import type { Response } from 'express';
 
 import { DYNAMIC_LOOKUP_CACHE_SECONDS, type AuthUser } from '@corpcal/shared';
 import type {
+  ActivityTeamSharingResponse,
   CategoryLookupItem,
   LookupItem,
   LookupQueryParams,
+  MinistryGroupResponse,
   MinistryLookupItem,
   OrganizationLookupItem,
   ThemeLookupItem,
@@ -36,6 +39,7 @@ import {
   createCityRequestSchema,
   createCommsMaterialRequestSchema,
   createGovernmentRepresentativeRequestSchema,
+  createMinistryGroupRequestSchema,
   createMinistryRequestSchema,
   createTagRequestSchema,
   createThemeRequestSchema,
@@ -45,6 +49,7 @@ import {
   updateCityRequestSchema,
   updateCommsMaterialRequestSchema,
   updateGovernmentRepresentativeRequestSchema,
+  updateMinistryGroupRequestSchema,
   updateMinistryRequestSchema,
   updateTagRequestSchema,
   updateThemeRequestSchema,
@@ -63,11 +68,14 @@ import {
   CreateCommsMaterialDto,
   CreateGovernmentRepresentativeDto,
   CreateMinistryDto,
+  CreateMinistryGroupDto,
   CreateTagDto,
   CreateThemeDto,
   CreateVenuePresetDto,
   GovernmentRepresentativeResponseWrapperDto,
   LookupArrayResponseWrapperDto,
+  MinistryGroupArrayResponseWrapperDto,
+  MinistryGroupResponseWrapperDto,
   MinistryResponseWrapperDto,
   TagResponseWrapperDto,
   ThemeResponseWrapperDto,
@@ -77,6 +85,7 @@ import {
   UpdateCommsMaterialDto,
   UpdateGovernmentRepresentativeDto,
   UpdateMinistryDto,
+  UpdateMinistryGroupDto,
   UpdateTagDto,
   UpdateThemeDto,
   UpdateVenuePresetDto,
@@ -88,6 +97,7 @@ import { ParseOptionalIntPipe } from '../common/pipes/parse-optional-int.pipe';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { parseCommaSeparatedIds } from '../common/utils/parse-query-ids';
 import { RequirePermission } from '../policy/decorators/require-permission.decorator';
+import { TeamsService } from '../teams/teams.service';
 import { lookupGetCacheControl } from './cache-control';
 import { LookupsService } from './lookups.service';
 
@@ -97,7 +107,29 @@ import { LookupsService } from './lookups.service';
 export class LookupsController {
   private readonly logger = new AppLogger(LookupsController.name);
 
-  constructor(private readonly lookupsService: LookupsService) {}
+  constructor(
+    private readonly lookupsService: LookupsService,
+    private readonly teamsService: TeamsService
+  ) {}
+
+  @ApiOperation({
+    summary: 'Teams and ministry quick-share for activity Shared with',
+    description:
+      'Returns active teams (same list as GET /teams) plus quick-share group definitions.',
+  })
+  @ApiResponse({ status: 200, description: 'Teams and quick-share config' })
+  @Get('activity-team-sharing')
+  @Header('Cache-Control', lookupGetCacheControl())
+  async getActivityTeamSharing(): Promise<{
+    success: boolean;
+    data: ActivityTeamSharingResponse;
+  }> {
+    const [teams, quickShare] = await Promise.all([
+      this.teamsService.findAll(true),
+      this.lookupsService.getActivityTeamSharingQuickShare(),
+    ]);
+    return { success: true, data: { teams, quickShare } };
+  }
 
   @ApiOperation({
     summary: 'Get all categories',
@@ -835,6 +867,86 @@ export class LookupsController {
       user.id
     );
     return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Get all ministry groups' })
+  @ApiResponse({
+    status: 200,
+    description: 'Ministry groups retrieved successfully',
+    type: MinistryGroupArrayResponseWrapperDto,
+  })
+  @Get('ministry-groups')
+  @Header('Cache-Control', lookupGetCacheControl())
+  async getMinistryGroups(): Promise<{
+    success: boolean;
+    data: MinistryGroupResponse[];
+  }> {
+    const data = await this.lookupsService.getMinistryGroups();
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Create a ministry group' })
+  @ApiResponse({
+    status: 201,
+    description: 'Ministry group created successfully',
+    type: MinistryGroupResponseWrapperDto,
+  })
+  @ApiBody({ type: CreateMinistryGroupDto })
+  @RequirePermission('lookups.manage')
+  @Post('ministry-groups')
+  async createMinistryGroup(
+    @Body(new ZodValidationPipe(createMinistryGroupRequestSchema))
+    body: CreateMinistryGroupDto,
+    @CurrentUser() user: AuthUser
+  ): Promise<{ success: boolean; data: MinistryGroupResponse }> {
+    const row = await this.lookupsService.createMinistryGroup(body, user.id);
+    return {
+      success: true,
+      data: { id: row.id, name: row.name, sortOrder: row.sortOrder },
+    };
+  }
+
+  @ApiOperation({ summary: 'Update a ministry group' })
+  @ApiResponse({
+    status: 200,
+    description: 'Ministry group updated successfully',
+    type: MinistryGroupResponseWrapperDto,
+  })
+  @ApiParam({ name: 'id', type: Number, description: 'Ministry group ID' })
+  @ApiBody({ type: UpdateMinistryGroupDto })
+  @RequirePermission('lookups.manage')
+  @Patch('ministry-groups/:id')
+  async updateMinistryGroup(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(updateMinistryGroupRequestSchema))
+    body: UpdateMinistryGroupDto,
+    @CurrentUser() user: AuthUser
+  ): Promise<{ success: boolean; data: MinistryGroupResponse }> {
+    const row = await this.lookupsService.updateMinistryGroup(
+      Number(id),
+      body,
+      user.id
+    );
+    if (!row) {
+      throw new NotFoundException(`Ministry group ${id} not found`);
+    }
+    return {
+      success: true,
+      data: { id: row.id, name: row.name, sortOrder: row.sortOrder },
+    };
+  }
+
+  @ApiOperation({ summary: 'Delete a ministry group' })
+  @ApiResponse({ status: 200, description: 'Ministry group deleted' })
+  @ApiResponse({ status: 404, description: 'Ministry group not found' })
+  @ApiParam({ name: 'id', type: Number, description: 'Ministry group ID' })
+  @RequirePermission('lookups.manage')
+  @Delete('ministry-groups/:id')
+  async deleteMinistryGroup(
+    @Param('id') id: string
+  ): Promise<{ success: boolean }> {
+    await this.lookupsService.deleteMinistryGroup(Number(id));
+    return { success: true };
   }
 
   @ApiOperation({ summary: 'Get all date statuses' })

--- a/calendar-service/src/lookups/lookups.module.ts
+++ b/calendar-service/src/lookups/lookups.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 
 import { DatabaseModule } from '../database/database.module';
+import { TeamsModule } from '../teams/teams.module';
 import { LookupsController } from './lookups.controller';
 import { LookupsService } from './lookups.service';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, TeamsModule],
   providers: [LookupsService],
   controllers: [LookupsController],
 })

--- a/calendar-service/src/lookups/lookups.service.ts
+++ b/calendar-service/src/lookups/lookups.service.ts
@@ -1021,6 +1021,7 @@ export class LookupsService {
 
   /**
    * Ministry groups for admin / activity "Shared with" shortcuts (derived from ministries FK).
+   * Returns all rows: there is no isActive on `ministry_groups` (retire by delete or reassign ministries).
    */
   async getMinistryGroups(): Promise<MinistryGroupResponse[]> {
     const rows = await this.databaseService.db
@@ -1039,6 +1040,10 @@ export class LookupsService {
     }));
   }
 
+  /**
+   * Insert a ministry group. Duplicate name (case-insensitive) causes SQLSTATE 23505;
+   * the HTTP layer maps that to 409 Conflict.
+   */
   async createMinistryGroup(
     data: { name: string; sortOrder: number },
     currentUserId: number
@@ -1058,6 +1063,10 @@ export class LookupsService {
     return result;
   }
 
+  /**
+   * Update a ministry group. Renaming to an existing name (case-insensitive) causes SQLSTATE 23505;
+   * the HTTP layer maps that to 409 Conflict.
+   */
   async updateMinistryGroup(
     id: number,
     data: Partial<{ name: string; sortOrder: number }>,

--- a/calendar-service/src/lookups/lookups.service.ts
+++ b/calendar-service/src/lookups/lookups.service.ts
@@ -793,11 +793,16 @@ export class LookupsService {
         name: governmentRepresentatives.name,
         displayName: governmentRepresentatives.displayName,
         title: governmentRepresentatives.title,
-        ministryId: governmentRepresentatives.ministryId,
+        ministryId: ministries.id,
+        representativeType: governmentRepresentatives.representativeType,
         sortOrder: governmentRepresentatives.sortOrder,
         isActive: governmentRepresentatives.isActive,
       })
       .from(governmentRepresentatives)
+      .leftJoin(
+        ministries,
+        eq(ministries.ministerGovernmentRepId, governmentRepresentatives.id)
+      )
       .orderBy(governmentRepresentatives.sortOrder);
 
     return results.map((rep) => ({
@@ -808,6 +813,9 @@ export class LookupsService {
       displayName: rep.displayName,
       title: rep.title,
       ministryId: rep.ministryId,
+      representativeType: rep.representativeType as NonNullable<
+        GovernmentRepresentativeLookupItem['representativeType']
+      > | null,
       sortOrder: rep.sortOrder,
       isActive: rep.isActive,
     }));
@@ -983,12 +991,17 @@ export class LookupsService {
         name: ministries.name,
         displayName: ministries.displayName,
         abbreviation: ministries.abbreviation,
-        ministerName: ministries.ministerName,
+        ministerGovernmentRepId: ministries.ministerGovernmentRepId,
+        ministerRepDisplayName: governmentRepresentatives.displayName,
         sortOrder: ministries.sortOrder,
         isActive: ministries.isActive,
         ministryGroupId: ministries.ministryGroupId,
       })
       .from(ministries)
+      .leftJoin(
+        governmentRepresentatives,
+        eq(ministries.ministerGovernmentRepId, governmentRepresentatives.id)
+      )
       .orderBy(ministries.sortOrder);
 
     return results.map((ministry) => ({
@@ -998,7 +1011,8 @@ export class LookupsService {
       name: ministry.name,
       displayName: ministry.displayName,
       abbreviation: ministry.abbreviation,
-      ministerName: ministry.ministerName,
+      ministerGovernmentRepId: ministry.ministerGovernmentRepId,
+      ministerDisplayName: ministry.ministerRepDisplayName ?? null,
       sortOrder: ministry.sortOrder,
       isActive: ministry.isActive,
       ministryGroupId: ministry.ministryGroupId,
@@ -1271,7 +1285,6 @@ export class LookupsService {
       title?: string | null;
       sortOrder: number;
       isActive?: boolean;
-      ministryId?: number | null;
       representativeType?: string | null;
     },
     currentUserId: number
@@ -1285,7 +1298,6 @@ export class LookupsService {
         title: data.title ?? undefined,
         sortOrder: data.sortOrder,
         isActive: data.isActive ?? true,
-        ministryId: data.ministryId ?? undefined,
         representativeType: data.representativeType ?? undefined,
         createdBy: currentUserId,
         lastUpdatedBy: currentUserId,
@@ -1352,7 +1364,7 @@ export class LookupsService {
       name: string;
       displayName: string;
       abbreviation: string; // Required by schema
-      ministerName?: string | null;
+      ministerGovernmentRepId?: number | null;
       sortOrder: number;
       isActive?: boolean;
       ministryGroupId?: number | null;
@@ -1360,13 +1372,32 @@ export class LookupsService {
     currentUserId: number
   ): Promise<typeof ministries.$inferSelect> {
     const now = new Date();
+    if (
+      data.ministerGovernmentRepId != null &&
+      data.ministerGovernmentRepId !== undefined
+    ) {
+      await this.databaseService.db
+        .update(ministries)
+        .set({
+          ministerGovernmentRepId: null,
+          lastUpdatedBy: currentUserId,
+          lastUpdatedDateTime: now,
+        })
+        .where(
+          eq(ministries.ministerGovernmentRepId, data.ministerGovernmentRepId)
+        );
+    }
     const [result] = await this.databaseService.db
       .insert(ministries)
       .values({
         name: data.name,
         displayName: data.displayName,
         abbreviation: data.abbreviation,
-        ministerName: data.ministerName ?? undefined,
+        ministerGovernmentRepId:
+          data.ministerGovernmentRepId === null ||
+          data.ministerGovernmentRepId === undefined
+            ? undefined
+            : data.ministerGovernmentRepId,
         sortOrder: data.sortOrder,
         isActive: data.isActive ?? true,
         ministryGroupId: data.ministryGroupId ?? undefined,
@@ -1555,7 +1586,6 @@ export class LookupsService {
       title: string | null;
       sortOrder: number;
       isActive: boolean;
-      ministryId: number | null;
       representativeType: string | null;
     }>,
     currentUserId: number
@@ -1572,8 +1602,6 @@ export class LookupsService {
     if (data.title !== undefined) updateData.title = data.title ?? undefined;
     if (data.sortOrder !== undefined) updateData.sortOrder = data.sortOrder;
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
-    if (data.ministryId !== undefined)
-      updateData.ministryId = data.ministryId ?? undefined;
     if (data.representativeType !== undefined)
       updateData.representativeType = data.representativeType ?? undefined;
 
@@ -1654,7 +1682,7 @@ export class LookupsService {
       name: string;
       displayName: string;
       abbreviation: string;
-      ministerName: string | null;
+      ministerGovernmentRepId: number | null;
       sortOrder: number;
       isActive: boolean;
       ministryGroupId: number | null;
@@ -1672,13 +1700,39 @@ export class LookupsService {
       updateData.displayName = data.displayName;
     if (data.abbreviation !== undefined)
       updateData.abbreviation = data.abbreviation;
-    if (data.ministerName !== undefined)
-      updateData.ministerName = data.ministerName ?? undefined;
+    if (data.ministerGovernmentRepId !== undefined) {
+      updateData.ministerGovernmentRepId =
+        data.ministerGovernmentRepId === null
+          ? null
+          : data.ministerGovernmentRepId;
+    }
     if (data.sortOrder !== undefined) updateData.sortOrder = data.sortOrder;
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
     if (data.ministryGroupId !== undefined) {
       updateData.ministryGroupId =
         data.ministryGroupId === null ? null : data.ministryGroupId;
+    }
+
+    if (
+      data.ministerGovernmentRepId !== undefined &&
+      data.ministerGovernmentRepId !== null
+    ) {
+      await this.databaseService.db
+        .update(ministries)
+        .set({
+          ministerGovernmentRepId: null,
+          lastUpdatedBy: currentUserId,
+          lastUpdatedDateTime: new Date(),
+        })
+        .where(
+          and(
+            eq(
+              ministries.ministerGovernmentRepId,
+              data.ministerGovernmentRepId
+            ),
+            ne(ministries.id, id)
+          )
+        );
     }
 
     const [result] = await this.databaseService.db

--- a/calendar-service/src/lookups/lookups.service.ts
+++ b/calendar-service/src/lookups/lookups.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
-import { and, eq, inArray, ne, type SQL } from 'drizzle-orm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { and, asc, eq, inArray, isNotNull, ne, type SQL } from 'drizzle-orm';
 
 import {
   activities,
@@ -11,6 +11,7 @@ import {
   eventPlanners,
   governmentRepresentatives,
   ministries,
+  ministryGroups,
   newsReleaseDistributions,
   newsReleaseOrigins,
   organizations,
@@ -32,11 +33,13 @@ import {
 } from '@corpcal/database/schema';
 import type { ActivityStatusName } from '@corpcal/shared';
 import type {
+  ActivityTeamSharingQuickShare,
   CategoryLookupItem,
   CommsMaterialsLookupItem,
   GovernmentRepresentativeLookupItem,
   LookupItem,
   LookupQueryParams,
+  MinistryGroupResponse,
   MinistryLookupItem,
   OrganizationLookupItem,
   PitchStatusLookupItem,
@@ -983,6 +986,7 @@ export class LookupsService {
         ministerName: ministries.ministerName,
         sortOrder: ministries.sortOrder,
         isActive: ministries.isActive,
+        ministryGroupId: ministries.ministryGroupId,
       })
       .from(ministries)
       .orderBy(ministries.sortOrder);
@@ -997,7 +1001,115 @@ export class LookupsService {
       ministerName: ministry.ministerName,
       sortOrder: ministry.sortOrder,
       isActive: ministry.isActive,
+      ministryGroupId: ministry.ministryGroupId,
     }));
+  }
+
+  /**
+   * Ministry groups for admin / activity "Shared with" shortcuts (derived from ministries FK).
+   */
+  async getMinistryGroups(): Promise<MinistryGroupResponse[]> {
+    const rows = await this.databaseService.db
+      .select({
+        id: ministryGroups.id,
+        name: ministryGroups.name,
+        sortOrder: ministryGroups.sortOrder,
+      })
+      .from(ministryGroups)
+      .orderBy(asc(ministryGroups.sortOrder), asc(ministryGroups.id));
+
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      sortOrder: r.sortOrder,
+    }));
+  }
+
+  async createMinistryGroup(
+    data: { name: string; sortOrder: number },
+    currentUserId: number
+  ): Promise<typeof ministryGroups.$inferSelect> {
+    const now = new Date();
+    const [result] = await this.databaseService.db
+      .insert(ministryGroups)
+      .values({
+        name: data.name,
+        sortOrder: data.sortOrder,
+        createdBy: currentUserId,
+        lastUpdatedBy: currentUserId,
+        createdDateTime: now,
+        lastUpdatedDateTime: now,
+      })
+      .returning();
+    return result;
+  }
+
+  async updateMinistryGroup(
+    id: number,
+    data: Partial<{ name: string; sortOrder: number }>,
+    currentUserId: number
+  ): Promise<typeof ministryGroups.$inferSelect | undefined> {
+    const updateData: Partial<typeof ministryGroups.$inferInsert> = {
+      lastUpdatedBy: currentUserId,
+      lastUpdatedDateTime: new Date(),
+    };
+    if (data.name !== undefined) updateData.name = data.name;
+    if (data.sortOrder !== undefined) updateData.sortOrder = data.sortOrder;
+
+    const [result] = await this.databaseService.db
+      .update(ministryGroups)
+      .set(updateData)
+      .where(eq(ministryGroups.id, id))
+      .returning();
+    return result;
+  }
+
+  async deleteMinistryGroup(id: number): Promise<void> {
+    const deleted = await this.databaseService.db
+      .delete(ministryGroups)
+      .where(eq(ministryGroups.id, id))
+      .returning({ id: ministryGroups.id });
+    if (deleted.length === 0) {
+      throw new NotFoundException(`Ministry group ${id} not found`);
+    }
+  }
+
+  /**
+   * Quick-share groups for GET /lookups/activity-team-sharing (membership from ministries.ministry_group_id).
+   */
+  async getActivityTeamSharingQuickShare(): Promise<ActivityTeamSharingQuickShare | null> {
+    const groupRows = await this.getMinistryGroups();
+
+    if (groupRows.length === 0) {
+      return null;
+    }
+
+    const db = this.databaseService.db;
+    const ministryRows = await db
+      .select({
+        id: ministries.id,
+        ministryGroupId: ministries.ministryGroupId,
+      })
+      .from(ministries)
+      .where(isNotNull(ministries.ministryGroupId));
+
+    const byGroup = new Map<number, number[]>();
+    for (const row of ministryRows) {
+      const gid = row.ministryGroupId;
+      if (gid == null) continue;
+      const list = byGroup.get(gid) ?? [];
+      list.push(row.id);
+      byGroup.set(gid, list);
+    }
+
+    return {
+      groups: groupRows.map((g) => ({
+        id: g.id,
+        name: g.name,
+        sortOrder: g.sortOrder,
+        ministryIds: (byGroup.get(g.id) ?? []).sort((a, b) => a - b),
+      })),
+    };
   }
 
   /**
@@ -1243,6 +1355,7 @@ export class LookupsService {
       ministerName?: string | null;
       sortOrder: number;
       isActive?: boolean;
+      ministryGroupId?: number | null;
     },
     currentUserId: number
   ): Promise<typeof ministries.$inferSelect> {
@@ -1256,6 +1369,7 @@ export class LookupsService {
         ministerName: data.ministerName ?? undefined,
         sortOrder: data.sortOrder,
         isActive: data.isActive ?? true,
+        ministryGroupId: data.ministryGroupId ?? undefined,
         createdBy: currentUserId,
         lastUpdatedBy: currentUserId,
         createdDateTime: now,
@@ -1543,6 +1657,7 @@ export class LookupsService {
       ministerName: string | null;
       sortOrder: number;
       isActive: boolean;
+      ministryGroupId: number | null;
     }>,
     currentUserId: number
   ): Promise<typeof ministries.$inferSelect | undefined> {
@@ -1561,6 +1676,10 @@ export class LookupsService {
       updateData.ministerName = data.ministerName ?? undefined;
     if (data.sortOrder !== undefined) updateData.sortOrder = data.sortOrder;
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
+    if (data.ministryGroupId !== undefined) {
+      updateData.ministryGroupId =
+        data.ministryGroupId === null ? null : data.ministryGroupId;
+    }
 
     const [result] = await this.databaseService.db
       .update(ministries)

--- a/calendar-service/src/lookups/lookups.service.ts
+++ b/calendar-service/src/lookups/lookups.service.ts
@@ -1,5 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { and, asc, eq, inArray, isNotNull, ne, type SQL } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  ne,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 
 import {
   activities,
@@ -1396,6 +1405,17 @@ export class LookupsService {
           eq(ministries.ministerGovernmentRepId, data.ministerGovernmentRepId)
         );
     }
+
+    // Seeds insert explicit ministry ids; PostgreSQL does not advance the serial sequence,
+    // so the next DEFAULT id can collide. Sync without requiring a migration.
+    await this.databaseService.db.execute(sql`
+      SELECT setval(
+        pg_get_serial_sequence('public.ministries', 'id'),
+        COALESCE((SELECT MAX(id) FROM ministries), 1),
+        EXISTS (SELECT 1 FROM ministries)
+      )
+    `);
+
     const [result] = await this.databaseService.db
       .insert(ministries)
       .values({
@@ -1463,6 +1483,13 @@ export class LookupsService {
     currentUserId: number
   ): Promise<any> {
     const now = new Date();
+    await this.databaseService.db.execute(sql`
+      SELECT setval(
+        pg_get_serial_sequence('public.themes', 'id'),
+        COALESCE((SELECT MAX(id) FROM themes), 1),
+        EXISTS (SELECT 1 FROM themes)
+      )
+    `);
     const [result] = await this.databaseService.db
       .insert(themes)
       .values({

--- a/calendar-ui/src/api/activityTeamSharingApi.ts
+++ b/calendar-ui/src/api/activityTeamSharingApi.ts
@@ -1,0 +1,16 @@
+import type { ActivityTeamSharingResponse } from '@corpcal/shared/api/types';
+import { activityTeamSharingResponseSchema } from '@corpcal/shared/schemas';
+
+import api from './axios';
+
+export async function fetchActivityTeamSharing(): Promise<ActivityTeamSharingResponse> {
+  const res = await api.get<{
+    success: boolean;
+    data: ActivityTeamSharingResponse;
+  }>('/lookups/activity-team-sharing');
+  const parsed = activityTeamSharingResponseSchema.safeParse(res.data.data);
+  if (!parsed.success) {
+    throw new Error('Invalid activity team sharing response');
+  }
+  return parsed.data;
+}

--- a/calendar-ui/src/api/lookupsApi.ts
+++ b/calendar-ui/src/api/lookupsApi.ts
@@ -6,6 +6,7 @@ import type {
   DateStatusLookupItem,
   GovernmentRepresentativeLookupItem,
   LookupItem,
+  MinistryGroupResponse,
   MinistryLookupItem,
   OrganizationLookupItem,
   PitchRequiredStatusLookupItem,
@@ -26,6 +27,7 @@ import type {
   CreateCityRequest,
   CreateCommsMaterialRequest,
   CreateGovernmentRepresentativeRequest,
+  CreateMinistryGroupRequest,
   CreateMinistryRequest,
   CreateTagRequest,
   CreateThemeRequest,
@@ -35,6 +37,7 @@ import type {
   UpdateCityRequest,
   UpdateCommsMaterialRequest,
   UpdateGovernmentRepresentativeRequest,
+  UpdateMinistryGroupRequest,
   UpdateMinistryRequest,
   UpdateTagRequest,
   UpdateThemeRequest,
@@ -251,6 +254,24 @@ export async function fetchMinistries(): Promise<MinistryLookupItem[]> {
   return res.data.data;
 }
 
+/** Ministry shortcut groups (admin); includes displayName for GenericLookupAdmin table. */
+export type MinistryGroupListItem = MinistryGroupResponse & {
+  displayName: string;
+  isActive: boolean;
+};
+
+export async function fetchMinistryGroups(): Promise<MinistryGroupListItem[]> {
+  const res = await api.get<{
+    success: boolean;
+    data: MinistryGroupResponse[];
+  }>('/lookups/ministry-groups');
+  return res.data.data.map((g) => ({
+    ...g,
+    displayName: g.name,
+    isActive: true,
+  }));
+}
+
 export async function fetchThemes(): Promise<ThemeLookupItem[]> {
   const res = await api.get<{ success: boolean; data: ThemeLookupItem[] }>(
     '/lookups/themes'
@@ -385,6 +406,36 @@ export async function updateMinistry(
   const res = await api.patch<{ success: boolean; data: any }>(
     `/lookups/ministries/${id}`,
     data
+  );
+  return res.data;
+}
+
+export async function createMinistryGroup(
+  data: CreateMinistryGroupRequest
+): Promise<{ success: boolean; data: MinistryGroupResponse }> {
+  const res = await api.post<{
+    success: boolean;
+    data: MinistryGroupResponse;
+  }>('/lookups/ministry-groups', data);
+  return res.data;
+}
+
+export async function updateMinistryGroup(
+  id: number,
+  data: UpdateMinistryGroupRequest
+): Promise<{ success: boolean; data: MinistryGroupResponse }> {
+  const res = await api.patch<{
+    success: boolean;
+    data: MinistryGroupResponse;
+  }>(`/lookups/ministry-groups/${id}`, data);
+  return res.data;
+}
+
+export async function deleteMinistryGroup(
+  id: number
+): Promise<{ success: boolean }> {
+  const res = await api.delete<{ success: boolean }>(
+    `/lookups/ministry-groups/${id}`
   );
   return res.data;
 }

--- a/calendar-ui/src/components/activity/ActivityFormBody.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormBody.tsx
@@ -179,10 +179,8 @@ export function ActivityFormBody({
             />
 
             <ActivitySharingSection
-              sharedWithTeamOptions={lookups.sharedWithTeams.map((t) => ({
-                value: String(t.id),
-                label: t.displayName ?? t.name,
-              }))}
+              sharedWithTeams={lookups.sharedWithTeams}
+              quickShareGroups={lookups.quickShareGroups}
             />
           </div>
         </div>

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
@@ -1,4 +1,6 @@
+import { CheckIcon } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
+import { useMemo, type FC } from 'react';
 
 import {
   DEFAULT_VISIBILITY,
@@ -16,6 +18,7 @@ import {
   ComboboxEmpty,
   ComboboxItem,
   ComboboxList,
+  ComboboxSeparator,
   ComboboxValue,
   useComboboxAnchor,
 } from '@/components/ui/combobox';
@@ -30,21 +33,118 @@ import {
 import { SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
+import { cn } from '@/lib/utils';
 import type { OptionItem } from '@/schemas/types';
 
 import { useActivityEdit } from '../activity-edit-context';
 import { ActivityFormSection } from './ActivityFormSection';
 
-type ActivitySharingSectionProps = {
-  sharedWithTeamOptions: OptionItem[];
+export type SharingTeamLookup = {
+  id: number;
+  name: string;
+  displayName?: string;
+  ministryId: number | null;
 };
 
-export const ActivitySharingSection: React.FC<ActivitySharingSectionProps> = ({
-  sharedWithTeamOptions,
+export type QuickShareGroupLookup = {
+  id: number;
+  name: string;
+  sortOrder: number;
+  ministryIds: number[];
+};
+
+function teamIdsForMinistries(
+  ministryIds: number[],
+  teams: SharingTeamLookup[]
+): number[] {
+  const set = new Set(ministryIds);
+  return teams
+    .filter((t) => t.ministryId != null && set.has(t.ministryId))
+    .map((t) => t.id);
+}
+
+function setsEqualAsSets(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const sb = new Set(b);
+  return a.every((id) => sb.has(id));
+}
+
+type ShortcutRowProps = {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  onToggle: () => void;
+};
+
+function SharingShortcutRow({
+  label,
+  checked,
+  disabled,
+  readOnly,
+  onToggle,
+}: ShortcutRowProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled || readOnly}
+      className={cn(
+        'relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        !disabled && !readOnly && 'hover:bg-accent hover:text-accent-foreground'
+      )}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled && !readOnly) onToggle();
+      }}
+    >
+      <span className="flex-1 text-left">{label}</span>
+      {checked ? (
+        <CheckIcon
+          className="text-foreground pointer-events-none absolute right-2 size-4 shrink-0"
+          aria-hidden
+        />
+      ) : null}
+    </button>
+  );
+}
+
+type ActivitySharingSectionProps = {
+  sharedWithTeams: SharingTeamLookup[];
+  quickShareGroups: QuickShareGroupLookup[];
+};
+
+export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
+  sharedWithTeams,
+  quickShareGroups,
 }) => {
   const { readOnly } = useActivityEdit();
   const form = useFormContext<ActivityFormData>();
   const sharedWithAnchorRef = useComboboxAnchor();
+
+  const sharedWithTeamOptions = useMemo<OptionItem[]>(
+    () =>
+      sharedWithTeams.map((t) => ({
+        value: String(t.id),
+        label: t.displayName ?? t.name,
+      })),
+    [sharedWithTeams]
+  );
+
+  const allTeamIds = useMemo(
+    () => sharedWithTeams.map((t) => t.id),
+    [sharedWithTeams]
+  );
+
+  const groupsWithTeamIds = useMemo(
+    () =>
+      quickShareGroups.map((g) => ({
+        ...g,
+        teamIds: teamIdsForMinistries(g.ministryIds, sharedWithTeams),
+      })),
+    [quickShareGroups, sharedWithTeams]
+  );
+
   return (
     <ActivityFormSection title={ACTIVITY_FORM_SECTION_LABELS.sharing}>
       <FormField
@@ -92,6 +192,21 @@ export const ActivitySharingSection: React.FC<ActivitySharingSectionProps> = ({
           const selectedOptions = sharedWithTeamOptions.filter((o) =>
             currentValues.includes(o.value)
           );
+
+          const selectedIds = selectedOptions.map((o) => parseInt(o.value, 10));
+
+          const toggleIds = (targetIds: number[], remove: boolean) => {
+            const target = new Set(targetIds);
+            if (remove) {
+              field.onChange(selectedIds.filter((id) => !target.has(id)));
+            } else {
+              field.onChange([...new Set([...selectedIds, ...targetIds])]);
+            }
+          };
+
+          const shareAllChecked =
+            allTeamIds.length > 0 && setsEqualAsSets(selectedIds, allTeamIds);
+
           return (
             <FormItem>
               <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
@@ -120,15 +235,55 @@ export const ActivitySharingSection: React.FC<ActivitySharingSectionProps> = ({
                       )}
                     </ComboboxValue>
                   </ComboboxChips>
-                  <ComboboxContent anchor={sharedWithAnchorRef}>
-                    <ComboboxEmpty>No teams found.</ComboboxEmpty>
-                    <ComboboxList>
-                      {(option: OptionItem) => (
-                        <ComboboxItem key={option.value} value={option}>
-                          {option.label}
-                        </ComboboxItem>
-                      )}
-                    </ComboboxList>
+                  <ComboboxContent
+                    anchor={sharedWithAnchorRef}
+                    className={cn(
+                      'popover-list-scroll flex max-h-[min(var(--popover-list-max-height),24rem)] flex-col overflow-x-hidden overflow-y-auto p-0'
+                    )}
+                  >
+                    <div className="bg-popover px-1 py-1">
+                      <SharingShortcutRow
+                        label="Share with all"
+                        checked={shareAllChecked}
+                        disabled={allTeamIds.length === 0}
+                        readOnly={readOnly}
+                        onToggle={() => {
+                          toggleIds(allTeamIds, shareAllChecked);
+                        }}
+                      />
+                      {groupsWithTeamIds.length > 0 ? (
+                        <ComboboxSeparator className="my-1" />
+                      ) : null}
+                      {groupsWithTeamIds.map((g) => {
+                        const empty = g.teamIds.length === 0;
+                        const groupChecked =
+                          !empty &&
+                          g.teamIds.every((id) => selectedIds.includes(id));
+                        return (
+                          <SharingShortcutRow
+                            key={g.id}
+                            label={g.name}
+                            checked={groupChecked}
+                            disabled={empty}
+                            readOnly={readOnly}
+                            onToggle={() => {
+                              toggleIds(g.teamIds, groupChecked);
+                            }}
+                          />
+                        );
+                      })}
+                      {sharedWithTeamOptions.length > 0 ? (
+                        <ComboboxSeparator className="my-1" />
+                      ) : null}
+                      <ComboboxEmpty>No teams found.</ComboboxEmpty>
+                      <ComboboxList className="max-h-none scroll-py-1 overflow-visible p-0 data-empty:p-0">
+                        {(option: OptionItem) => (
+                          <ComboboxItem key={option.value} value={option}>
+                            {option.label}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxList>
+                    </div>
                   </ComboboxContent>
                 </Combobox>
               </FormControl>

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
@@ -69,6 +69,11 @@ function setsEqualAsSets(a: number[], b: number[]): boolean {
   return a.every((id) => sb.has(id));
 }
 
+/** Quick-pick row label: "Share with all social" from group name "Social". */
+function quickShareGroupLabel(groupName: string): string {
+  return `Share with ${groupName.toLowerCase()}`;
+}
+
 type ShortcutRowProps = {
   label: string;
   checked: boolean;
@@ -89,7 +94,7 @@ function SharingShortcutRow({
       type="button"
       disabled={disabled || readOnly}
       className={cn(
-        'relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50',
         !disabled && !readOnly && 'hover:bg-accent hover:text-accent-foreground'
       )}
       onClick={(e) => {
@@ -171,10 +176,13 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
                 </FormSelectTrigger>
               </FormControl>
               <SelectContent>
-                <SelectItem value="global">All ministries</SelectItem>
+                <SelectItem value="global">Everyone</SelectItem>
                 <SelectItem value="team">My team only</SelectItem>
               </SelectContent>
             </FormSelect>
+            <FormDescription>
+              Activities are always visible to exec and admins.
+            </FormDescription>
             <FormMessage />
           </FormItem>
         )}
@@ -262,7 +270,7 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
                         return (
                           <SharingShortcutRow
                             key={g.id}
-                            label={g.name}
+                            label={quickShareGroupLabel(g.name)}
                             checked={groupChecked}
                             disabled={empty}
                             readOnly={readOnly}
@@ -288,7 +296,8 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
                 </Combobox>
               </FormControl>
               <FormDescription>
-                Teams selected can see the activity in their Shared with tab.
+                Teams selected will see this activity in their &apos;Shared
+                with&apos; tab.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/calendar-ui/src/components/admin/ADMIN_ARCHITECTURE.md
+++ b/calendar-ui/src/components/admin/ADMIN_ARCHITECTURE.md
@@ -19,7 +19,7 @@ This document describes the new reusable admin component architecture for managi
                │
                ├─► LookupAdmins.tsx (wraps GenericLookupAdmin)
                │   • CategoriesAdmin
-               │   • CitiesAdmin  
+               │   • CitiesAdmin
                │   • CommsMaterialsAdmin
                │   • etc. (8 total)
                │
@@ -40,6 +40,7 @@ This document describes the new reusable admin component architecture for managi
 **Purpose:** Reusable container for admin sections with consistent layout.
 
 **Features:**
+
 - BC Government brand colors
 - Optional add button
 - Custom header actions (filters, etc.)
@@ -47,6 +48,7 @@ This document describes the new reusable admin component architecture for managi
 - Responsive design
 
 **Usage:**
+
 ```tsx
 <AdminSection
   title="Categories"
@@ -65,6 +67,7 @@ This document describes the new reusable admin component architecture for managi
 **Purpose:** Standardized modal for add/edit/delete operations.
 
 **Features:**
+
 - Loading states with spinner
 - Destructive variant for delete confirmations
 - Consistent button placement
@@ -72,6 +75,7 @@ This document describes the new reusable admin component architecture for managi
 - Auto-focus management
 
 **Usage:**
+
 ```tsx
 <AdminModal
   open={showModal}
@@ -91,12 +95,14 @@ This document describes the new reusable admin component architecture for managi
 **Purpose:** Dynamic form generator for lookup data.
 
 **Features:**
+
 - Configurable field types (text, number, checkbox)
 - Required field validation
 - Auto-managed form state
 - onChange callback for parent components
 
 **Usage:**
+
 ```tsx
 const fields: FormField[] = [
   { name: 'name', label: 'Name', type: 'text', required: true },
@@ -105,16 +111,22 @@ const fields: FormField[] = [
 
 <LookupForm
   fields={fields}
+  resetKey={
+    editingItem != null ? String(editingItem.id) : `create-${createFormSession}`
+  }
   initialData={editingItem || {}}
   onChange={setFormData}
-/>
+/>;
 ```
+
+`createFormSession` is incremented in the "Add" handler (see `GenericLookupAdmin` / `CategoriesAdmin`).
 
 ### 4. GenericLookupAdmin
 
 **Purpose:** Complete CRUD interface template for any lookup type.
 
 **Features:**
+
 - Full CRUD operations (Create, Read, Update, Delete)
 - Filtering (All/Active/Inactive)
 - Custom additional columns
@@ -122,6 +134,7 @@ const fields: FormField[] = [
 - Optimistic updates
 
 **Usage:**
+
 ```tsx
 <GenericLookupAdmin<Category>
   title="Categories"
@@ -131,7 +144,11 @@ const fields: FormField[] = [
   queryKey="categories"
   queryFn={fetchCategories}
   formFields={categoryFields}
-  additionalColumns={[/* extra columns */]}
+  additionalColumns={
+    [
+      /* extra columns */
+    ]
+  }
 />
 ```
 
@@ -142,7 +159,7 @@ const fields: FormField[] = [
 ```tsx
 // Repetitive code for each lookup type:
 // - 8 separate modal states
-// - 8 separate editing states  
+// - 8 separate editing states
 // - 8 create mutations
 // - 8 update mutations
 // - Manual column definitions
@@ -151,6 +168,7 @@ const fields: FormField[] = [
 ```
 
 **Problems:**
+
 - Difficult to maintain consistency
 - Changes require updating 8+ places
 - High risk of bugs from copy-paste errors
@@ -189,6 +207,7 @@ export function CategoriesAdmin() {
 ```
 
 **Benefits:**
+
 - Single source of truth for admin UI
 - Updates apply to all sections automatically
 - Consistent UX across all lookups
@@ -200,6 +219,7 @@ export function CategoriesAdmin() {
 To add a new lookup admin section:
 
 ### Step 1: Define the type
+
 ```tsx
 type NewLookup = {
   id: number | string;
@@ -212,6 +232,7 @@ type NewLookup = {
 ```
 
 ### Step 2: Create API function
+
 ```tsx
 export async function fetchNewLookups(): Promise<NewLookup[]> {
   const response = await api.get('/lookups/new-lookups');
@@ -220,6 +241,7 @@ export async function fetchNewLookups(): Promise<NewLookup[]> {
 ```
 
 ### Step 3: Define form fields
+
 ```tsx
 const newLookupFields: FormField[] = [
   { name: 'name', label: 'Name', type: 'text', required: true },
@@ -229,6 +251,7 @@ const newLookupFields: FormField[] = [
 ```
 
 ### Step 4: Create the admin component
+
 ```tsx
 export function NewLookupsAdmin() {
   return (
@@ -246,12 +269,13 @@ export function NewLookupsAdmin() {
 ```
 
 ### Step 5: Add to Settings page
+
 ```tsx
 import { NewLookupsAdmin } from '@/components/admin/LookupAdmins';
 
 <div id="section-new-lookups">
   <NewLookupsAdmin />
-</div>
+</div>;
 ```
 
 **Total time:** ~5 minutes (vs. ~2 hours copying & modifying old code)
@@ -261,21 +285,24 @@ import { NewLookupsAdmin } from '@/components/admin/LookupAdmins';
 All components use Tailwind CSS with BC Government brand colors:
 
 ### CSS Variables (globals.css)
+
 ```css
---bc-blue: 210 100% 20%;        /* #003366 */
---bc-blue-light: 210 100% 35%;  /* #0056A3 */
---bc-gold: 45 98% 55%;          /* #fcba19 */
---bc-gold-dark: 45 100% 45%;    /* #e5a500 */
+--bc-blue: 210 100% 20%; /* #003366 */
+--bc-blue-light: 210 100% 35%; /* #0056A3 */
+--bc-gold: 45 98% 55%; /* #fcba19 */
+--bc-gold-dark: 45 100% 45%; /* #e5a500 */
 ```
 
 ### Tailwind Utilities
+
 ```tsx
-className="bg-bc-blue text-white"
-className="text-bc-gold hover:text-bc-gold-dark"
-className="border-bc-blue-light"
+className = 'bg-bc-blue text-white';
+className = 'text-bc-gold hover:text-bc-gold-dark';
+className = 'border-bc-blue-light';
 ```
 
 ### Component Variants
+
 ```tsx
 <Badge variant="success" />   // Green checkmark
 <Badge variant="warning" />   // BC Gold
@@ -315,14 +342,16 @@ calendar-ui/src/
 ### Switch to the new Settings page:
 
 1. **Update your route:**
+
 ```tsx
 // In App.tsx or router config
 import { SettingsModern } from './pages/SettingsModern';
 
-<Route path="/settings" element={<SettingsModern />} />
+<Route path="/settings" element={<SettingsModern />} />;
 ```
 
 2. **Test CRUD operations:**
+
 - ✅ Create new items
 - ✅ Edit existing items
 - ✅ Delete items (with confirmation)
@@ -331,6 +360,7 @@ import { SettingsModern } from './pages/SettingsModern';
 - ✅ Quick navigation between sections
 
 3. **Verify styling:**
+
 - ✅ BC Government brand colors
 - ✅ Responsive layout
 - ✅ Consistent spacing
@@ -338,13 +368,13 @@ import { SettingsModern } from './pages/SettingsModern';
 
 ## Performance Benefits
 
-| Metric | Old Settings.tsx | New Architecture | Improvement |
-|--------|------------------|------------------|-------------|
-| **Lines of Code** | 1,735 | ~500 | -71% |
-| **Bundle Size** | ~45 KB | ~32 KB | -29% |
-| **Maintainability** | Low | High | ++ |
-| **Type Safety** | Partial | Full | ++ |
-| **Reusability** | 0% | 95% | ++ |
+| Metric              | Old Settings.tsx | New Architecture | Improvement |
+| ------------------- | ---------------- | ---------------- | ----------- |
+| **Lines of Code**   | 1,735            | ~500             | -71%        |
+| **Bundle Size**     | ~45 KB           | ~32 KB           | -29%        |
+| **Maintainability** | Low              | High             | ++          |
+| **Type Safety**     | Partial          | Full             | ++          |
+| **Reusability**     | 0%               | 95%              | ++          |
 
 ## Accessibility
 
@@ -398,6 +428,7 @@ resolve: {
 **Problem:** `Type 'X' does not satisfy constraint 'BaseLookupItem'`
 
 **Solution:** Ensure your type extends the base interface:
+
 ```tsx
 type YourType = {
   id: number | string;
@@ -405,12 +436,13 @@ type YourType = {
   sortOrder: number;
   isActive: boolean;
   // ... custom fields
-}
+};
 ```
 
 ## Support
 
 For questions or issues with the admin architecture:
+
 1. Check this documentation
 2. Review existing implementations in `LookupAdmins.tsx`
 3. Consult the GenericLookupAdmin source code

--- a/calendar-ui/src/components/admin/ActivityCompletionSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/ActivityCompletionSettingsAdmin.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, Play } from 'lucide-react';
-import { toast } from 'sonner';
 import { useEffect, useMemo, useState, type ReactElement } from 'react';
 
 import {
@@ -43,6 +42,11 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { usePermission } from '@/hooks/usePermissions';
+import {
+  showErrorToast,
+  showInfoToast,
+  showSuccessToast,
+} from '@/lib/error-toast';
 
 const SCHEDULE_LABELS: Record<CompletionSchedule, string> = {
   every_15_minutes: 'Every 15 minutes',
@@ -150,10 +154,10 @@ export function ActivityCompletionSettingsAdmin(): ReactElement | null {
       void queryClient.invalidateQueries({
         queryKey: ['settings', 'activity-completion'],
       });
-      toast.success('Activity completion settings updated');
+      showSuccessToast('Activity completion settings updated');
     },
-    onError: () => {
-      toast.error('Failed to update completion settings');
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 
@@ -166,22 +170,22 @@ export function ActivityCompletionSettingsAdmin(): ReactElement | null {
       });
       if (result.skipped) {
         if (result.skipReason === 'advisory_lock') {
-          toast.info(
+          showInfoToast(
             'Another instance is running the completion job. Try again shortly.'
           );
         } else if (result.skipReason === 'in_flight') {
-          toast.info('Completion job is already running on this server.');
+          showInfoToast('Completion job is already running on this server.');
         } else {
-          toast.info('Completion job did not run.');
+          showInfoToast('Completion job did not run.');
         }
       } else {
-        toast.success(
+        showSuccessToast(
           `Completion job completed: ${result.updated} activity(s) updated`
         );
       }
     },
-    onError: () => {
-      toast.error('Failed to run completion job');
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 

--- a/calendar-ui/src/components/admin/BannerSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/BannerSettingsAdmin.tsx
@@ -17,6 +17,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermission } from '@/hooks/usePermissions';
+import { showErrorToast, showSuccessToast } from '@/lib/error-toast';
 
 import { SystemBanner } from '../layout/SystemBanner';
 
@@ -230,12 +231,10 @@ export function BannerSettingsAdmin() {
     onSuccess: (savedBanner) => {
       queryClient.setQueryData(['banner', 'settings'], savedBanner);
       void queryClient.invalidateQueries({ queryKey: ['banner', 'active'] });
-      toast.success('Banner settings saved');
+      showSuccessToast('Banner settings saved');
     },
     onError: (err) => {
-      const message =
-        err instanceof Error ? err.message : 'Failed to save banner settings';
-      toast.error(message);
+      showErrorToast(err);
     },
   });
 

--- a/calendar-ui/src/components/admin/CategoriesAdmin.tsx
+++ b/calendar-ui/src/components/admin/CategoriesAdmin.tsx
@@ -47,6 +47,7 @@ export function CategoriesAdmin() {
   const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('all');
   const [showModal, setShowModal] = useState(false);
   const [editingItem, setEditingItem] = useState<Category | null>(null);
+  const [createFormSession, setCreateFormSession] = useState(0);
   const [formData, setFormData] = useState<Record<string, any>>({});
 
   const { data, isLoading, error } = useQuery({
@@ -186,10 +187,23 @@ export function CategoriesAdmin() {
   const handleSubmit = () => {
     const processedData = { ...formData };
 
-    // Convert sortOrder to number
-    if (processedData.sortOrder) {
-      processedData.sortOrder = Number(processedData.sortOrder);
+    if (typeof processedData.name === 'string') {
+      processedData.name = processedData.name.trim();
     }
+    if (typeof processedData.displayName === 'string') {
+      processedData.displayName = processedData.displayName.trim();
+    }
+    const nameStr =
+      typeof processedData.name === 'string' ? processedData.name : '';
+    if (
+      (processedData.displayName == null || processedData.displayName === '') &&
+      nameStr !== ''
+    ) {
+      processedData.displayName = nameStr;
+    }
+
+    const so = processedData.sortOrder;
+    processedData.sortOrder = so === '' || so == null ? 0 : Number(so);
 
     if (editingItem) {
       updateMutation.mutate({ ...editingItem, ...processedData });
@@ -201,6 +215,7 @@ export function CategoriesAdmin() {
   const handleOpenModal = () => {
     setEditingItem(null);
     setFormData({});
+    setCreateFormSession((n) => n + 1);
     setShowModal(true);
   };
 
@@ -249,6 +264,11 @@ export function CategoriesAdmin() {
       >
         <LookupForm
           fields={formFields}
+          resetKey={
+            editingItem != null
+              ? String(editingItem.id)
+              : `create-${createFormSession}`
+          }
           initialData={editingItem || {}}
           onChange={setFormData}
         />

--- a/calendar-ui/src/components/admin/EditLockIdleSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/EditLockIdleSettingsAdmin.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermission } from '@/hooks/usePermissions';
+import { showErrorToast } from '@/lib/error-toast';
 
 export function EditLockIdleSettingsAdmin(): React.ReactElement | null {
   const queryClient = useQueryClient();
@@ -42,8 +43,8 @@ export function EditLockIdleSettingsAdmin(): React.ReactElement | null {
       });
       toast.success('Edit lock idle timeout updated');
     },
-    onError: () => {
-      toast.error('Failed to update idle timeout');
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 

--- a/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
+++ b/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
@@ -29,7 +29,7 @@ interface BaseLookupItem {
   displayName?: string | null;
   sortOrder?: number;
   isActive?: boolean;
-  [key: string]: unknown; // Allow additional properties (e.g. abbreviation, ministerName)
+  [key: string]: unknown; // Allow additional properties (e.g. abbreviation, ministerDisplayName)
 }
 
 export interface RenderModalContentProps {
@@ -65,6 +65,14 @@ interface GenericLookupAdminProps<T extends BaseLookupItem> {
   softDelete?: boolean;
   /** When false, hides active/inactive filter (entities without isActive). Default true. */
   showStatusFilter?: boolean;
+  /**
+   * When set, runs instead of the default POST/PATCH mutations (e.g. multi-step saves).
+   * Caller should invalidate relevant queries; this component only closes the modal on success.
+   */
+  submitOverride?: (args: {
+    formData: Record<string, any>;
+    editingItem: T | null;
+  }) => Promise<void>;
 }
 
 /**
@@ -92,9 +100,11 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   additionalInvalidateKeys,
   softDelete,
   showStatusFilter = true,
+  submitOverride,
 }: GenericLookupAdminProps<T>) {
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('all');
+  const [submitOverridePending, setSubmitOverridePending] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [editingItem, setEditingItem] = useState<T | null>(null);
   const [formData, setFormData] = useState<Record<string, any>>({});
@@ -250,7 +260,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
     [additionalColumns, deleteMutation, entityType, getItemName]
   );
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     let processedData = { ...formData };
 
     // Convert numeric fields
@@ -264,6 +274,19 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
           v === '__none__' || v === '' || v == null ? null : Number(v);
       }
     });
+
+    if (submitOverride) {
+      try {
+        setSubmitOverridePending(true);
+        await submitOverride({ formData: processedData, editingItem });
+        setShowModal(false);
+        setEditingItem(null);
+        setFormData({});
+      } finally {
+        setSubmitOverridePending(false);
+      }
+      return;
+    }
 
     if (transformSubmitData) {
       processedData = transformSubmitData(processedData);
@@ -330,15 +353,24 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
             ? `Update ${entityType.toLowerCase()} details`
             : `Create a new ${entityType.toLowerCase()}`
         }
-        onConfirm={handleSubmit}
+        onConfirm={() => {
+          void handleSubmit();
+        }}
         confirmLabel={editingItem ? 'Update' : 'Create'}
-        isLoading={createMutation.isPending || updateMutation.isPending}
+        isLoading={
+          createMutation.isPending ||
+          updateMutation.isPending ||
+          submitOverridePending
+        }
       >
         {renderModalContent ? (
           renderModalContent({
             initialData: editingItem ?? EMPTY_INITIAL,
             onChange: setFormData as (data: Record<string, unknown>) => void,
-            isSubmitting: createMutation.isPending || updateMutation.isPending,
+            isSubmitting:
+              createMutation.isPending ||
+              updateMutation.isPending ||
+              submitOverridePending,
           })
         ) : (
           <LookupForm

--- a/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
+++ b/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
@@ -107,6 +107,8 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   const [submitOverridePending, setSubmitOverridePending] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [editingItem, setEditingItem] = useState<T | null>(null);
+  /** Bumps on each "Add" open so `resetKey` changes every create session. */
+  const [createFormSession, setCreateFormSession] = useState(0);
   const [formData, setFormData] = useState<Record<string, any>>({});
 
   // Memoized only on editingItem to avoid re-creating the object every render,
@@ -263,10 +265,27 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   const handleSubmit = async () => {
     let processedData = { ...formData };
 
-    // Convert numeric fields
+    if (typeof processedData.name === 'string') {
+      processedData.name = processedData.name.trim();
+    }
+    if (typeof processedData.displayName === 'string') {
+      processedData.displayName = processedData.displayName.trim();
+    }
+
+    // Default display name from name when left empty (API schemas require both)
+    const nameStr =
+      typeof processedData.name === 'string' ? processedData.name : '';
+    const isDisplayEmpty =
+      processedData.displayName == null || processedData.displayName === '';
+    if (isDisplayEmpty && nameStr !== '') {
+      processedData.displayName = nameStr;
+    }
+
+    // Convert numeric fields (including 0 and empty -> 0 for sort order, etc.)
     formFields.forEach((field) => {
-      if (field.type === 'number' && processedData[field.name]) {
-        processedData[field.name] = Number(processedData[field.name]);
+      if (field.type === 'number') {
+        const raw = processedData[field.name];
+        processedData[field.name] = raw === '' || raw == null ? 0 : Number(raw);
       }
       if (field.type === 'select' && field.name === 'ministryGroupId') {
         const v = processedData[field.name];
@@ -302,6 +321,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   const handleOpenModal = () => {
     setEditingItem(null);
     setFormData({});
+    setCreateFormSession((n) => n + 1);
     setShowModal(true);
   };
 
@@ -375,6 +395,11 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
         ) : (
           <LookupForm
             fields={formFields}
+            resetKey={
+              editingItem != null
+                ? String(editingItem.id)
+                : `create-${createFormSession}`
+            }
             initialData={resolvedInitialData}
             onChange={setFormData}
           />

--- a/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
+++ b/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
@@ -20,6 +20,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  ClientValidationError,
+  showErrorToast,
+  showSuccessToast,
+} from '@/lib/error-toast';
 
 const EMPTY_INITIAL: Record<string, unknown> = {};
 
@@ -145,6 +150,10 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       setShowModal(false);
       setEditingItem(null);
       setFormData({});
+      showSuccessToast(`${entityType} created`);
+    },
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 
@@ -159,6 +168,10 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       setShowModal(false);
       setEditingItem(null);
       setFormData({});
+      showSuccessToast(`${entityType} updated`);
+    },
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 
@@ -173,6 +186,10 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
     },
     onSuccess: () => {
       invalidateListCaches();
+      showSuccessToast(`${entityType} deleted`);
+    },
+    onError: (error: unknown) => {
+      showErrorToast(error);
     },
   });
 
@@ -298,9 +315,17 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       try {
         setSubmitOverridePending(true);
         await submitOverride({ formData: processedData, editingItem });
+        showSuccessToast(
+          editingItem ? `${entityType} updated` : `${entityType} created`
+        );
         setShowModal(false);
         setEditingItem(null);
         setFormData({});
+      } catch (error: unknown) {
+        if (error instanceof ClientValidationError) {
+          return;
+        }
+        showErrorToast(error);
       } finally {
         setSubmitOverridePending(false);
       }

--- a/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
+++ b/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
@@ -63,6 +63,8 @@ interface GenericLookupAdminProps<T extends BaseLookupItem> {
   /** When true, "delete" sets isActive=false via PATCH instead of issuing a DELETE request.
    * Use for entities that may be referenced by other records (e.g. tags on activities). */
   softDelete?: boolean;
+  /** When false, hides active/inactive filter (entities without isActive). Default true. */
+  showStatusFilter?: boolean;
 }
 
 /**
@@ -89,6 +91,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   renderModalContent,
   additionalInvalidateKeys,
   softDelete,
+  showStatusFilter = true,
 }: GenericLookupAdminProps<T>) {
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('all');
@@ -163,10 +166,11 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
 
   const filteredData = useMemo(() => {
     if (!data) return [];
+    if (!showStatusFilter) return data;
     if (filter === 'active') return data.filter((item) => item.isActive);
     if (filter === 'inactive') return data.filter((item) => !item.isActive);
     return data;
-  }, [data, filter]);
+  }, [data, filter, showStatusFilter]);
 
   const baseColumns: ColumnDef<T>[] = useMemo(
     () => [
@@ -254,6 +258,11 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       if (field.type === 'number' && processedData[field.name]) {
         processedData[field.name] = Number(processedData[field.name]);
       }
+      if (field.type === 'select' && field.name === 'ministryGroupId') {
+        const v = processedData[field.name];
+        processedData[field.name] =
+          v === '__none__' || v === '' || v == null ? null : Number(v);
+      }
     });
 
     if (transformSubmitData) {
@@ -281,16 +290,21 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       addButtonLabel={`Add ${entityType}`}
       isLoading={isLoading}
       headerAction={
-        <Select value={filter} onValueChange={(value: any) => setFilter(value)}>
-          <SelectTrigger className="w-[150px]">
-            <SelectValue placeholder="Filter by status" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All</SelectItem>
-            <SelectItem value="active">Active</SelectItem>
-            <SelectItem value="inactive">Inactive</SelectItem>
-          </SelectContent>
-        </Select>
+        showStatusFilter ? (
+          <Select
+            value={filter}
+            onValueChange={(value: any) => setFilter(value)}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue placeholder="Filter by status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="active">Active</SelectItem>
+              <SelectItem value="inactive">Inactive</SelectItem>
+            </SelectContent>
+          </Select>
+        ) : undefined
       }
     >
       {error && (

--- a/calendar-ui/src/components/admin/LookupAdmins.tsx
+++ b/calendar-ui/src/components/admin/LookupAdmins.tsx
@@ -5,10 +5,11 @@
  * using the GenericLookupAdmin template.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
+import api from '@/api/axios';
 import {
   fetchActivityStatuses,
   fetchAllTags,
@@ -26,11 +27,18 @@ import {
   type ThemeLookupItem,
 } from '@/api/lookupsApi';
 import { fetchTeams } from '@/api/usersApi';
+import type { FreeformComboboxOption } from '@/components/ui/freeform-combobox';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 import { NONE_SELECT_VALUE } from '.';
 import { GenericLookupAdmin } from './GenericLookupAdmin';
 import { FormField } from './LookupForm';
+import {
+  filterMinisterPickerReps,
+  MinistryAdminModalForm,
+  type GovernmentRepMinisterListItem,
+  type MinisterFormSelection,
+} from './MinistryAdminModalForm';
 import { VenuePresetForm } from './VenuePresetForm';
 
 // Type definitions - these extend the base LookupItem from the API
@@ -55,6 +63,8 @@ type GovernmentRepresentative = LookupItem & {
   name?: string;
   displayName?: string | null;
   title?: string | null;
+  ministryId?: number | null;
+  representativeType?: string | null;
 };
 
 type Tag = LookupItem & {
@@ -65,9 +75,10 @@ type Tag = LookupItem & {
   teamIds?: number[];
 };
 
-/** Ministry list item; API may include ministerName on list responses */
+/** Ministry list item from admin API (includes joined minister display name). */
 type MinistryAdminItem = MinistryLookupItem & {
-  ministerName?: string | null;
+  ministerGovernmentRepId?: number | null;
+  ministerDisplayName?: string | null;
   ministryGroupId?: number | null;
 };
 
@@ -223,7 +234,8 @@ const tagFields: FormField[] = [
   },
 ];
 
-const ministryFieldsBase: FormField[] = [
+/** Ministry form fields handled by {@link MinistryAdminModalForm} (minister is a combobox). */
+const ministryCoreFields: FormField[] = [
   {
     name: 'name',
     label: 'Name',
@@ -245,12 +257,6 @@ const ministryFieldsBase: FormField[] = [
     required: true,
     placeholder: 'e.g., AG',
   },
-  {
-    name: 'ministerName',
-    label: 'Minister Name',
-    type: 'text',
-    placeholder: 'Current minister',
-  },
   { name: 'sortOrder', label: 'Sort Order', type: 'number', placeholder: '0' },
   {
     name: 'isActive',
@@ -259,6 +265,100 @@ const ministryFieldsBase: FormField[] = [
     placeholder: 'Item is active',
   },
 ];
+
+function stringField(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value).trim();
+  }
+  return '';
+}
+
+async function persistMinistryWithMinister({
+  formData,
+  editingItem,
+}: {
+  formData: Record<string, unknown>;
+  editingItem: MinistryAdminItem | null;
+}): Promise<void> {
+  const name = stringField(formData.name);
+  const displayName = stringField(formData.displayName);
+  const abbreviation = stringField(formData.abbreviation);
+  if (!name || !displayName || !abbreviation) {
+    window.alert('Name, display name, and abbreviation are required.');
+    throw new Error('Validation failed');
+  }
+
+  const ministerPick = (formData._ministerSelection as
+    | MinisterFormSelection
+    | undefined) ?? {
+    mode: 'none',
+  };
+
+  const rawGid = formData.ministryGroupId;
+  const ministryGroupId =
+    rawGid === '__none__' || rawGid === '' || rawGid == null
+      ? null
+      : Number(rawGid);
+
+  const coreBody = {
+    name,
+    displayName,
+    abbreviation,
+    sortOrder: Number(formData.sortOrder ?? 0),
+    isActive: formData.isActive !== false,
+    ministryGroupId,
+  };
+
+  let ministryId: number;
+  if (editingItem) {
+    ministryId = editingItem.id;
+  } else {
+    const res = await api.post<{ success?: boolean; data?: { id: number } }>(
+      '/lookups/ministries',
+      {
+        ...coreBody,
+        ministerGovernmentRepId: null,
+      }
+    );
+    const created = res.data?.data ?? (res.data as { id?: number });
+    if (created?.id == null) {
+      throw new Error('Ministry create response missing id');
+    }
+    ministryId = created.id;
+  }
+
+  let designatedRepId: number | null = null;
+
+  if (ministerPick.mode === 'none') {
+    designatedRepId = null;
+  } else if (ministerPick.mode === 'existing') {
+    designatedRepId = ministerPick.repId;
+  } else {
+    const trimmed = ministerPick.name.trim();
+    const postRes = await api.post<{
+      success?: boolean;
+      data?: { id: number };
+    }>('/lookups/government-representatives', {
+      name: trimmed,
+      displayName: trimmed,
+      title: 'Minister',
+      sortOrder: 0,
+      isActive: true,
+      representativeType: 'minister',
+    });
+    const newRep = postRes.data?.data ?? (postRes.data as { id?: number });
+    if (newRep?.id == null) {
+      throw new Error('Government representative create response missing id');
+    }
+    designatedRepId = newRep.id;
+  }
+
+  await api.patch(`/lookups/ministries/${ministryId}`, {
+    ...coreBody,
+    ministerGovernmentRepId: designatedRepId,
+  });
+}
 
 const ministryGroupFields: FormField[] = [
   {
@@ -413,7 +513,7 @@ export function GovernmentRepresentativesAdmin() {
   return (
     <GenericLookupAdmin<GovernmentRepresentative>
       title="Government Representatives"
-      description="Manage government representatives"
+      description="Manage government representatives. Ministers can be assigned from the Ministries section when creating or editing a ministry."
       entityType="Government Representative"
       apiEndpoint="/lookups/government-representatives"
       queryKey={lookupQueryKeys.governmentRepresentatives()}
@@ -526,29 +626,74 @@ export function MinistryGroupsAdmin() {
 }
 
 export function MinistriesAdmin() {
+  const queryClient = useQueryClient();
   const groupsQuery = useQuery({
     queryKey: lookupQueryKeys.ministryGroups(),
     queryFn: fetchMinistryGroups,
   });
+  const repsQuery = useQuery({
+    queryKey: lookupQueryKeys.governmentRepresentatives(),
+    queryFn: fetchGovernmentRepresentatives as () => Promise<
+      GovernmentRepresentative[]
+    >,
+  });
 
-  const ministryFields = useMemo((): FormField[] => {
-    const opts = [
+  const sharingGroupSelectOptions = useMemo(() => {
+    return [
       { value: '__none__', label: 'None' },
       ...(groupsQuery.data ?? []).map((g) => ({
         value: String(g.id),
         label: g.name,
       })),
     ];
+  }, [groupsQuery.data]);
+
+  const ministryFields = useMemo((): FormField[] => {
     return [
-      ...ministryFieldsBase,
+      ...ministryCoreFields,
       {
         name: 'ministryGroupId',
         label: 'Sharing group',
         type: 'select',
-        options: opts,
+        options: sharingGroupSelectOptions,
       },
     ];
-  }, [groupsQuery.data]);
+  }, [sharingGroupSelectOptions]);
+
+  const ministerRepOptions: FreeformComboboxOption[] = useMemo(() => {
+    const reps = filterMinisterPickerReps(
+      (repsQuery.data ?? []) as GovernmentRepMinisterListItem[]
+    );
+    return reps.map((r) => ({
+      value: String(r.id),
+      label: r.displayName || r.name,
+    }));
+  }, [repsQuery.data]);
+
+  const submitOverride = useCallback(
+    async ({
+      formData,
+      editingItem,
+    }: {
+      formData: Record<string, unknown>;
+      editingItem: MinistryAdminItem | null;
+    }) => {
+      await persistMinistryWithMinister({
+        formData,
+        editingItem,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: lookupQueryKeys.ministries(),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: lookupQueryKeys.governmentRepresentatives(),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: lookupQueryKeys.activityTeamSharing(),
+      });
+    },
+    [queryClient]
+  );
 
   const ministryExtraColumns = useMemo(
     (): ColumnDef<MinistryAdminItem>[] => [
@@ -562,11 +707,11 @@ export function MinistriesAdmin() {
         ),
       },
       {
-        accessorKey: 'ministerName',
+        accessorKey: 'ministerDisplayName',
         header: 'Minister',
         cell: ({ row }) => (
           <span className="text-slate-600">
-            {row.original.ministerName || '—'}
+            {row.original.ministerDisplayName || '—'}
           </span>
         ),
       },
@@ -589,7 +734,7 @@ export function MinistriesAdmin() {
   return (
     <GenericLookupAdmin<MinistryAdminItem>
       title="Ministries"
-      description="Manage BC government ministries"
+      description="Manage BC government ministries. Choose a minister from existing government representatives or create a new one; the list below stays in sync."
       entityType="Ministry"
       apiEndpoint="/lookups/ministries"
       queryKey={lookupQueryKeys.ministries()}
@@ -598,6 +743,14 @@ export function MinistriesAdmin() {
       additionalColumns={ministryExtraColumns}
       additionalInvalidateKeys={[lookupQueryKeys.activityTeamSharing()]}
       getItemName={(item) => item.displayName ?? item.name ?? String(item.id)}
+      renderModalContent={(props) => (
+        <MinistryAdminModalForm
+          {...props}
+          sharingGroupSelectOptions={sharingGroupSelectOptions}
+          ministerRepOptions={ministerRepOptions}
+        />
+      )}
+      submitOverride={submitOverride}
     />
   );
 }

--- a/calendar-ui/src/components/admin/LookupAdmins.tsx
+++ b/calendar-ui/src/components/admin/LookupAdmins.tsx
@@ -7,6 +7,7 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
+import { toast } from 'sonner';
 import { useCallback, useMemo } from 'react';
 
 import api from '@/api/axios';
@@ -28,6 +29,7 @@ import {
 } from '@/api/lookupsApi';
 import { fetchTeams } from '@/api/usersApi';
 import type { FreeformComboboxOption } from '@/components/ui/freeform-combobox';
+import { ClientValidationError } from '@/lib/error-toast';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 import { NONE_SELECT_VALUE } from '.';
@@ -285,8 +287,8 @@ async function persistMinistryWithMinister({
   const displayName = stringField(formData.displayName);
   const abbreviation = stringField(formData.abbreviation);
   if (!name || !displayName || !abbreviation) {
-    window.alert('Name, display name, and abbreviation are required.');
-    throw new Error('Validation failed');
+    toast.error('Name, display name, and abbreviation are required.');
+    throw new ClientValidationError();
   }
 
   const ministerPick = (formData._ministerSelection as

--- a/calendar-ui/src/components/admin/LookupAdmins.tsx
+++ b/calendar-ui/src/components/admin/LookupAdmins.tsx
@@ -7,6 +7,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
+import { useMemo } from 'react';
 
 import {
   fetchActivityStatuses,
@@ -16,9 +17,11 @@ import {
   fetchCommsMaterials,
   fetchGovernmentRepresentatives,
   fetchMinistries,
+  fetchMinistryGroups,
   fetchThemes,
   fetchVenuePresets,
   type LookupItem,
+  type MinistryGroupListItem,
   type MinistryLookupItem,
   type ThemeLookupItem,
 } from '@/api/lookupsApi';
@@ -65,6 +68,7 @@ type Tag = LookupItem & {
 /** Ministry list item; API may include ministerName on list responses */
 type MinistryAdminItem = MinistryLookupItem & {
   ministerName?: string | null;
+  ministryGroupId?: number | null;
 };
 
 type ActivityStatus = LookupItem & {
@@ -219,7 +223,7 @@ const tagFields: FormField[] = [
   },
 ];
 
-const ministryFields: FormField[] = [
+const ministryFieldsBase: FormField[] = [
   {
     name: 'name',
     label: 'Name',
@@ -254,6 +258,17 @@ const ministryFields: FormField[] = [
     type: 'checkbox',
     placeholder: 'Item is active',
   },
+];
+
+const ministryGroupFields: FormField[] = [
+  {
+    name: 'name',
+    label: 'Name',
+    type: 'text',
+    required: true,
+    placeholder: 'e.g., Social, Resource',
+  },
+  { name: 'sortOrder', label: 'Sort Order', type: 'number', placeholder: '0' },
 ];
 
 const statusFields: FormField[] = [
@@ -493,7 +508,84 @@ export function TagsAdmin() {
   );
 }
 
+export function MinistryGroupsAdmin() {
+  return (
+    <GenericLookupAdmin<MinistryGroupListItem>
+      title="Ministry groups"
+      description="Named groups for activity “Shared with teams” shortcuts. Assign ministries to a group in the Ministries section."
+      entityType="Ministry group"
+      apiEndpoint="/lookups/ministry-groups"
+      queryKey={lookupQueryKeys.ministryGroups()}
+      queryFn={fetchMinistryGroups}
+      formFields={ministryGroupFields}
+      showStatusFilter={false}
+      additionalInvalidateKeys={[lookupQueryKeys.activityTeamSharing()]}
+      getItemName={(item) => item.name ?? String(item.id)}
+    />
+  );
+}
+
 export function MinistriesAdmin() {
+  const groupsQuery = useQuery({
+    queryKey: lookupQueryKeys.ministryGroups(),
+    queryFn: fetchMinistryGroups,
+  });
+
+  const ministryFields = useMemo((): FormField[] => {
+    const opts = [
+      { value: '__none__', label: 'None' },
+      ...(groupsQuery.data ?? []).map((g) => ({
+        value: String(g.id),
+        label: g.name,
+      })),
+    ];
+    return [
+      ...ministryFieldsBase,
+      {
+        name: 'ministryGroupId',
+        label: 'Sharing group',
+        type: 'select',
+        options: opts,
+      },
+    ];
+  }, [groupsQuery.data]);
+
+  const ministryExtraColumns = useMemo(
+    (): ColumnDef<MinistryAdminItem>[] => [
+      {
+        accessorKey: 'abbreviation',
+        header: 'Abbreviation',
+        cell: ({ row }) => (
+          <span className="font-mono text-sm text-slate-600">
+            {row.original.abbreviation || '—'}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'ministerName',
+        header: 'Minister',
+        cell: ({ row }) => (
+          <span className="text-slate-600">
+            {row.original.ministerName || '—'}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'ministryGroupId',
+        header: 'Group',
+        cell: ({ row }) => {
+          const gid = row.original.ministryGroupId;
+          const name =
+            gid == null
+              ? null
+              : (groupsQuery.data ?? []).find((g) => g.id === gid)?.name;
+          return <span className="text-slate-600">{name ?? '—'}</span>;
+        },
+      },
+    ],
+    [groupsQuery.data]
+  );
+
   return (
     <GenericLookupAdmin<MinistryAdminItem>
       title="Ministries"
@@ -503,26 +595,8 @@ export function MinistriesAdmin() {
       queryKey={lookupQueryKeys.ministries()}
       queryFn={fetchMinistries as () => Promise<MinistryAdminItem[]>}
       formFields={ministryFields}
-      additionalColumns={[
-        {
-          accessorKey: 'abbreviation',
-          header: 'Abbreviation',
-          cell: ({ row }) => (
-            <span className="font-mono text-sm text-slate-600">
-              {row.original.abbreviation || '—'}
-            </span>
-          ),
-        },
-        {
-          accessorKey: 'ministerName',
-          header: 'Minister',
-          cell: ({ row }) => (
-            <span className="text-slate-600">
-              {row.original.ministerName || '—'}
-            </span>
-          ),
-        },
-      ]}
+      additionalColumns={ministryExtraColumns}
+      additionalInvalidateKeys={[lookupQueryKeys.activityTeamSharing()]}
       getItemName={(item) => item.displayName ?? item.name ?? String(item.id)}
     />
   );

--- a/calendar-ui/src/components/admin/LookupForm.tsx
+++ b/calendar-ui/src/components/admin/LookupForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { NONE_SELECT_VALUE } from '.';
 import { Checkbox } from '../ui/checkbox';
@@ -27,8 +27,25 @@ export interface FormField {
   options?: SelectOption[];
 }
 
+function buildDefaultFormData(
+  initialData?: Record<string, any>
+): Record<string, any> {
+  return {
+    isActive: true,
+    sortOrder: 0,
+    ...(initialData ?? {}),
+  };
+}
+
 interface LookupFormProps {
   fields: FormField[];
+  /**
+   * When this value changes (e.g. create vs edit, or one row vs another), the form
+   * resets from `initialData`. Use a stable id string per record. For create, use a
+   * value that changes on every new add (e.g. `create-${session}` incremented when
+   * opening the modal) so the form clears if the dialog keeps the same mount.
+   */
+  resetKey: string;
   initialData?: Record<string, any>;
   onChange: (data: Record<string, any>) => void;
 }
@@ -37,15 +54,30 @@ interface LookupFormProps {
  * LookupForm - Reusable form for admin lookup data
  * Provides consistent form styling and data handling for admin forms.
  */
-export function LookupForm({ fields, initialData, onChange }: LookupFormProps) {
-  const [formData, setFormData] = useState<Record<string, any>>({
-    isActive: true,
-    ...initialData,
-  });
+export function LookupForm({
+  fields,
+  resetKey,
+  initialData,
+  onChange,
+}: LookupFormProps) {
+  const [formData, setFormData] = useState<Record<string, any>>(() =>
+    buildDefaultFormData(initialData)
+  );
 
+  const lastResetKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    setFormData({ isActive: true, ...initialData });
-  }, [initialData]);
+    if (lastResetKeyRef.current === null) {
+      lastResetKeyRef.current = resetKey;
+      return;
+    }
+    if (lastResetKeyRef.current === resetKey) {
+      return;
+    }
+    lastResetKeyRef.current = resetKey;
+    setFormData(buildDefaultFormData(initialData));
+    // Only reset on `resetKey` changes; `initialData` is the snapshot for that key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey]);
 
   useEffect(() => {
     onChange(formData);

--- a/calendar-ui/src/components/admin/MinistryAdminModalForm.tsx
+++ b/calendar-ui/src/components/admin/MinistryAdminModalForm.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FreeformCombobox,
+  type FreeformComboboxOption,
+  type FreeformComboboxValueWithLead,
+} from '@/components/ui/freeform-combobox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+import type { RenderModalContentProps } from './GenericLookupAdmin';
+
+export type MinisterFormSelection =
+  | { mode: 'none' }
+  | { mode: 'existing'; repId: number }
+  | { mode: 'new'; name: string };
+
+export type GovernmentRepMinisterListItem = {
+  id: number;
+  name: string;
+  displayName: string;
+  representativeType: string | null;
+  /** Present on list API: ministry that designates this rep as minister, if any */
+  ministryId?: number | null;
+};
+
+function isMinisterPickerRep(rep: {
+  representativeType: string | null;
+}): boolean {
+  return (
+    rep.representativeType == null || rep.representativeType === 'minister'
+  );
+}
+
+export function filterMinisterPickerReps(
+  reps: GovernmentRepMinisterListItem[]
+): GovernmentRepMinisterListItem[] {
+  return reps.filter(isMinisterPickerRep);
+}
+
+function comboboxValueFromSelection(
+  sel: MinisterFormSelection
+): FreeformComboboxValueWithLead {
+  if (sel.mode === 'none') return null;
+  if (sel.mode === 'existing') {
+    return { type: 'option', value: String(sel.repId) };
+  }
+  return { type: 'freeform', value: sel.name };
+}
+
+function selectionFromComboboxValue(
+  v: FreeformComboboxValueWithLead
+): MinisterFormSelection {
+  if (v == null) return { mode: 'none' };
+  if (v.type === 'option') {
+    return { mode: 'existing', repId: Number(v.value) };
+  }
+  const name = v.value.trim();
+  if (!name) return { mode: 'none' };
+  return { mode: 'new', name };
+}
+
+function sortOrderToInputString(value: unknown): string {
+  if (value == null) return '0';
+  if (typeof value === 'number' || typeof value === 'string') {
+    return String(value);
+  }
+  return '0';
+}
+
+function deriveInitialMinisterSelection(
+  initial: Record<string, unknown>,
+  ministerOptionIds: Set<string>
+): MinisterFormSelection {
+  const designatedId = initial.ministerGovernmentRepId as
+    | number
+    | null
+    | undefined;
+  if (designatedId != null && ministerOptionIds.has(String(designatedId))) {
+    return { mode: 'existing', repId: designatedId };
+  }
+  return { mode: 'none' };
+}
+
+interface MinistryAdminModalFormProps extends RenderModalContentProps {
+  sharingGroupSelectOptions: { value: string; label: string }[];
+  ministerRepOptions: FreeformComboboxOption[];
+}
+
+/**
+ * Ministry create/edit form with minister as a freeform combobox over government reps
+ * (minister role / untyped legacy rows), plus inline creation of a new rep on save.
+ */
+export function MinistryAdminModalForm({
+  initialData,
+  onChange,
+  isSubmitting,
+  sharingGroupSelectOptions,
+  ministerRepOptions,
+}: MinistryAdminModalFormProps) {
+  const ministerOptionIds = useMemo(
+    () => new Set(ministerRepOptions.map((o) => o.value)),
+    [ministerRepOptions]
+  );
+
+  const [name, setName] = useState(() => (initialData.name as string) ?? '');
+  const [displayName, setDisplayName] = useState(
+    () => (initialData.displayName as string) ?? ''
+  );
+  const [abbreviation, setAbbreviation] = useState(
+    () => (initialData.abbreviation as string) ?? ''
+  );
+  const [sortOrder, setSortOrder] = useState(() =>
+    sortOrderToInputString(initialData.sortOrder)
+  );
+  const [isActive, setIsActive] = useState(
+    () => initialData.isActive !== false
+  );
+  const [ministryGroupId, setMinistryGroupId] = useState(() => {
+    const gid = initialData.ministryGroupId as number | null | undefined;
+    return gid == null ? '__none__' : String(gid);
+  });
+  const [ministerComboValue, setMinisterComboValue] =
+    useState<FreeformComboboxValueWithLead>(() =>
+      comboboxValueFromSelection(
+        deriveInitialMinisterSelection(
+          initialData,
+          new Set(ministerRepOptions.map((o) => o.value))
+        )
+      )
+    );
+
+  useEffect(() => {
+    setName((initialData.name as string) ?? '');
+    setDisplayName((initialData.displayName as string) ?? '');
+    setAbbreviation((initialData.abbreviation as string) ?? '');
+    setSortOrder(sortOrderToInputString(initialData.sortOrder));
+    setIsActive(initialData.isActive !== false);
+    const gid = initialData.ministryGroupId as number | null | undefined;
+    setMinistryGroupId(gid == null ? '__none__' : String(gid));
+    setMinisterComboValue(
+      comboboxValueFromSelection(
+        deriveInitialMinisterSelection(initialData, ministerOptionIds)
+      )
+    );
+  }, [initialData, ministerOptionIds]);
+
+  useEffect(() => {
+    const groupVal =
+      ministryGroupId === '__none__' || ministryGroupId === ''
+        ? '__none__'
+        : ministryGroupId;
+    onChange({
+      name,
+      displayName,
+      abbreviation,
+      sortOrder: sortOrder === '' ? 0 : Number(sortOrder),
+      isActive,
+      ministryGroupId: groupVal,
+      _ministerSelection: selectionFromComboboxValue(ministerComboValue),
+    });
+  }, [
+    name,
+    displayName,
+    abbreviation,
+    sortOrder,
+    isActive,
+    ministryGroupId,
+    ministerComboValue,
+    onChange,
+  ]);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="ministry-name" className="text-sm font-medium">
+          Name<span className="text-destructive ml-1">*</span>
+        </Label>
+        <Input
+          id="ministry-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g., PREM, AGRI"
+          required
+          disabled={isSubmitting}
+          className="w-full"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ministry-display-name" className="text-sm font-medium">
+          Display Name<span className="text-destructive ml-1">*</span>
+        </Label>
+        <Input
+          id="ministry-display-name"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Full ministry name"
+          required
+          disabled={isSubmitting}
+          className="w-full"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ministry-abbr" className="text-sm font-medium">
+          Abbreviation<span className="text-destructive ml-1">*</span>
+        </Label>
+        <Input
+          id="ministry-abbr"
+          value={abbreviation}
+          onChange={(e) => setAbbreviation(e.target.value)}
+          placeholder="e.g., AG"
+          required
+          disabled={isSubmitting}
+          className="w-full"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ministry-minister" className="text-sm font-medium">
+          Minister
+        </Label>
+        <FreeformCombobox
+          options={ministerRepOptions}
+          value={ministerComboValue}
+          onChange={(v) => {
+            if (v == null || Array.isArray(v)) {
+              setMinisterComboValue(null);
+              return;
+            }
+            setMinisterComboValue(v);
+          }}
+          placeholder="Search ministers or type a new name…"
+          searchPlaceholder="Search…"
+          emptyMessage="No matching ministers."
+          freeformLabel="Create new government representative"
+          freeformDescription="Saves as a minister linked to this ministry."
+          disabled={isSubmitting}
+          className="w-full"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ministry-sort" className="text-sm font-medium">
+          Sort Order
+        </Label>
+        <Input
+          id="ministry-sort"
+          type="number"
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value)}
+          placeholder="0"
+          disabled={isSubmitting}
+          className="w-full"
+        />
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="ministry-active"
+          checked={isActive}
+          onCheckedChange={(checked) => setIsActive(checked === true)}
+          disabled={isSubmitting}
+        />
+        <label
+          htmlFor="ministry-active"
+          className="text-sm leading-none font-normal peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Active
+        </label>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ministry-group" className="text-sm font-medium">
+          Sharing group
+        </Label>
+        <Select
+          value={ministryGroupId}
+          onValueChange={setMinistryGroupId}
+          disabled={isSubmitting}
+        >
+          <SelectTrigger id="ministry-group" className="w-full">
+            <SelectValue placeholder="None" />
+          </SelectTrigger>
+          <SelectContent>
+            {sharingGroupSelectOptions.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/calendar-ui/src/components/admin/MinistryAdminModalForm.tsx
+++ b/calendar-ui/src/components/admin/MinistryAdminModalForm.tsx
@@ -275,7 +275,7 @@ export function MinistryAdminModalForm({
       </div>
       <div className="space-y-2">
         <Label htmlFor="ministry-group" className="text-sm font-medium">
-          Sharing group
+          Ministry group
         </Label>
         <Select
           value={ministryGroupId}

--- a/calendar-ui/src/hooks/useActivityEditFormHydration.test.tsx
+++ b/calendar-ui/src/hooks/useActivityEditFormHydration.test.tsx
@@ -29,6 +29,7 @@ const mockLookups: FormLookupData = {
   premierRequested: [],
   newsReleaseOrigins: [],
   sharedWithTeams: [],
+  quickShareGroups: [],
   dateStatuses: [],
   timeStatuses: [],
   venueStatuses: [],

--- a/calendar-ui/src/hooks/useFormLookups.tsx
+++ b/calendar-ui/src/hooks/useFormLookups.tsx
@@ -11,6 +11,7 @@ import type { OptionItem } from '@/schemas/types';
 
 import {
   useActivityStatuses,
+  useActivityTeamSharing,
   useCategories,
   useCommsMaterials,
   useDateStatuses,
@@ -24,7 +25,6 @@ import {
   usePitchStatuses,
   usePremierRequested,
   useTags,
-  useTeams,
   useTimeStatuses,
   useTranslationLanguages,
   useTranslationRequiredStatuses,
@@ -95,7 +95,20 @@ export interface FormLookupData {
   newsReleaseOrigins: OptionItem[];
 
   // Teams - for Shared With resolution (name to id in mapper) and dropdown options
-  sharedWithTeams: Array<{ id: number; name: string; displayName?: string }>;
+  sharedWithTeams: Array<{
+    id: number;
+    name: string;
+    displayName?: string;
+    ministryId: number | null;
+  }>;
+
+  /** Ministry quick-share groups (activity form); empty if not configured. */
+  quickShareGroups: Array<{
+    id: number;
+    name: string;
+    sortOrder: number;
+    ministryIds: number[];
+  }>;
 
   // Date Statuses - for Schedule section and confirm modals
   dateStatuses: DateStatusLookupItem[];
@@ -134,7 +147,7 @@ export function useFormLookups(): FormLookupData {
   const newsReleaseDistributionsQuery = useNewsReleaseDistributions();
   const premierRequestedQuery = usePremierRequested();
   const newsReleaseOriginsQuery = useNewsReleaseOrigins();
-  const teamsQuery = useTeams();
+  const activityTeamSharingQuery = useActivityTeamSharing();
   const dateStatusesQuery = useDateStatuses();
   const timeStatusesQuery = useTimeStatuses();
   const venueStatusesQuery = useVenueStatuses();
@@ -156,7 +169,7 @@ export function useFormLookups(): FormLookupData {
     newsReleaseDistributionsQuery.isLoading ||
     premierRequestedQuery.isLoading ||
     newsReleaseOriginsQuery.isLoading ||
-    teamsQuery.isLoading ||
+    activityTeamSharingQuery.isLoading ||
     dateStatusesQuery.isLoading ||
     timeStatusesQuery.isLoading ||
     venueStatusesQuery.isLoading ||
@@ -178,7 +191,7 @@ export function useFormLookups(): FormLookupData {
     newsReleaseDistributionsQuery.isError ||
     premierRequestedQuery.isError ||
     newsReleaseOriginsQuery.isError ||
-    teamsQuery.isError ||
+    activityTeamSharingQuery.isError ||
     dateStatusesQuery.isError ||
     timeStatusesQuery.isError ||
     venueStatusesQuery.isError ||
@@ -299,11 +312,21 @@ export function useFormLookups(): FormLookupData {
       })) || [];
 
     // Teams for Shared With dropdown and response->form mapping (name to id)
+    const sharingPayload = activityTeamSharingQuery.data;
     const sharedWithTeams =
-      teamsQuery.data?.map((t) => ({
+      sharingPayload?.teams.map((t) => ({
         id: t.id,
         name: t.name,
         displayName: t.displayName ?? undefined,
+        ministryId: t.ministryId,
+      })) ?? [];
+
+    const quickShareGroups =
+      sharingPayload?.quickShare?.groups.map((g) => ({
+        id: g.id,
+        name: g.name,
+        sortOrder: g.sortOrder,
+        ministryIds: g.ministryIds,
       })) ?? [];
 
     return {
@@ -353,6 +376,7 @@ export function useFormLookups(): FormLookupData {
       premierRequested,
       newsReleaseOrigins,
       sharedWithTeams,
+      quickShareGroups,
       dateStatuses: dateStatusesQuery.data ?? [],
       timeStatuses: timeStatusesQuery.data ?? [],
       venueStatuses: venueStatusesQuery.data ?? [],
@@ -378,7 +402,7 @@ export function useFormLookups(): FormLookupData {
     pitchStatusesQuery.data,
     premierRequestedQuery.data,
     tagsQuery.data,
-    teamsQuery.data,
+    activityTeamSharingQuery.data,
     timeStatusesQuery.data,
     venueStatusesQuery.data,
     translationLanguagesQuery.data,

--- a/calendar-ui/src/hooks/useLookups.tsx
+++ b/calendar-ui/src/hooks/useLookups.tsx
@@ -5,6 +5,7 @@ import {
   REFERENCE_LOOKUP_CACHE_MS,
 } from '@corpcal/shared';
 import type {
+  ActivityTeamSharingResponse,
   DateStatusLookupItem,
   PitchRequiredStatusLookupItem,
   ReportResponse,
@@ -13,6 +14,7 @@ import type {
   VenueStatusLookupItem,
 } from '@corpcal/shared/api/types';
 
+import { fetchActivityTeamSharing } from '../api/activityTeamSharingApi';
 import {
   fetchActivitiesForLookup,
   fetchActivityStatuses,
@@ -52,6 +54,17 @@ import { fetchTeams } from '../api/usersApi';
 import { lookupQueryKeys } from '../lib/lookupQueryKeys';
 
 type TeamLookupItem = Awaited<ReturnType<typeof fetchTeams>>[number];
+
+/**
+ * Teams plus ministry quick-share groups for activity create/edit (single payload).
+ */
+export function useActivityTeamSharing() {
+  return useQuery<ActivityTeamSharingResponse>({
+    queryKey: lookupQueryKeys.activityTeamSharing(),
+    queryFn: fetchActivityTeamSharing,
+    staleTime: REFERENCE_LOOKUP_CACHE_MS,
+  });
+}
 
 export function useCategories() {
   return useQuery<CategoryLookupItem[]>({

--- a/calendar-ui/src/lib/error-toast.ts
+++ b/calendar-ui/src/lib/error-toast.ts
@@ -32,6 +32,17 @@ import { ApiError, NetworkError } from '../api/errors';
  */
 
 /**
+ * Throw after client-side validation has already called `toast.error` so
+ * `submitOverride` callers can abort without `showErrorToast` duplicating noise.
+ */
+export class ClientValidationError extends Error {
+  constructor(message = 'Validation failed') {
+    super(message);
+    this.name = 'ClientValidationError';
+  }
+}
+
+/**
  * Get a human-readable title for an HTTP status code
  */
 function getErrorTitle(status: number): string {

--- a/calendar-ui/src/lib/lookupQueryKeys.ts
+++ b/calendar-ui/src/lib/lookupQueryKeys.ts
@@ -30,6 +30,8 @@ export const lookupQueryKeys = {
     ['lookups', 'government-representatives'] as const,
   ministries: () => ['lookups', 'ministries'] as const,
   ministryGroups: () => ['lookups', 'ministry-groups'] as const,
+  /** Teams + ministry quick-share payload for activity Shared with (`GET /lookups/activity-team-sharing`). */
+  activityTeamSharing: () => ['lookups', 'activity-team-sharing'] as const,
   themes: () => ['lookups', 'themes'] as const,
   venuePresets: () => ['lookups', 'venue-presets'] as const,
   venueStatuses: () => ['lookups', 'venue-statuses'] as const,

--- a/calendar-ui/src/pages/ActivityPage.test.tsx
+++ b/calendar-ui/src/pages/ActivityPage.test.tsx
@@ -66,6 +66,7 @@ const mockLookupsReady: FormLookupData = {
   premierRequested: [],
   newsReleaseOrigins: [],
   sharedWithTeams: [],
+  quickShareGroups: [],
   dateStatuses: [],
   timeStatuses: [],
   venueStatuses: [],

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -70,16 +70,16 @@ const sections = [
     label: 'Ministry groups',
     icon: Share2,
   },
-  { id: 'categories' as Section, label: 'Categories', icon: FolderTree },
-  { id: 'cities' as Section, label: 'Cities', icon: MapPin },
-  { id: 'comms' as Section, label: 'Communications Materials', icon: FileText },
+  { id: 'ministries' as Section, label: 'Ministries', icon: Building2 },
   {
     id: 'representatives' as Section,
     label: 'Government Representatives',
     icon: Users,
   },
+  { id: 'categories' as Section, label: 'Categories', icon: FolderTree },
+  { id: 'cities' as Section, label: 'Cities', icon: MapPin },
+  { id: 'comms' as Section, label: 'Communications Materials', icon: FileText },
   { id: 'tags' as Section, label: 'Tags', icon: Tag },
-  { id: 'ministries' as Section, label: 'Ministries', icon: Building2 },
   { id: 'statuses' as Section, label: 'Activity Statuses', icon: Activity },
   { id: 'themes' as Section, label: 'Themes', icon: Palette },
   {
@@ -168,6 +168,14 @@ export function Settings() {
             <MinistryGroupsAdmin />
           </div>
 
+          <div id="section-ministries">
+            <MinistriesAdmin />
+          </div>
+
+          <div id="section-representatives">
+            <GovernmentRepresentativesAdmin />
+          </div>
+
           <div id="section-categories">
             <CategoriesAdmin />
           </div>
@@ -180,16 +188,8 @@ export function Settings() {
             <CommsMaterialsAdmin />
           </div>
 
-          <div id="section-representatives">
-            <GovernmentRepresentativesAdmin />
-          </div>
-
           <div id="section-tags">
             <TagsAdmin />
-          </div>
-
-          <div id="section-ministries">
-            <MinistriesAdmin />
           </div>
 
           <div id="section-statuses">

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import {
   MapPin,
   Megaphone,
   Palette,
+  Share2,
   Tag,
   Timer,
   Users,
@@ -25,6 +26,7 @@ import {
   CommsMaterialsAdmin,
   GovernmentRepresentativesAdmin,
   MinistriesAdmin,
+  MinistryGroupsAdmin,
   TagsAdmin,
   ThemesAdmin,
   VenuePresetsAdmin,
@@ -35,6 +37,7 @@ type Section =
   | 'edit-lock-idle'
   | 'activity-completion'
   | 'look-ahead-reset'
+  | 'ministry-groups'
   | 'categories'
   | 'cities'
   | 'comms'
@@ -61,6 +64,11 @@ const sections = [
     id: 'look-ahead-reset' as Section,
     label: 'Look Ahead reset',
     icon: Eraser,
+  },
+  {
+    id: 'ministry-groups' as Section,
+    label: 'Ministry groups',
+    icon: Share2,
   },
   { id: 'categories' as Section, label: 'Categories', icon: FolderTree },
   { id: 'cities' as Section, label: 'Cities', icon: MapPin },
@@ -154,6 +162,10 @@ export function Settings() {
 
           <div id="section-look-ahead-reset">
             <LookAheadResetSettingsAdmin />
+          </div>
+
+          <div id="section-ministry-groups">
+            <MinistryGroupsAdmin />
           </div>
 
           <div id="section-categories">

--- a/packages/database/migrations/0003_20260421_ministry_groups.sql
+++ b/packages/database/migrations/0003_20260421_ministry_groups.sql
@@ -14,6 +14,7 @@ ALTER TABLE "ministries" ADD COLUMN "minister_government_rep_id" integer;--> sta
 ALTER TABLE "ministries" ADD COLUMN "ministry_group_id" integer;--> statement-breakpoint
 ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_last_updated_by_users_id_fk" FOREIGN KEY ("last_updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "ministry_groups_name_lower_unique" ON "ministry_groups" USING btree (lower("name"));--> statement-breakpoint
 ALTER TABLE "ministries" ADD CONSTRAINT "ministries_ministry_group_id_ministry_groups_id_fk" FOREIGN KEY ("ministry_group_id") REFERENCES "public"."ministry_groups"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ministries" DROP COLUMN "minister_name";--> statement-breakpoint
 ALTER TABLE "government_representatives" DROP COLUMN "ministry_id";

--- a/packages/database/migrations/0003_20260421_ministry_groups.sql
+++ b/packages/database/migrations/0003_20260421_ministry_groups.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "ministry_groups" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(200) NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_date_time" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by" integer NOT NULL,
+	"last_updated_date_time" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_updated_by" integer NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ministries" ADD COLUMN "ministry_group_id" integer;--> statement-breakpoint
+ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_last_updated_by_users_id_fk" FOREIGN KEY ("last_updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ministries" ADD CONSTRAINT "ministries_ministry_group_id_ministry_groups_id_fk" FOREIGN KEY ("ministry_group_id") REFERENCES "public"."ministry_groups"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/database/migrations/0005_20260421_ministry_groups.sql
+++ b/packages/database/migrations/0005_20260421_ministry_groups.sql
@@ -8,7 +8,12 @@ CREATE TABLE "ministry_groups" (
 	"last_updated_by" integer NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "government_representatives" DROP CONSTRAINT "government_representatives_ministry_id_ministries_id_fk";
+--> statement-breakpoint
+ALTER TABLE "ministries" ADD COLUMN "minister_government_rep_id" integer;--> statement-breakpoint
 ALTER TABLE "ministries" ADD COLUMN "ministry_group_id" integer;--> statement-breakpoint
 ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "ministry_groups" ADD CONSTRAINT "ministry_groups_last_updated_by_users_id_fk" FOREIGN KEY ("last_updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "ministries" ADD CONSTRAINT "ministries_ministry_group_id_ministry_groups_id_fk" FOREIGN KEY ("ministry_group_id") REFERENCES "public"."ministry_groups"("id") ON DELETE set null ON UPDATE no action;
+ALTER TABLE "ministries" ADD CONSTRAINT "ministries_ministry_group_id_ministry_groups_id_fk" FOREIGN KEY ("ministry_group_id") REFERENCES "public"."ministry_groups"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ministries" DROP COLUMN "minister_name";--> statement-breakpoint
+ALTER TABLE "government_representatives" DROP COLUMN "ministry_id";

--- a/packages/database/migrations/meta/0003_snapshot.json
+++ b/packages/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,6814 @@
+{
+  "id": "9b0b3b83-1014-4e4d-a072-bb8bb133ec0d",
+  "prevId": "437e7cc7-93b9-4892-9e20-fe9f527be68a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_org_id": {
+          "name": "lead_org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_org_name": {
+          "name": "lead_org_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "significance": {
+          "name": "significance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_issue": {
+          "name": "is_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_all_day": {
+          "name": "is_all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_status_id": {
+          "name": "date_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_status_id": {
+          "name": "time_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduling_notes": {
+          "name": "scheduling_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue_status_id": {
+          "name": "venue_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "news_release_origin_id": {
+          "name": "news_release_origin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "news_release_id": {
+          "name": "news_release_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "news_release_date_time": {
+          "name": "news_release_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executive_summary": {
+          "name": "executive_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "look_ahead_status": {
+          "name": "look_ahead_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "look_ahead_section": {
+          "name": "look_ahead_section",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_confidential": {
+          "name": "is_confidential",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch_date": {
+          "name": "pitch_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch_required_status_id": {
+          "name": "pitch_required_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translations_required_status_id": {
+          "name": "translations_required_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "news_release_distribution_id": {
+          "name": "news_release_distribution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premier_requested_id": {
+          "name": "premier_requested_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "lead_team_id": {
+          "name": "lead_team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_ministry_id": {
+          "name": "lead_ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_status_id": {
+          "name": "activity_status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_field_snapshot": {
+          "name": "reviewed_field_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_field_snapshot_version": {
+          "name": "reviewed_field_snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "row_version": {
+          "name": "row_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_activities_title_trgm": {
+          "name": "idx_activities_title_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"title\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_activities_display_id_trgm": {
+          "name": "idx_activities_display_id_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"display_id\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_lead_org_id_organizations_id_fk": {
+          "name": "activities_lead_org_id_organizations_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "organizations",
+          "columnsFrom": ["lead_org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_date_status_id_date_statuses_id_fk": {
+          "name": "activities_date_status_id_date_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "date_statuses",
+          "columnsFrom": ["date_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_time_status_id_time_statuses_id_fk": {
+          "name": "activities_time_status_id_time_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "time_statuses",
+          "columnsFrom": ["time_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_venue_status_id_venue_statuses_id_fk": {
+          "name": "activities_venue_status_id_venue_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "venue_statuses",
+          "columnsFrom": ["venue_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_news_release_origin_id_news_release_origins_id_fk": {
+          "name": "activities_news_release_origin_id_news_release_origins_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "news_release_origins",
+          "columnsFrom": ["news_release_origin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_pitch_required_status_id_pitch_required_statuses_id_fk": {
+          "name": "activities_pitch_required_status_id_pitch_required_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "pitch_required_statuses",
+          "columnsFrom": ["pitch_required_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_translations_required_status_id_translation_required_statuses_id_fk": {
+          "name": "activities_translations_required_status_id_translation_required_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "translation_required_statuses",
+          "columnsFrom": ["translations_required_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_news_release_distribution_id_news_release_distributions_id_fk": {
+          "name": "activities_news_release_distribution_id_news_release_distributions_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "news_release_distributions",
+          "columnsFrom": ["news_release_distribution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_premier_requested_id_premier_requested_id_fk": {
+          "name": "activities_premier_requested_id_premier_requested_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "premier_requested",
+          "columnsFrom": ["premier_requested_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_lead_team_id_teams_id_fk": {
+          "name": "activities_lead_team_id_teams_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "teams",
+          "columnsFrom": ["lead_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_lead_ministry_id_ministries_id_fk": {
+          "name": "activities_lead_ministry_id_ministries_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "ministries",
+          "columnsFrom": ["lead_ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_activity_status_id_activity_statuses_id_fk": {
+          "name": "activities_activity_status_id_activity_statuses_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "activity_statuses",
+          "columnsFrom": ["activity_status_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_created_by_users_id_fk": {
+          "name": "activities_created_by_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activities_last_updated_by_users_id_fk": {
+          "name": "activities_last_updated_by_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activities_display_id_unique": {
+          "name": "activities_display_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["display_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lead_org_at_most_one": {
+          "name": "lead_org_at_most_one",
+          "value": "NOT (\"activities\".\"lead_org_id\" IS NOT NULL AND \"activities\".\"lead_org_name\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.activity_history": {
+      "name": "activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activity_title": {
+          "name": "activity_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_display_id": {
+          "name": "activity_display_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_tags_text": {
+          "name": "category_tags_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "activity_history_activity_id_idx": {
+          "name": "activity_history_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_history_user_id_idx": {
+          "name": "activity_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_history_timestamp_idx": {
+          "name": "activity_history_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_history_activity_id_timestamp_idx": {
+          "name": "activity_history_activity_id_timestamp_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_history_ts_id": {
+          "name": "idx_activity_history_ts_id",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_history_notes_trgm": {
+          "name": "idx_activity_history_notes_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"notes\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_history_activity_id_activities_id_fk": {
+          "name": "activity_history_activity_id_activities_id_fk",
+          "tableFrom": "activity_history",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_history_user_id_users_id_fk": {
+          "name": "activity_history_user_id_users_id_fk",
+          "tableFrom": "activity_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deletion_audit": {
+      "name": "deletion_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deletion_audit_user_id_users_id_fk": {
+          "name": "deletion_audit_user_id_users_id_fk",
+          "tableFrom": "deletion_audit",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_username": {
+          "name": "ad_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_display_name": {
+          "name": "ad_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_email": {
+          "name": "ad_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_phone": {
+          "name": "ad_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_division": {
+          "name": "ad_division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_department": {
+          "name": "ad_department",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_job_title": {
+          "name": "ad_job_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_date_time": {
+          "name": "last_login_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_ad_display_name_trgm": {
+          "name": "idx_users_ad_display_name_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"ad_display_name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_ad_username_trgm": {
+          "name": "idx_users_ad_username_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"ad_username\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_role_id_roles_id_fk": {
+          "name": "users_role_id_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_history": {
+      "name": "user_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_history_user_id_idx": {
+          "name": "user_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_history_changed_by_user_id_idx": {
+          "name": "user_history_changed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "changed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_history_timestamp_idx": {
+          "name": "user_history_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_history_user_id_timestamp_idx": {
+          "name": "user_history_user_id_timestamp_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_history_user_id_users_id_fk": {
+          "name": "user_history_user_id_users_id_fk",
+          "tableFrom": "user_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_history_changed_by_user_id_users_id_fk": {
+          "name": "user_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "user_history",
+          "tableTo": "users",
+          "columnsFrom": ["changed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_history": {
+      "name": "team_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_history_team_id_idx": {
+          "name": "team_history_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_history_changed_by_user_id_idx": {
+          "name": "team_history_changed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "changed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_history_timestamp_idx": {
+          "name": "team_history_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_history_team_id_timestamp_idx": {
+          "name": "team_history_team_id_timestamp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_history_team_id_teams_id_fk": {
+          "name": "team_history_team_id_teams_id_fk",
+          "tableFrom": "team_history",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_history_changed_by_user_id_users_id_fk": {
+          "name": "team_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "team_history",
+          "tableTo": "users",
+          "columnsFrom": ["changed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ministries": {
+      "name": "ministries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minister_name": {
+          "name": "minister_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_user_id": {
+          "name": "contact_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_contact_user_id": {
+          "name": "second_contact_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ministry_group_id": {
+          "name": "ministry_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ministries_contact_user_id_users_id_fk": {
+          "name": "ministries_contact_user_id_users_id_fk",
+          "tableFrom": "ministries",
+          "tableTo": "users",
+          "columnsFrom": ["contact_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ministries_second_contact_user_id_users_id_fk": {
+          "name": "ministries_second_contact_user_id_users_id_fk",
+          "tableFrom": "ministries",
+          "tableTo": "users",
+          "columnsFrom": ["second_contact_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ministries_ministry_group_id_ministry_groups_id_fk": {
+          "name": "ministries_ministry_group_id_ministry_groups_id_fk",
+          "tableFrom": "ministries",
+          "tableTo": "ministry_groups",
+          "columnsFrom": ["ministry_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ministries_created_by_users_id_fk": {
+          "name": "ministries_created_by_users_id_fk",
+          "tableFrom": "ministries",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ministries_last_updated_by_users_id_fk": {
+          "name": "ministries_last_updated_by_users_id_fk",
+          "tableFrom": "ministries",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pod_ministries": {
+      "name": "pod_ministries",
+      "schema": "",
+      "columns": {
+        "pod_id": {
+          "name": "pod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pod_ministries_pod_id_pods_id_fk": {
+          "name": "pod_ministries_pod_id_pods_id_fk",
+          "tableFrom": "pod_ministries",
+          "tableTo": "pods",
+          "columnsFrom": ["pod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pod_ministries_ministry_id_ministries_id_fk": {
+          "name": "pod_ministries_ministry_id_ministries_id_fk",
+          "tableFrom": "pod_ministries",
+          "tableTo": "ministries",
+          "columnsFrom": ["ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pod_ministries_pod_id_ministry_id_pk": {
+          "name": "pod_ministries_pod_id_ministry_id_pk",
+          "columns": ["pod_id", "ministry_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pod_shared_with_teams": {
+      "name": "pod_shared_with_teams",
+      "schema": "",
+      "columns": {
+        "pod_id": {
+          "name": "pod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pod_shared_with_teams_pod_id_pods_id_fk": {
+          "name": "pod_shared_with_teams_pod_id_pods_id_fk",
+          "tableFrom": "pod_shared_with_teams",
+          "tableTo": "pods",
+          "columnsFrom": ["pod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pod_shared_with_teams_team_id_teams_id_fk": {
+          "name": "pod_shared_with_teams_team_id_teams_id_fk",
+          "tableFrom": "pod_shared_with_teams",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pod_shared_with_teams_pod_id_team_id_pk": {
+          "name": "pod_shared_with_teams_pod_id_team_id_pk",
+          "columns": ["pod_id", "team_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pods": {
+      "name": "pods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pods_created_by_users_id_fk": {
+          "name": "pods_created_by_users_id_fk",
+          "tableFrom": "pods",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pods_last_updated_by_users_id_fk": {
+          "name": "pods_last_updated_by_users_id_fk",
+          "tableFrom": "pods",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ministry_groups": {
+      "name": "ministry_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ministry_groups_created_by_users_id_fk": {
+          "name": "ministry_groups_created_by_users_id_fk",
+          "tableFrom": "ministry_groups",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ministry_groups_last_updated_by_users_id_fk": {
+          "name": "ministry_groups_last_updated_by_users_id_fk",
+          "tableFrom": "ministry_groups",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_type": {
+          "name": "organization_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_ministry_id_ministries_id_fk": {
+          "name": "organizations_ministry_id_ministries_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "ministries",
+          "columnsFrom": ["ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizations_created_by_users_id_fk": {
+          "name": "organizations_created_by_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizations_last_updated_by_users_id_fk": {
+          "name": "organizations_last_updated_by_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_filters": {
+      "name": "activity_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query_string": {
+          "name": "query_string",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_filters_created_by_users_id_fk": {
+          "name": "activity_filters_created_by_users_id_fk",
+          "tableFrom": "activity_filters",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_filters_last_updated_by_users_id_fk": {
+          "name": "activity_filters_last_updated_by_users_id_fk",
+          "tableFrom": "activity_filters",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_statuses": {
+      "name": "activity_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_statuses_created_by_users_id_fk": {
+          "name": "activity_statuses_created_by_users_id_fk",
+          "tableFrom": "activity_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_statuses_last_updated_by_users_id_fk": {
+          "name": "activity_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "activity_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_categories_display_name_trgm": {
+          "name": "idx_categories_display_name_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"display_name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_created_by_users_id_fk": {
+          "name": "categories_created_by_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "categories_last_updated_by_users_id_fk": {
+          "name": "categories_last_updated_by_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "province_or_state": {
+          "name": "province_or_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cities_created_by_users_id_fk": {
+          "name": "cities_created_by_users_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cities_last_updated_by_users_id_fk": {
+          "name": "cities_last_updated_by_users_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comms_contacts": {
+      "name": "comms_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comms_contacts_created_by_users_id_fk": {
+          "name": "comms_contacts_created_by_users_id_fk",
+          "tableFrom": "comms_contacts",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comms_contacts_last_updated_by_users_id_fk": {
+          "name": "comms_contacts_last_updated_by_users_id_fk",
+          "tableFrom": "comms_contacts",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comms_materials": {
+      "name": "comms_materials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comms_materials_created_by_users_id_fk": {
+          "name": "comms_materials_created_by_users_id_fk",
+          "tableFrom": "comms_materials",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comms_materials_last_updated_by_users_id_fk": {
+          "name": "comms_materials_last_updated_by_users_id_fk",
+          "tableFrom": "comms_materials",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.date_statuses": {
+      "name": "date_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "date_statuses_created_by_users_id_fk": {
+          "name": "date_statuses_created_by_users_id_fk",
+          "tableFrom": "date_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "date_statuses_last_updated_by_users_id_fk": {
+          "name": "date_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "date_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_planners": {
+      "name": "event_planners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_planners_created_by_users_id_fk": {
+          "name": "event_planners_created_by_users_id_fk",
+          "tableFrom": "event_planners",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_planners_last_updated_by_users_id_fk": {
+          "name": "event_planners_last_updated_by_users_id_fk",
+          "tableFrom": "event_planners",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.government_representatives": {
+      "name": "government_representatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_type": {
+          "name": "representative_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "government_representatives_ministry_id_ministries_id_fk": {
+          "name": "government_representatives_ministry_id_ministries_id_fk",
+          "tableFrom": "government_representatives",
+          "tableTo": "ministries",
+          "columnsFrom": ["ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "government_representatives_created_by_users_id_fk": {
+          "name": "government_representatives_created_by_users_id_fk",
+          "tableFrom": "government_representatives",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "government_representatives_last_updated_by_users_id_fk": {
+          "name": "government_representatives_last_updated_by_users_id_fk",
+          "tableFrom": "government_representatives",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_release_distributions": {
+      "name": "news_release_distributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_release_distributions_created_by_users_id_fk": {
+          "name": "news_release_distributions_created_by_users_id_fk",
+          "tableFrom": "news_release_distributions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "news_release_distributions_last_updated_by_users_id_fk": {
+          "name": "news_release_distributions_last_updated_by_users_id_fk",
+          "tableFrom": "news_release_distributions",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_release_origins": {
+      "name": "news_release_origins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "news_release_origins_created_by_users_id_fk": {
+          "name": "news_release_origins_created_by_users_id_fk",
+          "tableFrom": "news_release_origins",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "news_release_origins_last_updated_by_users_id_fk": {
+          "name": "news_release_origins_last_updated_by_users_id_fk",
+          "tableFrom": "news_release_origins",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pitch_required_statuses": {
+      "name": "pitch_required_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pitch_required_statuses_created_by_users_id_fk": {
+          "name": "pitch_required_statuses_created_by_users_id_fk",
+          "tableFrom": "pitch_required_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pitch_required_statuses_last_updated_by_users_id_fk": {
+          "name": "pitch_required_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "pitch_required_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pitch_statuses": {
+      "name": "pitch_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pitch_statuses_created_by_users_id_fk": {
+          "name": "pitch_statuses_created_by_users_id_fk",
+          "tableFrom": "pitch_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pitch_statuses_last_updated_by_users_id_fk": {
+          "name": "pitch_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "pitch_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.premier_requested": {
+      "name": "premier_requested",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "premier_requested_created_by_users_id_fk": {
+          "name": "premier_requested_created_by_users_id_fk",
+          "tableFrom": "premier_requested",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premier_requested_last_updated_by_users_id_fk": {
+          "name": "premier_requested_last_updated_by_users_id_fk",
+          "tableFrom": "premier_requested",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'team'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_created_by_users_id_fk": {
+          "name": "reports_created_by_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_last_updated_by_users_id_fk": {
+          "name": "reports_last_updated_by_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_name_unique": {
+          "name": "reports_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sectors": {
+      "name": "sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sectors_created_by_users_id_fk": {
+          "name": "sectors_created_by_users_id_fk",
+          "tableFrom": "sectors",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sectors_last_updated_by_users_id_fk": {
+          "name": "sectors_last_updated_by_users_id_fk",
+          "tableFrom": "sectors",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tags_display_name_trgm": {
+          "name": "idx_tags_display_name_trgm",
+          "columns": [
+            {
+              "expression": "lower(\"display_name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_created_by_users_id_fk": {
+          "name": "tags_created_by_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_last_updated_by_users_id_fk": {
+          "name": "tags_last_updated_by_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.themes": {
+      "name": "themes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "top_release_id": {
+          "name": "top_release_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_release_id": {
+          "name": "feature_release_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "themes_created_by_users_id_fk": {
+          "name": "themes_created_by_users_id_fk",
+          "tableFrom": "themes",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "themes_last_updated_by_users_id_fk": {
+          "name": "themes_last_updated_by_users_id_fk",
+          "tableFrom": "themes",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_statuses": {
+      "name": "time_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "time_statuses_created_by_users_id_fk": {
+          "name": "time_statuses_created_by_users_id_fk",
+          "tableFrom": "time_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "time_statuses_last_updated_by_users_id_fk": {
+          "name": "time_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "time_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translated_languages": {
+      "name": "translated_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "translated_languages_created_by_users_id_fk": {
+          "name": "translated_languages_created_by_users_id_fk",
+          "tableFrom": "translated_languages",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "translated_languages_last_updated_by_users_id_fk": {
+          "name": "translated_languages_last_updated_by_users_id_fk",
+          "tableFrom": "translated_languages",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_required_statuses": {
+      "name": "translation_required_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "translation_required_statuses_created_by_users_id_fk": {
+          "name": "translation_required_statuses_created_by_users_id_fk",
+          "tableFrom": "translation_required_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "translation_required_statuses_last_updated_by_users_id_fk": {
+          "name": "translation_required_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "translation_required_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue_statuses": {
+      "name": "venue_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "venue_statuses_created_by_users_id_fk": {
+          "name": "venue_statuses_created_by_users_id_fk",
+          "tableFrom": "venue_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_statuses_last_updated_by_users_id_fk": {
+          "name": "venue_statuses_last_updated_by_users_id_fk",
+          "tableFrom": "venue_statuses",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_categories": {
+      "name": "activity_categories",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_categories_activity_id_activities_id_fk": {
+          "name": "activity_categories_activity_id_activities_id_fk",
+          "tableFrom": "activity_categories",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_categories_category_id_categories_id_fk": {
+          "name": "activity_categories_category_id_categories_id_fk",
+          "tableFrom": "activity_categories",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_categories_activity_id_category_id_pk": {
+          "name": "activity_categories_activity_id_category_id_pk",
+          "columns": ["activity_id", "category_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_comms_contacts": {
+      "name": "activity_comms_contacts",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_lead": {
+          "name": "is_lead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_comms_contacts_activity_id_activities_id_fk": {
+          "name": "activity_comms_contacts_activity_id_activities_id_fk",
+          "tableFrom": "activity_comms_contacts",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_comms_contacts_user_id_users_id_fk": {
+          "name": "activity_comms_contacts_user_id_users_id_fk",
+          "tableFrom": "activity_comms_contacts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_comms_contacts_activity_id_user_id_pk": {
+          "name": "activity_comms_contacts_activity_id_user_id_pk",
+          "columns": ["activity_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_comms_materials": {
+      "name": "activity_comms_materials",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comms_material_id": {
+          "name": "comms_material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_comms_materials_activity_id_activities_id_fk": {
+          "name": "activity_comms_materials_activity_id_activities_id_fk",
+          "tableFrom": "activity_comms_materials",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_comms_materials_comms_material_id_comms_materials_id_fk": {
+          "name": "activity_comms_materials_comms_material_id_comms_materials_id_fk",
+          "tableFrom": "activity_comms_materials",
+          "tableTo": "comms_materials",
+          "columnsFrom": ["comms_material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_comms_materials_activity_id_comms_material_id_pk": {
+          "name": "activity_comms_materials_activity_id_comms_material_id_pk",
+          "columns": ["activity_id", "comms_material_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_event_planners": {
+      "name": "activity_event_planners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_planner_id": {
+          "name": "event_planner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_planner_name": {
+          "name": "event_planner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_lead": {
+          "name": "is_lead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_event_planners_activity_id_activities_id_fk": {
+          "name": "activity_event_planners_activity_id_activities_id_fk",
+          "tableFrom": "activity_event_planners",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_event_planners_event_planner_id_event_planners_id_fk": {
+          "name": "activity_event_planners_event_planner_id_event_planners_id_fk",
+          "tableFrom": "activity_event_planners",
+          "tableTo": "event_planners",
+          "columnsFrom": ["event_planner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_report_settings": {
+      "name": "activity_report_settings",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "omitted": {
+          "name": "omitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_report_settings_activity_id": {
+          "name": "idx_activity_report_settings_activity_id",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_report_settings_report_id": {
+          "name": "idx_activity_report_settings_report_id",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_report_settings_activity_report": {
+          "name": "idx_activity_report_settings_activity_report",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_report_settings_omitted": {
+          "name": "idx_activity_report_settings_omitted",
+          "columns": [
+            {
+              "expression": "omitted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_report_settings_activity_id_activities_id_fk": {
+          "name": "activity_report_settings_activity_id_activities_id_fk",
+          "tableFrom": "activity_report_settings",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_report_settings_report_id_reports_id_fk": {
+          "name": "activity_report_settings_report_id_reports_id_fk",
+          "tableFrom": "activity_report_settings",
+          "tableTo": "reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_report_settings_activity_id_report_id_pk": {
+          "name": "activity_report_settings_activity_id_report_id_pk",
+          "columns": ["activity_id", "report_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_representatives": {
+      "name": "activity_representatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "representative_id": {
+          "name": "representative_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_name": {
+          "name": "representative_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_representatives_activity_id_activities_id_fk": {
+          "name": "activity_representatives_activity_id_activities_id_fk",
+          "tableFrom": "activity_representatives",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_sectors": {
+      "name": "activity_sectors",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sector_id": {
+          "name": "sector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_sectors_activity_id_activities_id_fk": {
+          "name": "activity_sectors_activity_id_activities_id_fk",
+          "tableFrom": "activity_sectors",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_sectors_sector_id_sectors_id_fk": {
+          "name": "activity_sectors_sector_id_sectors_id_fk",
+          "tableFrom": "activity_sectors",
+          "tableTo": "sectors",
+          "columnsFrom": ["sector_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_sectors_activity_id_sector_id_pk": {
+          "name": "activity_sectors_activity_id_sector_id_pk",
+          "columns": ["activity_id", "sector_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_shared_with_teams": {
+      "name": "activity_shared_with_teams",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_shared_with_teams_activity_id_activities_id_fk": {
+          "name": "activity_shared_with_teams_activity_id_activities_id_fk",
+          "tableFrom": "activity_shared_with_teams",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_shared_with_teams_team_id_teams_id_fk": {
+          "name": "activity_shared_with_teams_team_id_teams_id_fk",
+          "tableFrom": "activity_shared_with_teams",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_shared_with_teams_activity_id_team_id_pk": {
+          "name": "activity_shared_with_teams_activity_id_team_id_pk",
+          "columns": ["activity_id", "team_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_subscriptions": {
+      "name": "activity_subscriptions",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_subscriptions_activity_id_activities_id_fk": {
+          "name": "activity_subscriptions_activity_id_activities_id_fk",
+          "tableFrom": "activity_subscriptions",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_subscriptions_tag_id_tags_id_fk": {
+          "name": "activity_subscriptions_tag_id_tags_id_fk",
+          "tableFrom": "activity_subscriptions",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_subscriptions_activity_id_tag_id_pk": {
+          "name": "activity_subscriptions_activity_id_tag_id_pk",
+          "columns": ["activity_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_tags": {
+      "name": "activity_tags",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_tags_activity_id_activities_id_fk": {
+          "name": "activity_tags_activity_id_activities_id_fk",
+          "tableFrom": "activity_tags",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_tags_tag_id_tags_id_fk": {
+          "name": "activity_tags_tag_id_tags_id_fk",
+          "tableFrom": "activity_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_tags_activity_id_tag_id_pk": {
+          "name": "activity_tags_activity_id_tag_id_pk",
+          "columns": ["activity_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_themes": {
+      "name": "activity_themes",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_themes_activity_id_activities_id_fk": {
+          "name": "activity_themes_activity_id_activities_id_fk",
+          "tableFrom": "activity_themes",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_themes_theme_id_themes_id_fk": {
+          "name": "activity_themes_theme_id_themes_id_fk",
+          "tableFrom": "activity_themes",
+          "tableTo": "themes",
+          "columnsFrom": ["theme_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_themes_activity_id_theme_id_pk": {
+          "name": "activity_themes_activity_id_theme_id_pk",
+          "columns": ["activity_id", "theme_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_translation_languages": {
+      "name": "activity_translation_languages",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_translation_languages_activity_id_activities_id_fk": {
+          "name": "activity_translation_languages_activity_id_activities_id_fk",
+          "tableFrom": "activity_translation_languages",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_translation_languages_language_id_translated_languages_id_fk": {
+          "name": "activity_translation_languages_language_id_translated_languages_id_fk",
+          "tableFrom": "activity_translation_languages",
+          "tableTo": "translated_languages",
+          "columnsFrom": ["language_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_translation_languages_activity_id_language_id_pk": {
+          "name": "activity_translation_languages_activity_id_language_id_pk",
+          "columns": ["activity_id", "language_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorite_activities": {
+      "name": "favorite_activities",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorite_activities_user_id_users_id_fk": {
+          "name": "favorite_activities_user_id_users_id_fk",
+          "tableFrom": "favorite_activities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorite_activities_activity_id_activities_id_fk": {
+          "name": "favorite_activities_activity_id_activities_id_fk",
+          "tableFrom": "favorite_activities",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorite_activities_user_id_activity_id_pk": {
+          "name": "favorite_activities_user_id_activity_id_pk",
+          "columns": ["user_id", "activity_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ministry_users": {
+      "name": "ministry_users",
+      "schema": "",
+      "columns": {
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ministry_users_ministry_id_ministries_id_fk": {
+          "name": "ministry_users_ministry_id_ministries_id_fk",
+          "tableFrom": "ministry_users",
+          "tableTo": "ministries",
+          "columnsFrom": ["ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ministry_users_user_id_users_id_fk": {
+          "name": "ministry_users_user_id_users_id_fk",
+          "tableFrom": "ministry_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ministry_users_ministry_id_user_id_pk": {
+          "name": "ministry_users_ministry_id_user_id_pk",
+          "columns": ["ministry_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_categories": {
+      "name": "team_categories",
+      "schema": "",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_categories_category_id_categories_id_fk": {
+          "name": "team_categories_category_id_categories_id_fk",
+          "tableFrom": "team_categories",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_categories_team_id_teams_id_fk": {
+          "name": "team_categories_team_id_teams_id_fk",
+          "tableFrom": "team_categories",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_categories_category_id_team_id_pk": {
+          "name": "team_categories_category_id_team_id_pk",
+          "columns": ["category_id", "team_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_teams": {
+      "name": "user_teams",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_teams_user_id_users_id_fk": {
+          "name": "user_teams_user_id_users_id_fk",
+          "tableFrom": "user_teams",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_teams_team_id_teams_id_fk": {
+          "name": "user_teams_team_id_teams_id_fk",
+          "tableFrom": "user_teams",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_teams_user_id_team_id_pk": {
+          "name": "user_teams_user_id_team_id_pk",
+          "columns": ["user_id", "team_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_drafts": {
+      "name": "form_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_type": {
+          "name": "form_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_data": {
+          "name": "draft_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_user_form_null_entity": {
+          "name": "unique_user_form_null_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "entity_id IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_user_form_entity": {
+          "name": "unique_user_form_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "entity_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_drafts_user_id_idx": {
+          "name": "form_drafts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_drafts_form_type_idx": {
+          "name": "form_drafts_form_type_idx",
+          "columns": [
+            {
+              "expression": "form_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_drafts_expires_at_idx": {
+          "name": "form_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_drafts_user_id_users_id_fk": {
+          "name": "form_drafts_user_id_users_id_fk",
+          "tableFrom": "form_drafts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_permissions": {
+      "name": "team_permissions",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_permissions_team_id_teams_id_fk": {
+          "name": "team_permissions_team_id_teams_id_fk",
+          "tableFrom": "team_permissions",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_permissions_permission_id_permissions_id_fk": {
+          "name": "team_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "team_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_permissions_team_id_permission_id_pk": {
+          "name": "team_permissions_team_id_permission_id_pk",
+          "columns": ["team_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_role_id_roles_id_fk": {
+          "name": "teams_role_id_roles_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "teams_ministry_id_ministries_id_fk": {
+          "name": "teams_ministry_id_ministries_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "ministries",
+          "columnsFrom": ["ministry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "teams_created_by_users_id_fk": {
+          "name": "teams_created_by_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_last_updated_by_users_id_fk": {
+          "name": "teams_last_updated_by_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue_addresses": {
+      "name": "venue_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_name": {
+          "name": "venue_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "province_or_state": {
+          "name": "province_or_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "venue_addresses_activity_id_activities_id_fk": {
+          "name": "venue_addresses_activity_id_activities_id_fk",
+          "tableFrom": "venue_addresses",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "venue_addresses_activity_id_unique": {
+          "name": "venue_addresses_activity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["activity_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue_presets": {
+      "name": "venue_presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "venue_name": {
+          "name": "venue_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "province_or_state": {
+          "name": "province_or_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned_sort_order": {
+          "name": "pinned_sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "venue_presets_created_by_users_id_fk": {
+          "name": "venue_presets_created_by_users_id_fk",
+          "tableFrom": "venue_presets",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_presets_last_updated_by_users_id_fk": {
+          "name": "venue_presets_last_updated_by_users_id_fk",
+          "tableFrom": "venue_presets",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permissions_created_by_users_id_fk": {
+          "name": "permissions_created_by_users_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "permissions_updated_by_users_id_fk": {
+          "name": "permissions_updated_by_users_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_key_unique": {
+          "name": "permissions_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_created_by_users_id_fk": {
+          "name": "role_permissions_created_by_users_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "role_permissions_updated_by_users_id_fk": {
+          "name": "role_permissions_updated_by_users_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": ["role_id", "permission_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roles_created_by_users_id_fk": {
+          "name": "roles_created_by_users_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "roles_updated_by_users_id_fk": {
+          "name": "roles_updated_by_users_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_locks": {
+      "name": "edit_locks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idle_expires_at": {
+          "name": "idle_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edit_locks_entity_type_entity_id_unique": {
+          "name": "edit_locks_entity_type_entity_id_unique",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_locks_expires_at_idx": {
+          "name": "edit_locks_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_locks_user_id_idx": {
+          "name": "edit_locks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_locks_idle_expires_at_idx": {
+          "name": "edit_locks_idle_expires_at_idx",
+          "columns": [
+            {
+              "expression": "idle_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edit_locks_user_id_users_id_fk": {
+          "name": "edit_locks_user_id_users_id_fk",
+          "tableFrom": "edit_locks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_lock_pending_handoffs": {
+      "name": "edit_lock_pending_handoffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "edit_lock_pending_handoffs_activity_id_idx": {
+          "name": "edit_lock_pending_handoffs_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_lock_pending_handoffs_due_idx": {
+          "name": "edit_lock_pending_handoffs_due_idx",
+          "columns": [
+            {
+              "expression": "grace_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_lock_pending_handoffs_one_pending_per_activity": {
+          "name": "edit_lock_pending_handoffs_one_pending_per_activity",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edit_lock_pending_handoffs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edit_lock_pending_handoffs_activity_id_activities_id_fk": {
+          "name": "edit_lock_pending_handoffs_activity_id_activities_id_fk",
+          "tableFrom": "edit_lock_pending_handoffs",
+          "tableTo": "activities",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edit_lock_pending_handoffs_from_user_id_users_id_fk": {
+          "name": "edit_lock_pending_handoffs_from_user_id_users_id_fk",
+          "tableFrom": "edit_lock_pending_handoffs",
+          "tableTo": "users",
+          "columnsFrom": ["from_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edit_lock_pending_handoffs_to_user_id_users_id_fk": {
+          "name": "edit_lock_pending_handoffs_to_user_id_users_id_fk",
+          "tableFrom": "edit_lock_pending_handoffs",
+          "tableTo": "users",
+          "columnsFrom": ["to_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_settings": {
+      "name": "banner_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#E6A635'"
+        },
+        "text_color": {
+          "name": "text_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#000000'"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "is_dismissible": {
+          "name": "is_dismissible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dismiss_scope": {
+          "name": "dismiss_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'persistent'"
+        },
+        "start_date_time": {
+          "name": "start_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date_time": {
+          "name": "end_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_date_time": {
+          "name": "created_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_date_time": {
+          "name": "last_updated_date_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banner_settings_created_by_users_id_fk": {
+          "name": "banner_settings_created_by_users_id_fk",
+          "tableFrom": "banner_settings",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "banner_settings_last_updated_by_users_id_fk": {
+          "name": "banner_settings_last_updated_by_users_id_fk",
+          "tableFrom": "banner_settings",
+          "tableTo": "users",
+          "columnsFrom": ["last_updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_saved_filters": {
+      "name": "activity_saved_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_state": {
+          "name": "filter_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_keyword": {
+          "name": "search_keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "scope_team_id": {
+          "name": "scope_team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "asf_owner_user_id_idx": {
+          "name": "asf_owner_user_id_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asf_scope_type_idx": {
+          "name": "asf_scope_type_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asf_scope_team_id_idx": {
+          "name": "asf_scope_team_id_idx",
+          "columns": [
+            {
+              "expression": "scope_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asf_unique_user_scope_name": {
+          "name": "asf_unique_user_scope_name",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_active = true AND scope_type = 'user'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asf_unique_team_scope_name": {
+          "name": "asf_unique_team_scope_name",
+          "columns": [
+            {
+              "expression": "scope_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_active = true AND scope_type = 'team'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asf_unique_global_scope_name": {
+          "name": "asf_unique_global_scope_name",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_active = true AND scope_type = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_saved_filters_owner_user_id_users_id_fk": {
+          "name": "activity_saved_filters_owner_user_id_users_id_fk",
+          "tableFrom": "activity_saved_filters",
+          "tableTo": "users",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "asf_scope_type_check": {
+          "name": "asf_scope_type_check",
+          "value": "\"activity_saved_filters\".\"scope_type\" IN ('user', 'team', 'global')"
+        },
+        "asf_scope_team_scope_check": {
+          "name": "asf_scope_team_scope_check",
+          "value": "(\n        (\"activity_saved_filters\".\"scope_type\" = 'team' AND \"activity_saved_filters\".\"scope_team_id\" IS NOT NULL)\n        OR\n        (\"activity_saved_filters\".\"scope_type\" IN ('user', 'global') AND \"activity_saved_filters\".\"scope_team_id\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_activity_saved_filter_defaults": {
+      "name": "user_activity_saved_filter_defaults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_filter_id": {
+          "name": "saved_filter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uasfd_user_unique": {
+          "name": "uasfd_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uasfd_user_id_idx": {
+          "name": "uasfd_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uasfd_saved_filter_id_idx": {
+          "name": "uasfd_saved_filter_id_idx",
+          "columns": [
+            {
+              "expression": "saved_filter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_saved_filter_defaults_user_id_users_id_fk": {
+          "name": "user_activity_saved_filter_defaults_user_id_users_id_fk",
+          "tableFrom": "user_activity_saved_filter_defaults",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_activity_saved_filter_defaults_saved_filter_id_activity_saved_filters_id_fk": {
+          "name": "user_activity_saved_filter_defaults_saved_filter_id_activity_saved_filters_id_fk",
+          "tableFrom": "user_activity_saved_filter_defaults",
+          "tableTo": "activity_saved_filters",
+          "columnsFrom": ["saved_filter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/0003_snapshot.json
+++ b/packages/database/migrations/meta/0003_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "77af4a84-0eb5-4611-b5df-1a7400c413be",
+  "id": "128d5570-c880-4318-b22a-cb12ba401694",
   "prevId": "437e7cc7-93b9-4892-9e20-fe9f527be68a",
   "version": "7",
   "dialect": "postgresql",
@@ -1594,7 +1594,23 @@
           "notNull": true
         }
       },
-      "indexes": {},
+      "indexes": {
+        "ministry_groups_name_lower_unique": {
+          "name": "ministry_groups_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "ministry_groups_created_by_users_id_fk": {
           "name": "ministry_groups_created_by_users_id_fk",

--- a/packages/database/migrations/meta/0005_snapshot.json
+++ b/packages/database/migrations/meta/0005_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9b0b3b83-1014-4e4d-a072-bb8bb133ec0d",
+  "id": "77af4a84-0eb5-4611-b5df-1a7400c413be",
   "prevId": "437e7cc7-93b9-4892-9e20-fe9f527be68a",
   "version": "7",
   "dialect": "postgresql",
@@ -1209,9 +1209,9 @@
           "primaryKey": false,
           "notNull": true
         },
-        "minister_name": {
-          "name": "minister_name",
-          "type": "varchar(255)",
+        "minister_government_rep_id": {
+          "name": "minister_government_rep_id",
+          "type": "integer",
           "primaryKey": false,
           "notNull": false
         },
@@ -2586,12 +2586,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "ministry_id": {
-          "name": "ministry_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
         "representative_type": {
           "name": "representative_type",
           "type": "varchar(50)",
@@ -2627,15 +2621,6 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "government_representatives_ministry_id_ministries_id_fk": {
-          "name": "government_representatives_ministry_id_ministries_id_fk",
-          "tableFrom": "government_representatives",
-          "tableTo": "ministries",
-          "columnsFrom": ["ministry_id"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
         "government_representatives_created_by_users_id_fk": {
           "name": "government_representatives_created_by_users_id_fk",
           "tableFrom": "government_representatives",

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776123239799,
       "tag": "0001_20260413_history_pagination",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776799779124,
+      "tag": "0003_20260421_ministry_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1776799779124,
       "tag": "0003_20260421_ministry_groups",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776806000698,
+      "tag": "0004_20260421_ministry_groups",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776806192548,
+      "tag": "0005_20260421_ministry_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -26,22 +26,8 @@
     {
       "idx": 3,
       "version": "7",
-      "when": 1776799779124,
+      "when": 1776812701961,
       "tag": "0003_20260421_ministry_groups",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1776806000698,
-      "tag": "0004_20260421_ministry_groups",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1776806192548,
-      "tag": "0005_20260421_ministry_groups",
       "breakpoints": true
     }
   ]

--- a/packages/database/seeds/0000_20260127_roles_seed.sql
+++ b/packages/database/seeds/0000_20260127_roles_seed.sql
@@ -22,6 +22,3 @@ ON CONFLICT (id) DO UPDATE SET
   description = EXCLUDED.description,
   is_system = EXCLUDED.is_system,
   is_active = EXCLUDED.is_active;
-
--- Reset sequence to prevent conflicts when inserting new records
-SELECT setval('roles_id_seq', COALESCE((SELECT MAX(id) FROM roles), 1), true);

--- a/packages/database/seeds/0001_20260313_lookups_seed_data.sql
+++ b/packages/database/seeds/0001_20260313_lookups_seed_data.sql
@@ -3,6 +3,9 @@
 -- Based on the current schema definitions
 -- Run this after applying the base migration (0000_20250121_initial_tables.sql)
 --
+-- Serial sequences for explicit-id inserts are reset once at end of pipeline:
+-- packages/database/seeds/9999_20260423_sync_serial_sequences_seed.sql
+--
 -- IMPORTANT: Users must be seeded first as other tables reference them
 -- via created_by and last_updated_by foreign keys
 
@@ -695,71 +698,6 @@ INSERT INTO reports (id, name, display_name, sort_order, is_active, visibility, 
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================================
--- UPDATE SEQUENCES
--- Reset sequences to prevent conflicts when inserting new records
--- This ensures that after seeding with explicit IDs, the sequences are
--- synchronized to the maximum ID value, preventing primary key conflicts
--- when new records are inserted via application code.
--- ============================================================================
-
--- Activity statuses sequence
-SELECT setval('activity_statuses_id_seq', COALESCE((SELECT MAX(id) FROM activity_statuses), 1), true);
-
--- Pitch statuses sequence
-SELECT setval('pitch_statuses_id_seq', COALESCE((SELECT MAX(id) FROM pitch_statuses), 1), true);
-
--- Date statuses sequence
-SELECT setval('date_statuses_id_seq', COALESCE((SELECT MAX(id) FROM date_statuses), 1), true);
-
--- Time statuses sequence
-SELECT setval('time_statuses_id_seq', COALESCE((SELECT MAX(id) FROM time_statuses), 1), true);
-
--- Venue statuses sequence
-SELECT setval('venue_statuses_id_seq', COALESCE((SELECT MAX(id) FROM venue_statuses), 1), true);
-
--- Users sequence
-SELECT setval('users_id_seq', COALESCE((SELECT MAX(id) FROM users), 1), true);
-
--- Categories sequence
-SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1), true);
-
--- Comms materials sequence
-SELECT setval('comms_materials_id_seq', COALESCE((SELECT MAX(id) FROM comms_materials), 1), true);
-
--- Translated languages sequence
-SELECT setval('translated_languages_id_seq', COALESCE((SELECT MAX(id) FROM translated_languages), 1), true);
-
--- Cities sequence
-SELECT setval('cities_id_seq', COALESCE((SELECT MAX(id) FROM cities), 1), true);
-
--- Government representatives sequence
-SELECT setval('government_representatives_id_seq', COALESCE((SELECT MAX(id) FROM government_representatives), 1), true);
-
--- Tags sequence
-SELECT setval('tags_id_seq', COALESCE((SELECT MAX(id) FROM tags), 1), true);
-
--- Comms contacts sequence
-SELECT setval('comms_contacts_id_seq', COALESCE((SELECT MAX(id) FROM comms_contacts), 1), true);
-
--- Event planners sequence
-SELECT setval('event_planners_id_seq', COALESCE((SELECT MAX(id) FROM event_planners), 1), true);
-
--- News release origins sequence
-SELECT setval('news_release_origins_id_seq', COALESCE((SELECT MAX(id) FROM news_release_origins), 1), true);
-
--- News release distributions sequence
-SELECT setval('news_release_distributions_id_seq', COALESCE((SELECT MAX(id) FROM news_release_distributions), 1), true);
-
--- Premier requested sequence
-SELECT setval('premier_requested_id_seq', COALESCE((SELECT MAX(id) FROM premier_requested), 1), true);
-
--- Reports sequence
-SELECT setval('reports_id_seq', COALESCE((SELECT MAX(id) FROM reports), 1), true);
-
--- Teams sequence
-SELECT setval('teams_id_seq', COALESCE((SELECT MAX(id) FROM teams), 1), true);
-
--- ============================================================================
 -- VENUE PRESETS
 -- Admin-defined named venues for the activity form.
 -- Pinned presets appear as quick-select badges beneath the Venue Name input.
@@ -772,6 +710,3 @@ SELECT * FROM (VALUES
   ('Government House', '1401 Rockland Ave', 'Victoria', 'British Columbia', 'Canada', 3, true, true, 3, 1, 1)
 ) AS v(venue_name, address_line1, city, province_or_state, country, sort_order, is_active, is_pinned, pinned_sort_order, created_by, last_updated_by)
 WHERE NOT EXISTS (SELECT 1 FROM venue_presets LIMIT 1);
-
--- Venue presets sequence
-SELECT setval('venue_presets_id_seq', COALESCE((SELECT MAX(id) FROM venue_presets), 1), true);

--- a/packages/database/seeds/0001_20260313_lookups_seed_data.sql
+++ b/packages/database/seeds/0001_20260313_lookups_seed_data.sql
@@ -393,55 +393,79 @@ ON CONFLICT (id) DO NOTHING;
 -- Representatives for activities
 -- ============================================================================
 
--- PREMIER
-INSERT INTO government_representatives (id, name, display_name, sort_order, is_active, title, ministry_id, representative_type, created_by, last_updated_by) VALUES
-  (1000, 'David Eby', 'Premier David Eby', 1, true, 'Premier of British Columbia', 1, 'premier', 1, 1)
+-- PREMIER (portfolio link is ministries.minister_government_rep_id, not on this row)
+INSERT INTO government_representatives (id, name, display_name, sort_order, is_active, title, representative_type, created_by, last_updated_by) VALUES
+  (1000, 'David Eby', 'Premier David Eby', 1, true, 'Premier of British Columbia', 'premier', 1, 1)
 ON CONFLICT (id) DO UPDATE
   SET name = EXCLUDED.name,
       display_name = EXCLUDED.display_name,
       sort_order = EXCLUDED.sort_order,
       is_active = EXCLUDED.is_active,
       title = EXCLUDED.title,
-      ministry_id = EXCLUDED.ministry_id,
       representative_type = EXCLUDED.representative_type,
       created_by = EXCLUDED.created_by,
       last_updated_by = EXCLUDED.last_updated_by;
 
 -- MINISTERS
-INSERT INTO government_representatives (id, name, display_name, sort_order, is_active, title, ministry_id, representative_type, created_by, last_updated_by) VALUES
-  (2002, 'Lana Popham', 'Minister Lana Popham', 2, true, 'Minister of Agriculture and Food', 2, 'minister', 1, 1),
-  (2003, 'Niki Sharma', 'Attorney General Niki Sharma', 3, true, 'Attorney General and Deputy Premier', 3, 'minister', 1, 1),
-  (2004, 'Jodie Wickens', 'Minister Jodie Wickens', 4, true, 'Minister of Children and Family Development', 4, 'minister', 1, 1),
-  (2005, 'Diana Gibson', 'Minister Diana Gibson', 5, true, 'Minister of Citizens'' Services', 5, 'minister', 1, 1),
-  (2006, 'Lisa Beare', 'Minister Lisa Beare', 6, true, 'Minister of Education and Child Care', 6, 'minister', 1, 1),
-  (2007, 'Kelly Greene', 'Minister Kelly Greene', 7, true, 'Minister of Emergency Management and Climate Readiness', 7, 'minister', 1, 1),
-  (2008, 'Adrian Dix', 'Minister Adrian Dix', 8, true, 'Minister of Energy and Climate Solutions', 8, 'minister', 1, 1),
-  (2009, 'Tamara Davidson', 'Minister Tamara Davidson', 9, true, 'Minister of Environment and Parks', 9, 'minister', 1, 1),
-  (2010, 'Brenda Bailey', 'Minister Brenda Bailey', 10, true, 'Minister of Finance', 10, 'minister', 1, 1),
-  (2011, 'Ravi Parmar', 'Minister Ravi Parmar', 11, true, 'Minister of Forests', 11, 'minister', 1, 1),
-  (2012, 'Josie Osborne', 'Minister Josie Osborne', 12, true, 'Minister of Health', 12, 'minister', 1, 1),
-  (2013, 'Christine Boyle', 'Minister Christine Boyle', 13, true, 'Minister of Housing and Municipal Affairs', 13, 'minister', 1, 1),
-  (2014, 'Spencer Chandra Herbert', 'Minister Spencer Chandra Herbert', 14, true, 'Minister of Indigenous Relations and Reconciliation', 14, 'minister', 1, 1),
-  (2015, 'Bowinn Ma', 'Minister Bowinn Ma', 15, true, 'Minister of Infrastructure', 15, 'minister', 1, 1),
-  (2017, 'Ravi Kahlon', 'Minister Ravi Kahlon', 17, true, 'Minister of Jobs and Economic Growth', 17, 'minister', 1, 1),
-  (2018, 'Jennifer Whiteside', 'Minister Jennifer Whiteside', 18, true, 'Minister of Labour', 18, 'minister', 1, 1),
-  (2019, 'Jagrup Brar', 'Minister Jagrup Brar', 19, true, 'Minister of Mining and Critical Minerals', 19, 'minister', 1, 1),
-  (2020, 'Jessie Sunner', 'Minister Jessie Sunner', 20, true, 'Minister of Post-Secondary Education and Future Skills', 20, 'minister', 1, 1),
-  (2021, 'Nina Krieger', 'Minister Nina Krieger', 21, true, 'Minister of Public Safety and Solicitor General', 21, 'minister', 1, 1),
-  (2022, 'Sheila Malcolmson', 'Minister Sheila Malcolmson', 22, true, 'Minister of Social Development and Poverty Reduction', 22, 'minister', 1, 1),
-  (2023, 'Anne Kang', 'Minister Anne Kang', 23, true, 'Minister of Tourism, Arts, Culture and Sport', 23, 'minister', 1, 1),
-  (2024, 'Mike Farnworth', 'Minister Mike Farnworth', 24, true, 'Minister of Transportation and Transit', 24, 'minister', 1, 1),
-  (2025, 'Randene Neill', 'Minister Randene Neill', 25, true, 'Minister of Water, Land and Resource Stewardship', 25, 'minister', 1, 1)
+INSERT INTO government_representatives (id, name, display_name, sort_order, is_active, title, representative_type, created_by, last_updated_by) VALUES
+  (2002, 'Lana Popham', 'Minister Lana Popham', 2, true, 'Minister of Agriculture and Food', 'minister', 1, 1),
+  (2003, 'Niki Sharma', 'Attorney General Niki Sharma', 3, true, 'Attorney General and Deputy Premier', 'minister', 1, 1),
+  (2004, 'Jodie Wickens', 'Minister Jodie Wickens', 4, true, 'Minister of Children and Family Development', 'minister', 1, 1),
+  (2005, 'Diana Gibson', 'Minister Diana Gibson', 5, true, 'Minister of Citizens'' Services', 'minister', 1, 1),
+  (2006, 'Lisa Beare', 'Minister Lisa Beare', 6, true, 'Minister of Education and Child Care', 'minister', 1, 1),
+  (2007, 'Kelly Greene', 'Minister Kelly Greene', 7, true, 'Minister of Emergency Management and Climate Readiness', 'minister', 1, 1),
+  (2008, 'Adrian Dix', 'Minister Adrian Dix', 8, true, 'Minister of Energy and Climate Solutions', 'minister', 1, 1),
+  (2009, 'Tamara Davidson', 'Minister Tamara Davidson', 9, true, 'Minister of Environment and Parks', 'minister', 1, 1),
+  (2010, 'Brenda Bailey', 'Minister Brenda Bailey', 10, true, 'Minister of Finance', 'minister', 1, 1),
+  (2011, 'Ravi Parmar', 'Minister Ravi Parmar', 11, true, 'Minister of Forests', 'minister', 1, 1),
+  (2012, 'Josie Osborne', 'Minister Josie Osborne', 12, true, 'Minister of Health', 'minister', 1, 1),
+  (2013, 'Christine Boyle', 'Minister Christine Boyle', 13, true, 'Minister of Housing and Municipal Affairs', 'minister', 1, 1),
+  (2014, 'Spencer Chandra Herbert', 'Minister Spencer Chandra Herbert', 14, true, 'Minister of Indigenous Relations and Reconciliation', 'minister', 1, 1),
+  (2015, 'Bowinn Ma', 'Minister Bowinn Ma', 15, true, 'Minister of Infrastructure', 'minister', 1, 1),
+  (2017, 'Ravi Kahlon', 'Minister Ravi Kahlon', 17, true, 'Minister of Jobs and Economic Growth', 'minister', 1, 1),
+  (2018, 'Jennifer Whiteside', 'Minister Jennifer Whiteside', 18, true, 'Minister of Labour', 'minister', 1, 1),
+  (2019, 'Jagrup Brar', 'Minister Jagrup Brar', 19, true, 'Minister of Mining and Critical Minerals', 'minister', 1, 1),
+  (2020, 'Jessie Sunner', 'Minister Jessie Sunner', 20, true, 'Minister of Post-Secondary Education and Future Skills', 'minister', 1, 1),
+  (2021, 'Nina Krieger', 'Minister Nina Krieger', 21, true, 'Minister of Public Safety and Solicitor General', 'minister', 1, 1),
+  (2022, 'Sheila Malcolmson', 'Minister Sheila Malcolmson', 22, true, 'Minister of Social Development and Poverty Reduction', 'minister', 1, 1),
+  (2023, 'Anne Kang', 'Minister Anne Kang', 23, true, 'Minister of Tourism, Arts, Culture and Sport', 'minister', 1, 1),
+  (2024, 'Mike Farnworth', 'Minister Mike Farnworth', 24, true, 'Minister of Transportation and Transit', 'minister', 1, 1),
+  (2025, 'Randene Neill', 'Minister Randene Neill', 25, true, 'Minister of Water, Land and Resource Stewardship', 'minister', 1, 1)
 ON CONFLICT (id) DO UPDATE
   SET name = EXCLUDED.name,
       display_name = EXCLUDED.display_name,
       sort_order = EXCLUDED.sort_order,
       is_active = EXCLUDED.is_active,
       title = EXCLUDED.title,
-      ministry_id = EXCLUDED.ministry_id,
       representative_type = EXCLUDED.representative_type,
       created_by = EXCLUDED.created_by,
       last_updated_by = EXCLUDED.last_updated_by;
+
+-- Designated minister per ministry (source of truth on ministries row)
+UPDATE ministries SET minister_government_rep_id = 1000 WHERE id = 1;
+UPDATE ministries SET minister_government_rep_id = 2002 WHERE id = 2;
+UPDATE ministries SET minister_government_rep_id = 2003 WHERE id = 3;
+UPDATE ministries SET minister_government_rep_id = 2004 WHERE id = 4;
+UPDATE ministries SET minister_government_rep_id = 2005 WHERE id = 5;
+UPDATE ministries SET minister_government_rep_id = 2006 WHERE id = 6;
+UPDATE ministries SET minister_government_rep_id = 2007 WHERE id = 7;
+UPDATE ministries SET minister_government_rep_id = 2008 WHERE id = 8;
+UPDATE ministries SET minister_government_rep_id = 2009 WHERE id = 9;
+UPDATE ministries SET minister_government_rep_id = 2010 WHERE id = 10;
+UPDATE ministries SET minister_government_rep_id = 2011 WHERE id = 11;
+UPDATE ministries SET minister_government_rep_id = 2012 WHERE id = 12;
+UPDATE ministries SET minister_government_rep_id = 2013 WHERE id = 13;
+UPDATE ministries SET minister_government_rep_id = 2014 WHERE id = 14;
+UPDATE ministries SET minister_government_rep_id = 2015 WHERE id = 15;
+UPDATE ministries SET minister_government_rep_id = 2017 WHERE id = 17;
+UPDATE ministries SET minister_government_rep_id = 2018 WHERE id = 18;
+UPDATE ministries SET minister_government_rep_id = 2019 WHERE id = 19;
+UPDATE ministries SET minister_government_rep_id = 2020 WHERE id = 20;
+UPDATE ministries SET minister_government_rep_id = 2021 WHERE id = 21;
+UPDATE ministries SET minister_government_rep_id = 2022 WHERE id = 22;
+UPDATE ministries SET minister_government_rep_id = 2023 WHERE id = 23;
+UPDATE ministries SET minister_government_rep_id = 2024 WHERE id = 24;
+UPDATE ministries SET minister_government_rep_id = 2025 WHERE id = 25;
 
 -- -- ============================================================================
 -- -- TAGS

--- a/packages/database/seeds/0003_20260313_teams_users_seed.sql
+++ b/packages/database/seeds/0003_20260313_teams_users_seed.sql
@@ -52,9 +52,6 @@ INSERT INTO teams (id, name, display_name, description, sort_order, is_active, c
   (36, 'EAO', 'EAO', 'Environmental Assessment Office', 36, true, 1, 1)
 ON CONFLICT (id) DO NOTHING;
 
--- Reset sequence so future inserts get ids > 36
-SELECT setval('teams_id_seq', COALESCE((SELECT MAX(id) FROM teams), 1), true);
-
 -- ----------------------------------------------------------------------------
 -- TEAM_CATEGORIES
 -- Links team-scoped categories (categories.visibility = team) to teams.

--- a/packages/database/seeds/0004_20260313_activities_seed_data.sql
+++ b/packages/database/seeds/0004_20260313_activities_seed_data.sql
@@ -2260,11 +2260,3 @@ INSERT INTO activity_comms_contacts (activity_id, user_id, is_lead, is_active, t
   (100, 7, true, true, now()),
   (100, 29, false, true, now())
 ON CONFLICT (activity_id, user_id) DO NOTHING;
-
--- ============================================================================
--- UPDATE SEQUENCES
--- ============================================================================
-
-SELECT setval('activities_id_seq', COALESCE((SELECT MAX(id) FROM activities), 1), true);
-SELECT setval('activity_representatives_id_seq', COALESCE((SELECT MAX(id) FROM activity_representatives), 1), true);
-SELECT setval('venue_addresses_id_seq', COALESCE((SELECT MAX(id) FROM venue_addresses), 1), true);

--- a/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
+++ b/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
@@ -1,0 +1,28 @@
+-- Ministry groups for activity "Shared with teams" shortcuts (depends on users id=999; see 0008 completion permission seed / CALENDAR_SYSTEM_USER_ID)
+-- Social: CITZ, AG, MCFD, ECC, HLTH, IRR, PSFS, PSSG, SDPR, TACS
+-- Resource: AF, EMCR, ECS, ENV, FOR, MIN, WLRS
+-- Economical: FIN, HMA, INF, JEG, LRB, MOTT
+
+INSERT INTO ministry_groups (id, name, sort_order, created_by, last_updated_by)
+VALUES
+  (1, 'Social', 0, 999, 999),
+  (2, 'Resource', 1, 999, 999),
+  (3, 'Economical', 2, 999, 999)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval(
+  'ministry_groups_id_seq',
+  COALESCE((SELECT MAX(id) FROM ministry_groups), 1)
+);
+
+UPDATE ministries SET ministry_group_id = 1 WHERE id IN (
+  5, 3, 4, 6, 12, 14, 20, 21, 22, 23
+);
+
+UPDATE ministries SET ministry_group_id = 2 WHERE id IN (
+  2, 7, 8, 9, 11, 19, 25
+);
+
+UPDATE ministries SET ministry_group_id = 3 WHERE id IN (
+  10, 13, 15, 17, 18, 24
+);

--- a/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
+++ b/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
@@ -10,11 +10,6 @@ VALUES
   (3, 'Economical', 2, 999, 999)
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval(
-  'ministry_groups_id_seq',
-  COALESCE((SELECT MAX(id) FROM ministry_groups), 1)
-);
-
 UPDATE ministries SET ministry_group_id = 1 WHERE id IN (
   5, 3, 4, 6, 12, 14, 20, 21, 22, 23
 );

--- a/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
+++ b/packages/database/seeds/0009_20260421_ministry_quick_share_seed.sql
@@ -7,7 +7,7 @@ INSERT INTO ministry_groups (id, name, sort_order, created_by, last_updated_by)
 VALUES
   (1, 'Social', 0, 999, 999),
   (2, 'Resource', 1, 999, 999),
-  (3, 'Economical', 2, 999, 999)
+  (3, 'Economic', 2, 999, 999)
 ON CONFLICT (id) DO NOTHING;
 
 UPDATE ministries SET ministry_group_id = 1 WHERE id IN (

--- a/packages/database/seeds/9999_20260423_sync_serial_sequences_seed.sql
+++ b/packages/database/seeds/9999_20260423_sync_serial_sequences_seed.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- SYNC SERIAL SEQUENCES (run last in pipeline)
+-- Seed files use explicit integer ids for many lookup rows; PostgreSQL does not
+-- advance serial sequences for those inserts. This script resets every affected
+-- sequence to MAX(id) so application INSERTs using DEFAULT get unique PKs.
+--
+-- Prefix 9999_ so this file sorts after any future ####_*_seed*.sql (0000–9998).
+-- Safe to re-run: idempotent relative to current MAX(id) per table.
+-- ============================================================================
+
+SELECT setval('activities_id_seq', COALESCE((SELECT MAX(id) FROM activities), 1), true);
+SELECT setval('activity_history_id_seq', COALESCE((SELECT MAX(id) FROM activity_history), 1), true);
+SELECT setval('activity_representatives_id_seq', COALESCE((SELECT MAX(id) FROM activity_representatives), 1), true);
+SELECT setval('activity_statuses_id_seq', COALESCE((SELECT MAX(id) FROM activity_statuses), 1), true);
+SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1), true);
+SELECT setval('cities_id_seq', COALESCE((SELECT MAX(id) FROM cities), 1), true);
+SELECT setval('comms_contacts_id_seq', COALESCE((SELECT MAX(id) FROM comms_contacts), 1), true);
+SELECT setval('comms_materials_id_seq', COALESCE((SELECT MAX(id) FROM comms_materials), 1), true);
+SELECT setval('date_statuses_id_seq', COALESCE((SELECT MAX(id) FROM date_statuses), 1), true);
+SELECT setval('event_planners_id_seq', COALESCE((SELECT MAX(id) FROM event_planners), 1), true);
+SELECT setval('government_representatives_id_seq', COALESCE((SELECT MAX(id) FROM government_representatives), 1), true);
+SELECT setval('ministries_id_seq', COALESCE((SELECT MAX(id) FROM ministries), 1), true);
+SELECT setval('ministry_groups_id_seq', COALESCE((SELECT MAX(id) FROM ministry_groups), 1), true);
+SELECT setval('news_release_distributions_id_seq', COALESCE((SELECT MAX(id) FROM news_release_distributions), 1), true);
+SELECT setval('news_release_origins_id_seq', COALESCE((SELECT MAX(id) FROM news_release_origins), 1), true);
+SELECT setval('organizations_id_seq', COALESCE((SELECT MAX(id) FROM organizations), 1), true);
+SELECT setval('permissions_id_seq', COALESCE((SELECT MAX(id) FROM permissions), 1), true);
+SELECT setval('pitch_required_statuses_id_seq', COALESCE((SELECT MAX(id) FROM pitch_required_statuses), 1), true);
+SELECT setval('pitch_statuses_id_seq', COALESCE((SELECT MAX(id) FROM pitch_statuses), 1), true);
+SELECT setval('premier_requested_id_seq', COALESCE((SELECT MAX(id) FROM premier_requested), 1), true);
+SELECT setval('reports_id_seq', COALESCE((SELECT MAX(id) FROM reports), 1), true);
+SELECT setval('roles_id_seq', COALESCE((SELECT MAX(id) FROM roles), 1), true);
+-- sectors: UUID PK (gen_random_uuid), no serial sequence — omit setval
+SELECT setval('tags_id_seq', COALESCE((SELECT MAX(id) FROM tags), 1), true);
+SELECT setval('team_history_id_seq', COALESCE((SELECT MAX(id) FROM team_history), 1), true);
+SELECT setval('teams_id_seq', COALESCE((SELECT MAX(id) FROM teams), 1), true);
+SELECT setval('themes_id_seq', COALESCE((SELECT MAX(id) FROM themes), 1), true);
+SELECT setval('time_statuses_id_seq', COALESCE((SELECT MAX(id) FROM time_statuses), 1), true);
+SELECT setval('translation_required_statuses_id_seq', COALESCE((SELECT MAX(id) FROM translation_required_statuses), 1), true);
+SELECT setval('translated_languages_id_seq', COALESCE((SELECT MAX(id) FROM translated_languages), 1), true);
+SELECT setval('user_history_id_seq', COALESCE((SELECT MAX(id) FROM user_history), 1), true);
+SELECT setval('users_id_seq', COALESCE((SELECT MAX(id) FROM users), 1), true);
+SELECT setval('venue_addresses_id_seq', COALESCE((SELECT MAX(id) FROM venue_addresses), 1), true);
+SELECT setval('venue_presets_id_seq', COALESCE((SELECT MAX(id) FROM venue_presets), 1), true);
+SELECT setval('venue_statuses_id_seq', COALESCE((SELECT MAX(id) FROM venue_statuses), 1), true);

--- a/packages/database/src/schema/docs/SCHEMA_MAPPING.md
+++ b/packages/database/src/schema/docs/SCHEMA_MAPPING.md
@@ -51,6 +51,7 @@ Lookup tables use a consistent shape for type safety and generic UI components:
 12. [UserTeams](#userteams)
 13. [Venue addresses](#venue-addresses)
 14. [Venue Presets](#venue-presets)
+15. [Ministries and government representatives](#ministries-and-government-representatives)
 
 ---
 
@@ -487,6 +488,19 @@ Pods use an explicit visibility model with three levels: 'global', 'team', and '
 | New Field Name      | New Type  | New Constraints                                         | Description             |
 | ------------------- | --------- | ------------------------------------------------------- | ----------------------- |
 | `ministry_group_id` | `integer` | nullable, FK to `ministry_groups`, `ON DELETE SET NULL` | Optional shortcut group |
+
+---
+
+## Ministries and government representatives
+
+**Description:** A ministry’s **designated minister** (or premier for the Office of the Premier) is stored only on the ministry row: `ministries.minister_government_rep_id` → `government_representatives.id` (`ON DELETE SET NULL`). The `government_representatives` table **does not** have a `ministry_id` column; that relationship was removed in favor of this single source of truth. Admin UX assigns the minister from **Settings → Ministries**; when `minister_government_rep_id` is set, the lookups service clears the same representative from any **other** ministry that previously pointed at it.
+
+| Table / field                             | Notes                                                                                                                                                                            |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ministries.minister_government_rep_id`   | Nullable FK to `government_representatives.id`. Display name for the minister in lists comes from a join on that representative.                                                 |
+| `ministries.minister_name`                | **Removed** (replaced by the representative row + join).                                                                                                                         |
+| `government_representatives.ministry_id`  | **Removed**. Portfolio link exists only on `ministries`.                                                                                                                         |
+| GET `/lookups/government-representatives` | May include a derived **`ministryId`** on each item: the ministry whose `minister_government_rep_id` equals that representative’s `id`, if any (left join). Not a stored column. |
 
 ---
 

--- a/packages/database/src/schema/docs/SCHEMA_MAPPING.md
+++ b/packages/database/src/schema/docs/SCHEMA_MAPPING.md
@@ -466,6 +466,30 @@ Pods use an explicit visibility model with three levels: 'global', 'team', and '
 
 ---
 
+## Ministry groups
+
+**Legacy Table Name:** _N/A_  
+**New Table Name:** `ministry_groups`
+
+**Description:** Named groups used as shortcuts in the activity form (“Shared with teams”). Each ministry may optionally belong to one group via `ministries.ministry_group_id` (`ON DELETE SET NULL`). The UI resolves a group to team IDs via `teams.ministry_id`. Separate from `pods`.
+
+### `ministry_groups`
+
+| New Field Name | New Type       | New Constraints      | Description                                 |
+| -------------- | -------------- | -------------------- | ------------------------------------------- |
+| `id`           | `serial`       | primary key          |                                             |
+| `name`         | `varchar(200)` | `notNull`            | Group label (e.g. Social, Resource)         |
+| `sort_order`   | `integer`      | `notNull`, default 0 | Display order                               |
+| Audit columns  |                |                      | `created_by`, `last_updated_by`, timestamps |
+
+### `ministries.ministry_group_id`
+
+| New Field Name      | New Type  | New Constraints                                         | Description             |
+| ------------------- | --------- | ------------------------------------------------------- | ----------------------- |
+| `ministry_group_id` | `integer` | nullable, FK to `ministry_groups`, `ON DELETE SET NULL` | Optional shortcut group |
+
+---
+
 ## Reports
 
 **Legacy Table Name:** _N/A (New table)_  

--- a/packages/database/src/schema/docs/SCHEMA_USAGE.md
+++ b/packages/database/src/schema/docs/SCHEMA_USAGE.md
@@ -1,6 +1,6 @@
 # Schema Usage Guide
 
-This document provides detailed usage information, examples, and behavioral patterns for the new database schema. For field mappings and structural information, see [SCHEMA_MAPPING.md](./SCHEMA_MAPPING.md).
+This document provides detailed usage information, examples, and behavioral patterns for the new database schema. For field mappings and structural information, see [SCHEMA_MAPPING.md](./SCHEMA_MAPPING.md). For how a ministry’s designated minister is stored (ministry row → government representative, no `ministry_id` on the rep), see [Ministries and government representatives](./SCHEMA_MAPPING.md#ministries-and-government-representatives).
 
 ## Table of Contents
 

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -5,6 +5,7 @@ export * from './user';
 export * from './userHistory';
 export * from './teamHistory';
 export * from './ministry';
+export * from './ministry-groups';
 export * from './organizations';
 export * from './lookups';
 export * from './relations';

--- a/packages/database/src/schema/lookups.ts
+++ b/packages/database/src/schema/lookups.ts
@@ -270,7 +270,6 @@ export const governmentRepresentatives = pgTable('government_representatives', {
   sortOrder: integer('sort_order').notNull().default(0),
   isActive: boolean('is_active').notNull().default(true),
   title: varchar('title', { length: 255 }),
-  ministryId: integer('ministry_id').references(() => ministries.id), // Nullable FK - links ministers to ministries
   representativeType: varchar('representative_type', { length: 50 }), // 'premier', 'minister', 'cabinet_member', 'mla', 'other'
   createdDateTime: timestamp('created_date_time', { withTimezone: true })
     .notNull()
@@ -681,9 +680,10 @@ export const reports = pgTable('reports', {
 export const governmentRepresentativesRelations = relations(
   governmentRepresentatives,
   ({ one }) => ({
-    ministry: one(ministries, {
-      fields: [governmentRepresentatives.ministryId],
-      references: [ministries.id],
+    /** Ministry that designates this rep as its minister (via ministries.minister_government_rep_id). */
+    ministryAsPortfolio: one(ministries, {
+      fields: [governmentRepresentatives.id],
+      references: [ministries.ministerGovernmentRepId],
     }),
   })
 );

--- a/packages/database/src/schema/ministry-groups.ts
+++ b/packages/database/src/schema/ministry-groups.ts
@@ -1,0 +1,33 @@
+import {
+  integer,
+  pgTable,
+  serial,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { users } from './user';
+
+/**
+ * Named groups for activity "Shared with teams" shortcuts (e.g. Social, Resource).
+ * Ministries optionally reference one group via ministries.ministry_group_id.
+ */
+export const ministryGroups = pgTable('ministry_groups', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 200 }).notNull(),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdDateTime: timestamp('created_date_time', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  createdBy: integer('created_by')
+    .notNull()
+    .references(() => users.id),
+  lastUpdatedDateTime: timestamp('last_updated_date_time', {
+    withTimezone: true,
+  })
+    .notNull()
+    .defaultNow(),
+  lastUpdatedBy: integer('last_updated_by')
+    .notNull()
+    .references(() => users.id),
+});

--- a/packages/database/src/schema/ministry-groups.ts
+++ b/packages/database/src/schema/ministry-groups.ts
@@ -1,8 +1,10 @@
+import { sql } from 'drizzle-orm';
 import {
   integer,
   pgTable,
   serial,
   timestamp,
+  uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
 
@@ -11,23 +13,34 @@ import { users } from './user';
 /**
  * Named groups for activity "Shared with teams" shortcuts (e.g. Social, Resource).
  * Ministries optionally reference one group via ministries.ministry_group_id.
+ * There is no is_active flag: retiring a group is done by deleting it (ministries
+ * are cleared via ON DELETE SET NULL) or by reassigning ministries first.
+ * Display names are unique case-insensitively (see unique index on lower(name)).
  */
-export const ministryGroups = pgTable('ministry_groups', {
-  id: serial('id').primaryKey(),
-  name: varchar('name', { length: 200 }).notNull(),
-  sortOrder: integer('sort_order').notNull().default(0),
-  createdDateTime: timestamp('created_date_time', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  createdBy: integer('created_by')
-    .notNull()
-    .references(() => users.id),
-  lastUpdatedDateTime: timestamp('last_updated_date_time', {
-    withTimezone: true,
+export const ministryGroups = pgTable(
+  'ministry_groups',
+  {
+    id: serial('id').primaryKey(),
+    name: varchar('name', { length: 200 }).notNull(),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdDateTime: timestamp('created_date_time', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdBy: integer('created_by')
+      .notNull()
+      .references(() => users.id),
+    lastUpdatedDateTime: timestamp('last_updated_date_time', {
+      withTimezone: true,
+    })
+      .notNull()
+      .defaultNow(),
+    lastUpdatedBy: integer('last_updated_by')
+      .notNull()
+      .references(() => users.id),
+  },
+  (table) => ({
+    nameLowerUnique: uniqueIndex('ministry_groups_name_lower_unique').on(
+      sql`lower(${table.name})`
+    ),
   })
-    .notNull()
-    .defaultNow(),
-  lastUpdatedBy: integer('last_updated_by')
-    .notNull()
-    .references(() => users.id),
-});
+);

--- a/packages/database/src/schema/ministry.ts
+++ b/packages/database/src/schema/ministry.ts
@@ -31,8 +31,11 @@ export const ministries = pgTable('ministries', {
   displayName: varchar('display_name', { length: 255 }).notNull(),
   abbreviation: varchar('abbreviation', { length: 10 }).notNull(),
 
-  // Minister information
-  ministerName: varchar('minister_name', { length: 255 }),
+  /**
+   * Designated minister (government representative) for this ministry.
+   * FK to government_representatives.id is enforced in SQL migrations (avoids circular schema inference).
+   */
+  ministerGovernmentRepId: integer('minister_government_rep_id'),
 
   // Contacts
   contactUserId: integer('contact_user_id').references(() => users.id), // FK to User
@@ -76,10 +79,13 @@ export const ministriesRelations = relations(ministries, ({ one, many }) => ({
     fields: [ministries.ministryGroupId],
     references: [ministryGroups.id],
   }),
+  ministerRep: one(governmentRepresentatives, {
+    fields: [ministries.ministerGovernmentRepId],
+    references: [governmentRepresentatives.id],
+  }),
   children: many(ministries, { relationName: 'parent' }),
   activities: many(activities),
   ministryUsers: many(ministryUsers),
-  governmentRepresentatives: many(governmentRepresentatives),
   podMinistries: many(podMinistries, { relationName: 'ministryPodMinistries' }),
 }));
 

--- a/packages/database/src/schema/ministry.ts
+++ b/packages/database/src/schema/ministry.ts
@@ -11,6 +11,7 @@ import {
 
 import { activities } from './activity';
 import { governmentRepresentatives } from './lookups';
+import { ministryGroups } from './ministry-groups';
 import { ministryUsers } from './relations';
 import { teams } from './teams';
 import { users } from './user';
@@ -39,6 +40,11 @@ export const ministries = pgTable('ministries', {
     () => users.id
   ), // FK to User
 
+  ministryGroupId: integer('ministry_group_id').references(
+    () => ministryGroups.id,
+    { onDelete: 'set null' }
+  ),
+
   createdDateTime: timestamp('created_date_time', { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -66,12 +72,23 @@ export const ministriesRelations = relations(ministries, ({ one, many }) => ({
     references: [users.id],
     relationName: 'secondContactUser',
   }),
+  ministryGroup: one(ministryGroups, {
+    fields: [ministries.ministryGroupId],
+    references: [ministryGroups.id],
+  }),
   children: many(ministries, { relationName: 'parent' }),
   activities: many(activities),
   ministryUsers: many(ministryUsers),
   governmentRepresentatives: many(governmentRepresentatives),
   podMinistries: many(podMinistries, { relationName: 'ministryPodMinistries' }),
 }));
+
+export const ministryGroupsRelations = relations(
+  ministryGroups,
+  ({ many }) => ({
+    ministries: many(ministries),
+  })
+);
 
 /**
  * Pods table - Collections of ministries defined by users

--- a/packages/shared/scripts/validate-types.ts
+++ b/packages/shared/scripts/validate-types.ts
@@ -185,7 +185,6 @@ const _govRepResponseCheck: {
   displayName: GovernmentRepresentative['displayName'];
   isActive: GovernmentRepresentative['isActive'];
   title: GovernmentRepresentative['title'];
-  ministryId: GovernmentRepresentative['ministryId'];
 } = {} as never;
 
 // ============================================================================

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -51,6 +51,16 @@ export type {
   UpdateTeamBody,
 } from '../schemas/team.schema';
 
+// Ministry groups (activity "Shared with" shortcuts + group CRUD)
+export type {
+  ActivityTeamSharingResponse,
+  ActivityTeamSharingQuickShare,
+  MinistryQuickShareGroupResponse,
+  MinistryGroupResponse,
+  CreateMinistryGroupRequest,
+  UpdateMinistryGroupRequest,
+} from '../schemas/ministry-groups.schema';
+
 // Lookup types - re-exported from lookup schema
 export type {
   LookupItem,

--- a/packages/shared/src/constants/constants.ts
+++ b/packages/shared/src/constants/constants.ts
@@ -117,6 +117,13 @@ export const REFERENCE_LOOKUP_CACHE_MS = REFERENCE_LOOKUP_CACHE_SECONDS * 1000; 
 export const DYNAMIC_LOOKUP_CACHE_SECONDS = 300; // 5 minutes
 export const DYNAMIC_LOOKUP_CACHE_MS = DYNAMIC_LOOKUP_CACHE_SECONDS * 1000; // 300000 ms
 
+/**
+ * GET /lookups/activity-team-sharing (teams + ministry quick-share).
+ * Shorter than reference cache because quick-share data changes when admins edit groups
+ * or ministry assignments. Same duration as dynamic lookups.
+ */
+export const ACTIVITY_TEAM_SHARING_CACHE_SECONDS = DYNAMIC_LOOKUP_CACHE_SECONDS;
+
 // ============================================================================
 // Default Values Constants
 // ============================================================================

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -7,6 +7,7 @@ export * from './activity-junction.schema';
 export * from './banner.schema';
 export * from './history.schema';
 export * from './lookup.schema';
+export * from './ministry-groups.schema';
 export * from './report-config.schema';
 export * from './query-params.schema';
 export * from './saved-filter.schema';

--- a/packages/shared/src/schemas/lookup.schema.ts
+++ b/packages/shared/src/schemas/lookup.schema.ts
@@ -141,6 +141,7 @@ export const ministryResponseSchema = z.object({
   sortOrder: z.number().int(),
   isActive: z.boolean(),
   ministerName: z.string().nullable(),
+  ministryGroupId: z.number().int().nullable().optional(),
 });
 
 export const ministryLookupItemSchema = z.object({
@@ -150,6 +151,7 @@ export const ministryLookupItemSchema = z.object({
   name: z.string(),
   displayName: z.string(),
   abbreviation: z.string().nullable(),
+  ministryGroupId: z.number().int().nullable().optional(),
 });
 
 // ============================================
@@ -664,6 +666,7 @@ export const createMinistryRequestSchema = z.object({
   ministerName: z.string().max(255).nullable().optional(),
   sortOrder: z.number().int(),
   isActive: z.boolean().default(true).optional(),
+  ministryGroupId: z.number().int().nullable().optional(),
 });
 
 /**
@@ -676,6 +679,7 @@ export const updateMinistryRequestSchema = z.object({
   ministerName: z.string().max(255).nullable().optional(),
   sortOrder: z.number().int().optional(),
   isActive: z.boolean().optional(),
+  ministryGroupId: z.number().int().nullable().optional(),
 });
 
 /**

--- a/packages/shared/src/schemas/lookup.schema.ts
+++ b/packages/shared/src/schemas/lookup.schema.ts
@@ -140,7 +140,7 @@ export const ministryResponseSchema = z.object({
   abbreviation: z.string(),
   sortOrder: z.number().int(),
   isActive: z.boolean(),
-  ministerName: z.string().nullable(),
+  ministerGovernmentRepId: z.number().int().nullable(),
   ministryGroupId: z.number().int().nullable().optional(),
 });
 
@@ -151,6 +151,9 @@ export const ministryLookupItemSchema = z.object({
   name: z.string(),
   displayName: z.string(),
   abbreviation: z.string().nullable(),
+  ministerGovernmentRepId: z.number().int().nullable().optional(),
+  /** Joined from government_representatives when minister_government_rep_id is set */
+  ministerDisplayName: z.string().nullable().optional(),
   ministryGroupId: z.number().int().nullable().optional(),
 });
 
@@ -427,7 +430,6 @@ export const governmentRepresentativeResponseSchema = z.object({
   isActive: z.boolean(),
   title: z.string().nullable(),
   email: z.string().nullable(),
-  ministryId: z.number().int().nullable(),
   representativeType: z.enum(REPRESENTATIVE_TYPE).nullable(),
 });
 
@@ -436,7 +438,9 @@ export const governmentRepresentativeLookupItemSchema = lookupItemSchema.extend(
     name: z.string(),
     displayName: z.string(),
     title: z.string().nullable(),
-    ministryId: z.number().int().nullable(),
+    /** Derived: ministry id when this rep is that ministry’s designated minister */
+    ministryId: z.number().int().nullable().optional(),
+    representativeType: z.enum(REPRESENTATIVE_TYPE).nullable(),
   }
 );
 
@@ -663,7 +667,7 @@ export const createMinistryRequestSchema = z.object({
   name: z.string().min(1).max(255),
   displayName: z.string().min(1).max(255),
   abbreviation: z.string().min(1).max(10),
-  ministerName: z.string().max(255).nullable().optional(),
+  ministerGovernmentRepId: z.number().int().nullable().optional(),
   sortOrder: z.number().int(),
   isActive: z.boolean().default(true).optional(),
   ministryGroupId: z.number().int().nullable().optional(),
@@ -676,7 +680,7 @@ export const updateMinistryRequestSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   displayName: z.string().min(1).max(255).optional(),
   abbreviation: z.string().min(1).max(10).optional(),
-  ministerName: z.string().max(255).nullable().optional(),
+  ministerGovernmentRepId: z.number().int().nullable().optional(),
   sortOrder: z.number().int().optional(),
   isActive: z.boolean().optional(),
   ministryGroupId: z.number().int().nullable().optional(),
@@ -708,7 +712,6 @@ export const createGovernmentRepresentativeRequestSchema = z.object({
   title: z.string().max(255).nullable().optional(),
   sortOrder: z.number().int(),
   isActive: z.boolean().default(true).optional(),
-  ministryId: z.number().int().nullable().optional(),
   representativeType: z.enum(REPRESENTATIVE_TYPE).nullable().optional(),
 });
 

--- a/packages/shared/src/schemas/ministry-groups.schema.ts
+++ b/packages/shared/src/schemas/ministry-groups.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+import { teamListItemSchema } from './team.schema';
+
+/** One shortcut group returned to the activity form (ministry membership derived from ministries.ministry_group_id). */
+export const ministryQuickShareGroupResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  sortOrder: z.number().int(),
+  ministryIds: z.array(z.number().int()),
+});
+
+export type MinistryQuickShareGroupResponse = z.infer<
+  typeof ministryQuickShareGroupResponseSchema
+>;
+
+/** Groups for GET /lookups/activity-team-sharing (no set — single global list). */
+export const activityTeamSharingQuickShareSchema = z.object({
+  groups: z.array(ministryQuickShareGroupResponseSchema),
+});
+
+export type ActivityTeamSharingQuickShare = z.infer<
+  typeof activityTeamSharingQuickShareSchema
+>;
+
+export const activityTeamSharingResponseSchema = z.object({
+  teams: z.array(teamListItemSchema),
+  quickShare: activityTeamSharingQuickShareSchema.nullable(),
+});
+
+export type ActivityTeamSharingResponse = z.infer<
+  typeof activityTeamSharingResponseSchema
+>;
+
+/** Ministry group row for admin / lookups list */
+export const ministryGroupResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  sortOrder: z.number().int(),
+});
+
+export type MinistryGroupResponse = z.infer<typeof ministryGroupResponseSchema>;
+
+export const createMinistryGroupRequestSchema = z.object({
+  name: z.string().min(1).max(200),
+  sortOrder: z.number().int(),
+});
+
+export type CreateMinistryGroupRequest = z.infer<
+  typeof createMinistryGroupRequestSchema
+>;
+
+export const updateMinistryGroupRequestSchema =
+  createMinistryGroupRequestSchema.partial();
+
+export type UpdateMinistryGroupRequest = z.infer<
+  typeof updateMinistryGroupRequestSchema
+>;

--- a/packages/shared/src/utils/activity-field-labels.ts
+++ b/packages/shared/src/utils/activity-field-labels.ts
@@ -51,7 +51,7 @@ export const ACTIVITY_FIELD_LABELS: Partial<
   tagIds: 'Tags',
   commsMaterialIds: 'Comms materials',
   translationLanguageIds: 'Translation languages',
-  sharedWithTeamIds: 'Shared with teams',
+  sharedWithTeamIds: 'Share with',
   visibility: 'Visibility',
   notes: 'Notes',
   strategy: 'Strategy',


### PR DESCRIPTION
# PR: feat/CORPCAL-222-ministry-groups

## Summary

Introduces **ministry groups** as a first-class lookup: new `ministry_groups` table, optional `ministries.ministry_group_id`, and API/UI to manage groups and assign ministries. The activity form gains **quick-share shortcuts** that map each group to teams via ministry membership (teams with a matching `ministryId`), exposed through `GET /lookups/activity-team-sharing` together with the active teams list.

## Important

- Rebuild shared types if needed: `npm run build:packages`.
- **Database schema and migration** — run against every environment that applies migrations; **(dropped `ministries.minister_name`, dropped `government_representatives.ministry_id`, and FK changes)**
- After pulling: `npm run db:push -w packages/database` (or your standard migration command).
- Reseed as your process requires, e.g. `npm run seed -w calendar-service` if you rely on lookup seeds.

Ministry groups in the **Share with** field
<img width="719" height="407" alt="Screenshot 2026-04-22 at 12 09 06 PM" src="https://github.com/user-attachments/assets/93c8aa7b-63dd-43e5-b4ec-be2be5e01d5f" />

Admin UI for the groups
<img width="1580" height="384" alt="Screenshot 2026-04-22 at 12 09 22 PM" src="https://github.com/user-attachments/assets/7a60190b-0f70-4ce2-9bc3-a30d89d63354" />

## Changes

1. **Database:** add `ministry_groups`, `ministries.ministry_group_id` (FK `ON DELETE SET NULL`), Drizzle schema module, migration `0005_20260421_ministry_groups.sql`, snapshot/journal updates, and seed data for groups and ministry assignments.
   - Related doc updates in `SCHEMA_MAPPING.md` / `SCHEMA_USAGE.md` clarifying ministry groups vs legacy `pods`.

2. **Shared:** Zod schemas and API types for ministry groups, activity team sharing response (`teams` + nullable `quickShare`), and lookup request/response shapes.

3. **Calendar service:** `GET /lookups/activity-team-sharing`; CRUD for `/lookups/ministry-groups`; ministry create/update includes `ministryGroupId`; `getMinistries` returns `ministryGroupId`.

4. **Calendar UI:** activity sharing section loads combined team-sharing payload; quick-share rows per group; Settings and generic lookup admin for ministry groups; `MinistryAdminModalForm` for ministry create/edit (minister combobox, group select, etc.).

## Testing

- `npm run typecheck` (root) — passed.
- `npm run test --workspace calendar-service -- --run lookups.controller.spec` — passed.
- Manual: apply migration and seeds locally, confirm Settings ministry/ministry-group admin, activity form “Shared with” shortcuts and team selection, and that users without `lookups.manage` cannot mutate groups (smoke via API or UI).

## Future work

- **Ministry pods (`pods`, `pod_ministries`, `pod_shared_with_teams`):** review whether this legacy “pod” model is still required now that ministry groups and team-based sharing exist. If redundant, we can remove, migrate or drop data, remove schema and routes, and update docs (`SCHEMA_USAGE` pods sections) accordingly.
