### PR TITLE
Fix/corpcal 000 cache invalidation

### DIFF
--- a/calendar-service/src/lookups/cache-control.spec.ts
+++ b/calendar-service/src/lookups/cache-control.spec.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { lookupGetCacheControl } from './cache-control';
+
+describe('lookupGetCacheControl', () => {
+  let previousNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    previousNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  it('returns private, no-cache in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(lookupGetCacheControl()).toBe('private, no-cache');
+  });
+
+  it('returns no-store when NODE_ENV is not production', () => {
+    for (const env of ['development', 'test', 'staging'] as const) {
+      process.env.NODE_ENV = env;
+      expect(lookupGetCacheControl()).toBe('no-store');
+    }
+  });
+
+  it('returns no-store when NODE_ENV is unset', () => {
+    delete process.env.NODE_ENV;
+    expect(lookupGetCacheControl()).toBe('no-store');
+  });
+});

--- a/calendar-service/src/lookups/cache-control.ts
+++ b/calendar-service/src/lookups/cache-control.ts
@@ -1,0 +1,26 @@
+/**
+ * Cache-Control header helpers for authenticated lookup GET routes.
+ *
+ * The browser's HTTP cache and TanStack Query's in-memory cache overlap, and
+ * a long `public, max-age` on the HTTP layer will serve stale payloads after
+ * schema/seed changes (especially locally) regardless of what React Query does.
+ *
+ * We prefer a revalidation-first policy:
+ * - Non-production: `no-store` so local schema/seed changes are immediately
+ *   visible on refresh without clearing caches manually.
+ * - Production: `private, no-cache` so the browser may store the response for
+ *   a given user but must revalidate with the server before reuse. Paired with
+ *   the short React Query `staleTime` this keeps bandwidth low while avoiding
+ *   user-visible staleness.
+ *
+ * For endpoints that truly never change (e.g. translation languages) callers
+ * may still opt into a longer `max-age` by using a literal header instead of
+ * this helper.
+ */
+
+/** Cache-Control value for idempotent lookup GETs (authenticated, per-user). */
+export function lookupGetCacheControl(): string {
+  return process.env.NODE_ENV === 'production'
+    ? 'private, no-cache'
+    : 'no-store';
+}

--- a/calendar-service/src/lookups/lookups.controller.ts
+++ b/calendar-service/src/lookups/lookups.controller.ts
@@ -20,11 +20,7 @@ import {
 } from '@nestjs/swagger';
 import type { Response } from 'express';
 
-import {
-  DYNAMIC_LOOKUP_CACHE_SECONDS,
-  REFERENCE_LOOKUP_CACHE_SECONDS,
-  type AuthUser,
-} from '@corpcal/shared';
+import { DYNAMIC_LOOKUP_CACHE_SECONDS, type AuthUser } from '@corpcal/shared';
 import type {
   CategoryLookupItem,
   LookupItem,
@@ -92,6 +88,7 @@ import { ParseOptionalIntPipe } from '../common/pipes/parse-optional-int.pipe';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { parseCommaSeparatedIds } from '../common/utils/parse-query-ids';
 import { RequirePermission } from '../policy/decorators/require-permission.decorator';
+import { lookupGetCacheControl } from './cache-control';
 import { LookupsService } from './lookups.service';
 
 @ApiTags('lookups')
@@ -113,7 +110,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('categories')
-  @Header('Cache-Control', `private, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getCategories(@CurrentUser() user: AuthUser): Promise<{
     success: boolean;
     data: CategoryLookupItem[];
@@ -197,7 +194,7 @@ export class LookupsController {
     description: 'Filter to a specific organization by ID',
   })
   @Get('organizations')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getOrganizations(
     @Query('userId', new ParseOptionalIntPipe()) userId?: number,
     @Query('role') role?: string,
@@ -217,7 +214,7 @@ export class LookupsController {
     description: 'Roles retrieved successfully',
   })
   @Get('roles')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getRoles(): Promise<{
     success: boolean;
     data: { id: number; name: string; description: string | null }[];
@@ -262,7 +259,7 @@ export class LookupsController {
       'Comma-separated list of user IDs to filter by (e.g., "1,2,3")',
   })
   @Get('users')
-  @Header('Cache-Control', `public, max-age=${DYNAMIC_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getUsers(
     @Query('userId', new ParseOptionalIntPipe()) userId?: number,
     @Query('role') role?: string,
@@ -425,7 +422,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('activity-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getActivityStatuses(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -487,7 +484,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('pitch-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getPitchStatuses(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getPitchStatuses();
     return { success: true, data };
@@ -500,7 +497,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('comms-materials')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getCommsMaterials(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getCommsMaterials();
     return { success: true, data };
@@ -555,7 +552,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('translation-languages')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getTranslationLanguages(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -571,7 +568,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('government-representatives')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getGovernmentRepresentatives(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -636,7 +633,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('event-planners')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getEventPlanners(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getEventPlanners();
     return { success: true, data };
@@ -649,7 +646,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('news-release-distributions')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getNewsReleaseDistributions(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -665,7 +662,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('premier-requested')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getPremierRequested(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -681,7 +678,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('news-release-origins')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getNewsReleaseOrigins(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -713,7 +710,7 @@ export class LookupsController {
     description: 'Filter activities by user role',
   })
   @Get('activities')
-  @Header('Cache-Control', `public, max-age=${DYNAMIC_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getActivitiesForLookup(
     @Query('userId', new ParseOptionalIntPipe()) userId?: number,
     @Query('role') role?: string
@@ -730,7 +727,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('cities')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getCities(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getCities();
     return { success: true, data };
@@ -789,7 +786,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('ministries')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getMinistries(): Promise<{
     success: boolean;
     data: MinistryLookupItem[];
@@ -847,7 +844,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('date-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getDateStatuses(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getDateStatuses();
     return { success: true, data };
@@ -860,7 +857,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('time-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getTimeStatuses(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getTimeStatuses();
     return { success: true, data };
@@ -873,7 +870,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('venue-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getVenueStatuses(): Promise<{ success: boolean; data: LookupItem[] }> {
     const data = await this.lookupsService.getVenueStatuses();
     return { success: true, data };
@@ -886,7 +883,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('pitch-required-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getPitchRequiredStatuses(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -902,7 +899,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('translation-required-statuses')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getTranslationRequiredStatuses(): Promise<{
     success: boolean;
     data: LookupItem[];
@@ -918,7 +915,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('reports')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getReports(): Promise<{ success: boolean; data: any[] }> {
     const data = await this.lookupsService.getReports();
     return { success: true, data };
@@ -931,7 +928,7 @@ export class LookupsController {
     type: LookupArrayResponseWrapperDto,
   })
   @Get('themes')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getThemes(): Promise<{ success: boolean; data: ThemeLookupItem[] }> {
     const data = await this.lookupsService.getThemes();
     return { success: true, data };
@@ -990,7 +987,7 @@ export class LookupsController {
     type: VenuePresetArrayResponseWrapperDto,
   })
   @Get('venue-presets')
-  @Header('Cache-Control', `public, max-age=${REFERENCE_LOOKUP_CACHE_SECONDS}`)
+  @Header('Cache-Control', lookupGetCacheControl())
   async getVenuePresets(): Promise<{
     success: boolean;
     data: VenuePresetItem[];

--- a/calendar-service/test/lookups.e2e-spec.ts
+++ b/calendar-service/test/lookups.e2e-spec.ts
@@ -41,11 +41,11 @@ describe('LookupsController (e2e)', () => {
         });
     });
 
-    it('should have cache-control headers', () => {
+    it('should set a revalidation-first Cache-Control header', () => {
       return createAuthRequest(app, accessToken)
         .get('/lookups/categories')
         .expect(200)
-        .expect('Cache-Control', /public/);
+        .expect('Cache-Control', /no-store|no-cache/);
     });
   });
 
@@ -153,11 +153,11 @@ describe('LookupsController (e2e)', () => {
         });
     });
 
-    it('should have cache-control headers', () => {
+    it('should set a revalidation-first Cache-Control header', () => {
       return createAuthRequest(app, accessToken)
         .get('/lookups/venue-presets')
         .expect(200)
-        .expect('Cache-Control', /public/);
+        .expect('Cache-Control', /no-store|no-cache/);
     });
   });
 

--- a/calendar-ui/src/api/reportsApi.ts
+++ b/calendar-ui/src/api/reportsApi.ts
@@ -1,8 +1,6 @@
-import type {
-  ActivityResponse,
-  ReportResponse,
-} from '@corpcal/shared/api/types';
+import type { ActivityResponse } from '@corpcal/shared/api/types';
 import type { ReportDataQueryParams } from '@corpcal/shared/schemas';
+import type { ReportResponse } from '@corpcal/shared/schemas/lookup.schema';
 
 import api from './axios';
 
@@ -28,11 +26,6 @@ export async function fetchReportData(
   const response = await api.get<ReportDataResponse>(`/reports/data/${type}`, {
     params,
   });
-  return response.data;
-}
-
-export async function fetchReportsList(): Promise<ReportResponse[]> {
-  const response = await api.get<ReportResponse[]>('/reports');
   return response.data;
 }
 

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityEventSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityEventSection.tsx
@@ -53,6 +53,7 @@ import { Input } from '@/components/ui/input';
 import { SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 import { cn } from '@/lib/utils';
 import type { OptionItem } from '@/schemas/types';
 
@@ -261,11 +262,11 @@ export const ActivityEventSection: FC<ActivityEventSectionProps> = ({
   const representativesAnchorRef = useComboboxAnchor();
 
   const { data: allPresets = [] } = useQuery({
-    queryKey: ['venuePresets'],
+    queryKey: lookupQueryKeys.venuePresets(),
     queryFn: fetchVenuePresets,
   });
   const { data: citiesList = [] } = useQuery({
-    queryKey: ['cities'],
+    queryKey: lookupQueryKeys.cities(),
     queryFn: fetchCities,
   });
 

--- a/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
+++ b/calendar-ui/src/components/admin/GenericLookupAdmin.tsx
@@ -43,7 +43,11 @@ interface GenericLookupAdminProps<T extends BaseLookupItem> {
   description: string;
   entityType: string;
   apiEndpoint: string;
-  queryKey: string;
+  /**
+   * React Query key for the list query. Prefer a key from `lookupQueryKeys`
+   * so admin and consumer caches stay aligned and type-safe.
+   */
+  queryKey: readonly unknown[];
   queryFn: () => Promise<T[]>;
   formFields: FormField[];
   additionalColumns?: ColumnDef<T>[];
@@ -55,7 +59,7 @@ interface GenericLookupAdminProps<T extends BaseLookupItem> {
   /** When provided, renders custom modal body instead of LookupForm (e.g. for address search). */
   renderModalContent?: (props: RenderModalContentProps) => ReactNode;
   /** Additional query keys to invalidate on create/update (e.g. to bust related caches). */
-  additionalInvalidateKeys?: string[][];
+  additionalInvalidateKeys?: readonly (readonly unknown[])[];
   /** When true, "delete" sets isActive=false via PATCH instead of issuing a DELETE request.
    * Use for entities that may be referenced by other records (e.g. tags on activities). */
   softDelete?: boolean;
@@ -102,9 +106,19 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
   }, [editingItem]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [queryKey],
+    queryKey,
     queryFn: queryFn,
+    // Always refetch when an admin section mounts so Settings reflects any
+    // mutation or seed/schema change from another tab or the backend.
+    refetchOnMount: 'always',
   });
+
+  const invalidateListCaches = () => {
+    void queryClient.invalidateQueries({ queryKey });
+    for (const key of additionalInvalidateKeys ?? []) {
+      void queryClient.invalidateQueries({ queryKey: key });
+    }
+  };
 
   const createMutation = useMutation({
     mutationFn: async (data: Partial<T>) => {
@@ -112,10 +126,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       return response.data;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: [queryKey] });
-      for (const key of additionalInvalidateKeys ?? []) {
-        void queryClient.invalidateQueries({ queryKey: key });
-      }
+      invalidateListCaches();
       setShowModal(false);
       setEditingItem(null);
       setFormData({});
@@ -129,10 +140,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       return response.data;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: [queryKey] });
-      for (const key of additionalInvalidateKeys ?? []) {
-        void queryClient.invalidateQueries({ queryKey: key });
-      }
+      invalidateListCaches();
       setShowModal(false);
       setEditingItem(null);
       setFormData({});
@@ -149,10 +157,7 @@ export function GenericLookupAdmin<T extends BaseLookupItem>({
       return id;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: [queryKey] });
-      for (const key of additionalInvalidateKeys ?? []) {
-        void queryClient.invalidateQueries({ queryKey: key });
-      }
+      invalidateListCaches();
     },
   });
 

--- a/calendar-ui/src/components/admin/LookupAdmins.tsx
+++ b/calendar-ui/src/components/admin/LookupAdmins.tsx
@@ -423,7 +423,7 @@ export function GovernmentRepresentativesAdmin() {
 
 export function TagsAdmin() {
   const { data: teams = [] } = useQuery({
-    queryKey: ['teams'],
+    queryKey: lookupQueryKeys.teams(),
     queryFn: fetchTeams,
   });
 

--- a/calendar-ui/src/components/admin/LookupAdmins.tsx
+++ b/calendar-ui/src/components/admin/LookupAdmins.tsx
@@ -23,6 +23,7 @@ import {
   type ThemeLookupItem,
 } from '@/api/lookupsApi';
 import { fetchTeams } from '@/api/usersApi';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 import { NONE_SELECT_VALUE } from '.';
 import { GenericLookupAdmin } from './GenericLookupAdmin';
@@ -338,7 +339,7 @@ export function CategoriesAdmin() {
       description="Manage activity categories"
       entityType="Category"
       apiEndpoint="/lookups/categories"
-      queryKey="categories"
+      queryKey={lookupQueryKeys.categories()}
       queryFn={fetchCategories as () => Promise<Category[]>}
       formFields={categoryFields}
     />
@@ -352,7 +353,7 @@ export function CitiesAdmin() {
       description="Manage city locations"
       entityType="City"
       apiEndpoint="/lookups/cities"
-      queryKey="cities"
+      queryKey={lookupQueryKeys.cities()}
       queryFn={fetchCities as () => Promise<City[]>}
       formFields={cityFields}
       additionalColumns={[
@@ -386,7 +387,7 @@ export function CommsMaterialsAdmin() {
       description="Manage communication material types"
       entityType="Communications Material"
       apiEndpoint="/lookups/comms-materials"
-      queryKey="commsMaterials"
+      queryKey={lookupQueryKeys.commsMaterials()}
       queryFn={fetchCommsMaterials as () => Promise<CommsMaterial[]>}
       formFields={commsMaterialFields}
     />
@@ -400,7 +401,7 @@ export function GovernmentRepresentativesAdmin() {
       description="Manage government representatives"
       entityType="Government Representative"
       apiEndpoint="/lookups/government-representatives"
-      queryKey="governmentRepresentatives"
+      queryKey={lookupQueryKeys.governmentRepresentatives()}
       queryFn={
         fetchGovernmentRepresentatives as () => Promise<
           GovernmentRepresentative[]
@@ -451,10 +452,10 @@ export function TagsAdmin() {
       description="Manage activity tags"
       entityType="Tag"
       apiEndpoint="/lookups/tags"
-      queryKey="tags-admin"
+      queryKey={lookupQueryKeys.tagsAdmin()}
       queryFn={fetchAllTags as () => Promise<Tag[]>}
       softDelete
-      additionalInvalidateKeys={[['lookups', 'tags']]}
+      additionalInvalidateKeys={[lookupQueryKeys.tags()]}
       formFields={tagFormFields}
       getItemName={(item) => item.name ?? item.displayName ?? String(item.id)}
       getInitialData={(item) => ({
@@ -499,7 +500,7 @@ export function MinistriesAdmin() {
       description="Manage BC government ministries"
       entityType="Ministry"
       apiEndpoint="/lookups/ministries"
-      queryKey="ministries"
+      queryKey={lookupQueryKeys.ministries()}
       queryFn={fetchMinistries as () => Promise<MinistryAdminItem[]>}
       formFields={ministryFields}
       additionalColumns={[
@@ -534,7 +535,7 @@ export function ActivityStatusesAdmin() {
       description="Manage activity status types"
       entityType="Activity Status"
       apiEndpoint="/lookups/activity-statuses"
-      queryKey="activityStatuses"
+      queryKey={lookupQueryKeys.activityStatuses()}
       queryFn={fetchActivityStatuses as () => Promise<ActivityStatus[]>}
       formFields={statusFields}
     />
@@ -548,7 +549,7 @@ export function ThemesAdmin() {
       description="Manage activity themes"
       entityType="Theme"
       apiEndpoint="/lookups/themes"
-      queryKey="themes"
+      queryKey={lookupQueryKeys.themes()}
       queryFn={fetchThemes}
       formFields={themeFields}
       getItemName={(item) => item.displayName ?? item.label ?? String(item.id)}
@@ -596,7 +597,7 @@ export function VenuePresetsAdmin() {
       description="Manage venue presets for the activity form"
       entityType="Venue Preset"
       apiEndpoint="/lookups/venue-presets"
-      queryKey="venuePresets"
+      queryKey={lookupQueryKeys.venuePresets()}
       queryFn={fetchVenuePresets as () => Promise<VenuePreset[]>}
       formFields={venuePresetFields}
       additionalColumns={venuePresetAdditionalColumns}

--- a/calendar-ui/src/components/admin/VenuePresetForm.tsx
+++ b/calendar-ui/src/components/admin/VenuePresetForm.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 export interface VenuePresetFormData {
   venueName?: string | null;
@@ -105,7 +106,7 @@ export function VenuePresetForm({
   );
 
   const { data: citiesList = [] } = useQuery({
-    queryKey: ['cities'],
+    queryKey: lookupQueryKeys.cities(),
     queryFn: fetchCities,
   });
 

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -96,7 +96,7 @@ export function TeamEditModal({
   const createMutation = useMutation({
     mutationFn: createTeam,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      void queryClient.invalidateQueries({ queryKey: lookupQueryKeys.teams() });
       toast.success('Team created', { id: 'team-created' });
       onSaved();
       onClose();
@@ -117,7 +117,7 @@ export function TeamEditModal({
       body: Parameters<typeof updateTeam>[1];
     }) => updateTeam(id, body),
     onSuccess: (_data, variables) => {
-      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      void queryClient.invalidateQueries({ queryKey: lookupQueryKeys.teams() });
       toast.success('Team updated', { id: `team-updated-${variables.id}` });
       onSaved();
       onClose();

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -27,6 +27,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 import type { OptionItem } from '@/schemas/types';
 
 interface TeamEditModalProps {
@@ -59,7 +60,7 @@ export function TeamEditModal({
     });
 
   const { data: ministries = [] } = useQuery({
-    queryKey: ['lookups', 'ministries'],
+    queryKey: lookupQueryKeys.ministries(),
     queryFn: fetchMinistries,
     enabled: open,
   });

--- a/calendar-ui/src/components/teams/TeamsTabContent.tsx
+++ b/calendar-ui/src/components/teams/TeamsTabContent.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 const SKELETON_ROW_COUNT = 8;
 const SKELETON_DELAY_MS = 300;
@@ -107,7 +108,7 @@ export function TeamsTabContent({
   const tableScrollRef = useRef<HTMLDivElement>(null);
 
   const { data: teams = [], isLoading } = useQuery({
-    queryKey: ['teams', 'list', showInactive],
+    queryKey: lookupQueryKeys.teamsList(showInactive),
     queryFn: () => fetchTeamsList(!showInactive),
   });
 

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -45,6 +45,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 import type { OptionItem } from '@/schemas/types';
 
 const createUserFormSchema = z.object({
@@ -105,7 +106,7 @@ export function UserCreateModal({
   });
 
   const { data: teams = [] } = useQuery({
-    queryKey: ['teams'],
+    queryKey: lookupQueryKeys.teams(),
     queryFn: fetchTeams,
     enabled: open,
   });

--- a/calendar-ui/src/components/users/UserEditModal.tsx
+++ b/calendar-ui/src/components/users/UserEditModal.tsx
@@ -28,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 interface UserEditModalProps {
   user: UserListItem;
@@ -65,7 +66,7 @@ export function UserEditModal({
   });
 
   const { data: teams = [] } = useQuery({
-    queryKey: ['teams'],
+    queryKey: lookupQueryKeys.teams(),
     queryFn: fetchTeams,
   });
 

--- a/calendar-ui/src/components/users/UsersTabContent.tsx
+++ b/calendar-ui/src/components/users/UsersTabContent.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { UserManagementFilters } from '@/components/users/UserManagementFilters';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 const IDIR_PLACEHOLDER = 'MYIDIR';
 const SKELETON_ROW_COUNT = 8;
@@ -174,7 +175,7 @@ export function UsersTabContent({
   }, [isLoading]);
 
   const { data: teamsForFilter = [] } = useQuery({
-    queryKey: ['teams'],
+    queryKey: lookupQueryKeys.teams(),
     queryFn: fetchTeams,
   });
 

--- a/calendar-ui/src/hooks/useCommsContactCandidates.ts
+++ b/calendar-ui/src/hooks/useCommsContactCandidates.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { CommsContactCandidate } from '@corpcal/shared/api/types';
 
 import { fetchCommsContactCandidates } from '../api/teamsApi';
+import { lookupQueryKeys } from '../lib/lookupQueryKeys';
 
 /**
  * Eligible comms contact candidates for a given lead team.
@@ -16,7 +17,7 @@ export function useCommsContactCandidates(
   fetchEnabled = true
 ) {
   return useQuery<CommsContactCandidate[]>({
-    queryKey: ['teams', teamId, 'comms-contact-candidates'] as const,
+    queryKey: lookupQueryKeys.teamsCommsContactCandidates(teamId ?? 0),
     queryFn: () => fetchCommsContactCandidates(teamId!),
     enabled: teamId != null && teamId > 0 && fetchEnabled,
     staleTime: 60_000,

--- a/calendar-ui/src/hooks/useLeadTeamOptions.ts
+++ b/calendar-ui/src/hooks/useLeadTeamOptions.ts
@@ -3,8 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { TeamListItem } from '@corpcal/shared/api/types';
 
 import { fetchLeadTeamOptions } from '../api/teamsApi';
-
-const LEAD_TEAM_OPTIONS_QUERY_KEY = ['teams', 'lead-options'] as const;
+import { lookupQueryKeys } from '../lib/lookupQueryKeys';
 
 /**
  * Teams the current user may choose as activity lead team (for create/edit forms).
@@ -14,7 +13,7 @@ const LEAD_TEAM_OPTIONS_QUERY_KEY = ['teams', 'lead-options'] as const;
  */
 export function useLeadTeamOptions(enabled: boolean) {
   return useQuery<TeamListItem[]>({
-    queryKey: LEAD_TEAM_OPTIONS_QUERY_KEY,
+    queryKey: lookupQueryKeys.teamsLeadOptions(),
     queryFn: () => fetchLeadTeamOptions(),
     enabled,
     staleTime: 60_000,

--- a/calendar-ui/src/hooks/useLookups.tsx
+++ b/calendar-ui/src/hooks/useLookups.tsx
@@ -49,12 +49,13 @@ import {
   type UserLookupItem,
 } from '../api/lookupsApi';
 import { fetchTeams } from '../api/usersApi';
+import { lookupQueryKeys } from '../lib/lookupQueryKeys';
 
 type TeamLookupItem = Awaited<ReturnType<typeof fetchTeams>>[number];
 
 export function useCategories() {
   return useQuery<CategoryLookupItem[]>({
-    queryKey: ['lookups', 'categories'],
+    queryKey: lookupQueryKeys.categories(),
     queryFn: () => fetchCategories(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -62,7 +63,7 @@ export function useCategories() {
 
 export function useOrganizations(params?: LookupQueryParams) {
   return useQuery<OrganizationLookupItem[]>({
-    queryKey: ['lookups', 'organizations', params],
+    queryKey: lookupQueryKeys.organizations(params),
     queryFn: () => fetchOrganizations(params),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -70,7 +71,7 @@ export function useOrganizations(params?: LookupQueryParams) {
 
 export function useUsers(params?: LookupQueryParams) {
   return useQuery<UserLookupItem[]>({
-    queryKey: ['lookups', 'users', params],
+    queryKey: lookupQueryKeys.users(params),
     queryFn: () => fetchUsers(params),
     staleTime: DYNAMIC_LOOKUP_CACHE_MS,
   });
@@ -86,7 +87,7 @@ export function useTeams() {
 
 export function useTags() {
   return useQuery<TagLookupItem[]>({
-    queryKey: ['lookups', 'tags'],
+    queryKey: lookupQueryKeys.tags(),
     queryFn: () => fetchTags(),
     staleTime: DYNAMIC_LOOKUP_CACHE_MS, // user-specific results; don't cache as long as static lookups
   });
@@ -94,7 +95,7 @@ export function useTags() {
 
 export function usePitchStatuses() {
   return useQuery<PitchStatusLookupItem[]>({
-    queryKey: ['lookups', 'pitch-statuses'],
+    queryKey: lookupQueryKeys.pitchStatuses(),
     queryFn: () => fetchPitchStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -102,7 +103,7 @@ export function usePitchStatuses() {
 
 export function useActivityStatuses() {
   return useQuery<ActivityStatusLookupItem[]>({
-    queryKey: ['lookups', 'activity-statuses'],
+    queryKey: lookupQueryKeys.activityStatuses(),
     queryFn: () => fetchActivityStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -110,7 +111,7 @@ export function useActivityStatuses() {
 
 export function useCommsMaterials() {
   return useQuery<CommsMaterialsLookupItem[]>({
-    queryKey: ['lookups', 'comms-materials'],
+    queryKey: lookupQueryKeys.commsMaterials(),
     queryFn: () => fetchCommsMaterials(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -118,7 +119,7 @@ export function useCommsMaterials() {
 
 export function useTranslationLanguages() {
   return useQuery<TranslationLanguageLookupItem[]>({
-    queryKey: ['lookups', 'translation-languages'],
+    queryKey: lookupQueryKeys.translationLanguages(),
     queryFn: () => fetchTranslationLanguages(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -126,7 +127,7 @@ export function useTranslationLanguages() {
 
 export function useGovernmentRepresentatives() {
   return useQuery<GovernmentRepresentativeLookupItem[]>({
-    queryKey: ['lookups', 'government-representatives'],
+    queryKey: lookupQueryKeys.governmentRepresentatives(),
     queryFn: () => fetchGovernmentRepresentatives(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -134,7 +135,7 @@ export function useGovernmentRepresentatives() {
 
 export function useEventPlanners() {
   return useQuery<LookupItem[]>({
-    queryKey: ['lookups', 'event-planners'],
+    queryKey: lookupQueryKeys.eventPlanners(),
     queryFn: () => fetchEventPlanners(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -142,7 +143,7 @@ export function useEventPlanners() {
 
 export function useNewsReleaseDistributions() {
   return useQuery<LookupItem[]>({
-    queryKey: ['lookups', 'news-release-distributions'],
+    queryKey: lookupQueryKeys.newsReleaseDistributions(),
     queryFn: () => fetchNewsReleaseDistributions(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -150,7 +151,7 @@ export function useNewsReleaseDistributions() {
 
 export function usePremierRequested() {
   return useQuery<LookupItem[]>({
-    queryKey: ['lookups', 'premier-requested'],
+    queryKey: lookupQueryKeys.premierRequested(),
     queryFn: () => fetchPremierRequested(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -158,7 +159,7 @@ export function usePremierRequested() {
 
 export function useNewsReleaseOrigins() {
   return useQuery<LookupItem[]>({
-    queryKey: ['lookups', 'news-release-origins'],
+    queryKey: lookupQueryKeys.newsReleaseOrigins(),
     queryFn: () => fetchNewsReleaseOrigins(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -168,7 +169,7 @@ export function useActivitiesForLookup(
   params?: Pick<LookupQueryParams, 'userId' | 'role'>
 ) {
   return useQuery<LookupItem[]>({
-    queryKey: ['lookups', 'activities', params],
+    queryKey: lookupQueryKeys.activities(params),
     queryFn: () => fetchActivitiesForLookup(params),
     staleTime: DYNAMIC_LOOKUP_CACHE_MS,
   });
@@ -176,7 +177,7 @@ export function useActivitiesForLookup(
 
 export function useReports() {
   return useQuery<ReportResponse[]>({
-    queryKey: ['reports'],
+    queryKey: lookupQueryKeys.reports(),
     queryFn: () => fetchReports(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -184,7 +185,7 @@ export function useReports() {
 
 export function useDateStatuses() {
   return useQuery<DateStatusLookupItem[]>({
-    queryKey: ['lookups', 'date-statuses'],
+    queryKey: lookupQueryKeys.dateStatuses(),
     queryFn: () => fetchDateStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -192,7 +193,7 @@ export function useDateStatuses() {
 
 export function useTimeStatuses() {
   return useQuery<TimeStatusLookupItem[]>({
-    queryKey: ['lookups', 'time-statuses'],
+    queryKey: lookupQueryKeys.timeStatuses(),
     queryFn: () => fetchTimeStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -200,7 +201,7 @@ export function useTimeStatuses() {
 
 export function useVenueStatuses() {
   return useQuery<VenueStatusLookupItem[]>({
-    queryKey: ['lookups', 'venue-statuses'],
+    queryKey: lookupQueryKeys.venueStatuses(),
     queryFn: () => fetchVenueStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -208,7 +209,7 @@ export function useVenueStatuses() {
 
 export function usePitchRequiredStatuses() {
   return useQuery<PitchRequiredStatusLookupItem[]>({
-    queryKey: ['lookups', 'pitch-required-statuses'],
+    queryKey: lookupQueryKeys.pitchRequiredStatuses(),
     queryFn: () => fetchPitchRequiredStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -216,7 +217,7 @@ export function usePitchRequiredStatuses() {
 
 export function useTranslationRequiredStatuses() {
   return useQuery<TranslationRequiredStatusLookupItem[]>({
-    queryKey: ['lookups', 'translation-required-statuses'],
+    queryKey: lookupQueryKeys.translationRequiredStatuses(),
     queryFn: () => fetchTranslationRequiredStatuses(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });
@@ -224,7 +225,7 @@ export function useTranslationRequiredStatuses() {
 
 export function useMinistries() {
   return useQuery<MinistryLookupItem[]>({
-    queryKey: ['lookups', 'ministries'],
+    queryKey: lookupQueryKeys.ministries(),
     queryFn: () => fetchMinistries(),
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });

--- a/calendar-ui/src/hooks/useLookups.tsx
+++ b/calendar-ui/src/hooks/useLookups.tsx
@@ -79,7 +79,7 @@ export function useUsers(params?: LookupQueryParams) {
 
 export function useTeams() {
   return useQuery<TeamLookupItem[]>({
-    queryKey: ['teams'],
+    queryKey: lookupQueryKeys.teams(),
     queryFn: fetchTeams,
     staleTime: REFERENCE_LOOKUP_CACHE_MS,
   });

--- a/calendar-ui/src/lib/lookupQueryKeys.ts
+++ b/calendar-ui/src/lib/lookupQueryKeys.ts
@@ -1,0 +1,63 @@
+/**
+ * Centralized React Query key factory for lookup data.
+ *
+ * All keys are rooted at `['lookups']` so callers can invalidate the entire
+ * lookup cache with `invalidateQueries({ queryKey: lookupQueryKeys.root })`.
+ *
+ * Second segments mirror the backend URL segment (kebab-case) for each
+ * `/lookups/<segment>` route, which keeps them easy to audit against the
+ * controller and gives a single place to add future lookups.
+ *
+ * Tag list has two variants that share the `['lookups', 'tags']` prefix:
+ * - `tags()` - user-scoped list (no `includeAll`) used by forms, pickers, etc.
+ * - `tagsAdmin()` - admin list (`includeAll=true`) used by the Settings admin.
+ * Invalidating the prefix `['lookups', 'tags']` refreshes both variants.
+ */
+
+import type { LookupQueryParams } from '../api/lookupsApi';
+
+export const lookupQueryKeys = {
+  /** Root prefix; invalidating this refreshes every lookup query. */
+  root: ['lookups'] as const,
+
+  categories: () => ['lookups', 'categories'] as const,
+  cities: () => ['lookups', 'cities'] as const,
+  commsMaterials: () => ['lookups', 'comms-materials'] as const,
+  activityStatuses: () => ['lookups', 'activity-statuses'] as const,
+  pitchStatuses: () => ['lookups', 'pitch-statuses'] as const,
+  governmentRepresentatives: () =>
+    ['lookups', 'government-representatives'] as const,
+  ministries: () => ['lookups', 'ministries'] as const,
+  ministryGroups: () => ['lookups', 'ministry-groups'] as const,
+  themes: () => ['lookups', 'themes'] as const,
+  venuePresets: () => ['lookups', 'venue-presets'] as const,
+  venueStatuses: () => ['lookups', 'venue-statuses'] as const,
+  eventPlanners: () => ['lookups', 'event-planners'] as const,
+  newsReleaseDistributions: () =>
+    ['lookups', 'news-release-distributions'] as const,
+  newsReleaseOrigins: () => ['lookups', 'news-release-origins'] as const,
+  premierRequested: () => ['lookups', 'premier-requested'] as const,
+  dateStatuses: () => ['lookups', 'date-statuses'] as const,
+  timeStatuses: () => ['lookups', 'time-statuses'] as const,
+  pitchRequiredStatuses: () => ['lookups', 'pitch-required-statuses'] as const,
+  translationRequiredStatuses: () =>
+    ['lookups', 'translation-required-statuses'] as const,
+  translationLanguages: () => ['lookups', 'translation-languages'] as const,
+
+  users: (params?: LookupQueryParams) => ['lookups', 'users', params] as const,
+  organizations: (params?: LookupQueryParams) =>
+    ['lookups', 'organizations', params] as const,
+  activities: (params?: Pick<LookupQueryParams, 'userId' | 'role'>) =>
+    ['lookups', 'activities', params] as const,
+
+  /** User-scoped tags list (no `includeAll`). */
+  tags: () => ['lookups', 'tags'] as const,
+  /** Admin tags list (`includeAll=true`). Shares the `['lookups', 'tags']` prefix. */
+  tagsAdmin: () => ['lookups', 'tags', 'admin'] as const,
+
+  /** Reports list (single source of truth for Settings/Reports page and activity form). */
+  reports: () => ['lookups', 'reports'] as const,
+} as const;
+
+/** Readonly array variant of any factory return; useful for `GenericLookupAdmin` props. */
+export type LookupQueryKey = readonly unknown[];

--- a/calendar-ui/src/lib/lookupQueryKeys.ts
+++ b/calendar-ui/src/lib/lookupQueryKeys.ts
@@ -1,12 +1,13 @@
 /**
- * Centralized React Query key factory for lookup data.
+ * Centralized React Query key factory for lookup and lookup-style lists.
  *
  * All keys are rooted at `['lookups']` so callers can invalidate the entire
- * lookup cache with `invalidateQueries({ queryKey: lookupQueryKeys.root })`.
+ * tree with `invalidateQueries({ queryKey: lookupQueryKeys.root })` (see `teams`
+ * and `teamsList` for the users API list that uses this prefix for the same
+ * reason).
  *
- * Second segments mirror the backend URL segment (kebab-case) for each
- * `/lookups/<segment>` route, which keeps them easy to audit against the
- * controller and gives a single place to add future lookups.
+ * For `/lookups/<segment>` routes, the second segment mirrors the backend path
+ * (kebab-case) so keys stay easy to audit against the controller.
  *
  * Tag list has two variants that share the `['lookups', 'tags']` prefix:
  * - `tags()` - user-scoped list (no `includeAll`) used by forms, pickers, etc.
@@ -57,6 +58,26 @@ export const lookupQueryKeys = {
 
   /** Reports list (single source of truth for Settings/Reports page and activity form). */
   reports: () => ['lookups', 'reports'] as const,
+
+  /**
+   * Team options from `GET /users/teams` (`fetchTeams`). Shared prefix with lookups
+   * so global `['lookups']` invalidation refreshes team pickers after lookup/seed work.
+   */
+  teams: () => ['lookups', 'teams'] as const,
+  /**
+   * Teams admin table list (`fetchTeamsList`). Inherits the `['lookups', 'teams']`
+   * prefix so it refetches with the same invalidation as `teams()`.
+   */
+  teamsList: (showInactive: boolean) =>
+    ['lookups', 'teams', 'list', showInactive] as const,
+  /**
+   * Comms contact candidate list for a team (`/teams/:id/comms-contact-candidates`).
+   * Shares the `['lookups', 'teams', ...]` prefix for invalidation.
+   */
+  teamsCommsContactCandidates: (teamId: number) =>
+    ['lookups', 'teams', teamId, 'comms-contact-candidates'] as const,
+  /** Lead team picker options (`GET /teams/lead-options` for activity forms). */
+  teamsLeadOptions: () => ['lookups', 'teams', 'lead-options'] as const,
 } as const;
 
 /** Readonly array variant of any factory return; useful for `GenericLookupAdmin` props. */

--- a/calendar-ui/src/pages/GlobalHistory.tsx
+++ b/calendar-ui/src/pages/GlobalHistory.tsx
@@ -51,6 +51,7 @@ import {
   getHistoryFieldLabel,
 } from '@/lib/activity-history-format';
 import { formatExactDate, formatLongDate } from '@/lib/datetime-utils';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 const EMPTY_DATE_RANGE: DateRangeValue = {
   startDate: '',
@@ -60,6 +61,8 @@ const EMPTY_DATE_RANGE: DateRangeValue = {
 };
 
 const MAX_CHANGE_VALUE_LENGTH = 120;
+
+const HISTORY_FILTER_LOOKUP_STALE_MS = 5 * 60 * 1000;
 
 type HistoryTab = 'all' | 'mine';
 
@@ -404,45 +407,51 @@ export function GlobalHistory() {
   const activityStatusesQuery = useActivityStatuses();
 
   const dateStatusesQuery = useQuery({
-    queryKey: ['lookups', 'date-statuses', 'history-filters'],
+    queryKey: [...lookupQueryKeys.dateStatuses(), 'history-filters'],
     queryFn: fetchDateStatuses,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const timeStatusesQuery = useQuery({
-    queryKey: ['lookups', 'time-statuses', 'history-filters'],
+    queryKey: [...lookupQueryKeys.timeStatuses(), 'history-filters'],
     queryFn: fetchTimeStatuses,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const pitchRequiredStatusesQuery = useQuery({
-    queryKey: ['lookups', 'pitch-required-statuses', 'history-filters'],
+    queryKey: [...lookupQueryKeys.pitchRequiredStatuses(), 'history-filters'],
     queryFn: fetchPitchRequiredStatuses,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const translationRequiredStatusesQuery = useQuery({
-    queryKey: ['lookups', 'translation-required-statuses', 'history-filters'],
+    queryKey: [
+      ...lookupQueryKeys.translationRequiredStatuses(),
+      'history-filters',
+    ],
     queryFn: fetchTranslationRequiredStatuses,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const newsReleaseOriginsQuery = useQuery({
-    queryKey: ['lookups', 'news-release-origins', 'history-filters'],
+    queryKey: [...lookupQueryKeys.newsReleaseOrigins(), 'history-filters'],
     queryFn: fetchNewsReleaseOrigins,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const newsReleaseDistributionsQuery = useQuery({
-    queryKey: ['lookups', 'news-release-distributions', 'history-filters'],
+    queryKey: [
+      ...lookupQueryKeys.newsReleaseDistributions(),
+      'history-filters',
+    ],
     queryFn: fetchNewsReleaseDistributions,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const premierRequestedQuery = useQuery({
-    queryKey: ['lookups', 'premier-requested', 'history-filters'],
+    queryKey: [...lookupQueryKeys.premierRequested(), 'history-filters'],
     queryFn: fetchPremierRequested,
-    staleTime: 5 * 60 * 1000,
+    staleTime: HISTORY_FILTER_LOOKUP_STALE_MS,
   });
 
   const entries = useMemo(

--- a/calendar-ui/src/pages/ReportsPage.tsx
+++ b/calendar-ui/src/pages/ReportsPage.tsx
@@ -4,11 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { SYSTEM_ROLES } from '@corpcal/shared/auth';
 import { getReportTypeConfigByReportName } from '@corpcal/shared/reports/reportTypeConfig';
-import {
-  fetchReportData,
-  fetchReportsList,
-  type ReportSectionData,
-} from '@/api/reportsApi';
+import { fetchReportData, type ReportSectionData } from '@/api/reportsApi';
 import { PageHeader } from '@/components/layout';
 import { CustomReportPreviewSection } from '@/components/reports/CustomReportPreviewSection';
 import { EditReportModal } from '@/components/reports/EditReportModal';
@@ -18,7 +14,7 @@ import { StatusMessage } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/hooks/useAuth';
-import { useActivityStatuses } from '@/hooks/useLookups';
+import { useActivityStatuses, useReports } from '@/hooks/useLookups';
 import { useReportsTablePreferences } from '@/hooks/useReportsTablePreferences';
 import {
   loadCustomReportConfig,
@@ -109,10 +105,7 @@ export function ReportsPage() {
   const initialTabAppliedRef = useRef(false);
   const defaultsAppliedForReportRef = useRef<string | null>(null);
 
-  const { data: reports = [] } = useQuery({
-    queryKey: ['reports'],
-    queryFn: fetchReportsList,
-  });
+  const { data: reports = [] } = useReports();
 
   useEffect(() => {
     if (initialTabAppliedRef.current || reports.length === 0) return;

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -19,6 +19,7 @@ import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserHistoryDrawer } from '@/components/users/UserHistoryDrawer';
 import { UsersTabContent } from '@/components/users/UsersTabContent';
 import { useAuth } from '@/hooks/useAuth';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 
 export function Users() {
   const [activeTab, setActiveTab] = useState<'users' | 'teams'>('users');
@@ -82,7 +83,7 @@ export function Users() {
   const deactivateTeamMutation = useMutation({
     mutationFn: (teamId: number) => updateTeam(teamId, { isActive: false }),
     onSuccess: (_data, teamId) => {
-      void queryClient.invalidateQueries({ queryKey: ['teams'] });
+      void queryClient.invalidateQueries({ queryKey: lookupQueryKeys.teams() });
       toast.success('Team deactivated', { id: `team-deactivated-${teamId}` });
     },
     onError: (err: Error, teamId) => {
@@ -212,7 +213,9 @@ export function Users() {
           setTeamToEdit(null);
         }}
         onSaved={() => {
-          void queryClient.invalidateQueries({ queryKey: ['teams'] });
+          void queryClient.invalidateQueries({
+            queryKey: lookupQueryKeys.teams(),
+          });
           setShowCreateTeam(false);
           setTeamToEdit(null);
         }}


### PR DESCRIPTION
# PR: fix/CORPCAL-000-cache-invalidation

## Summary

Lookup GET responses no longer use long `public, max-age` HTTP caching, which could serve stale data beside TanStack Query. The API now uses a small shared helper: `no-store` in non-production and `private, no-cache` in production. On the client, React Query keys for lookups are centralized in `lookupQueryKeys` so admin screens, `useLookups`, and ad hoc queries share the same keys and invalidation behavior.

## Changes

1. **Lookups API (calendar-service):** Revalidation-oriented HTTP `Cache-Control` for authenticated lookup list routes.
   - New `lookupGetCacheControl()` in `cache-control.ts` (env-based policy).
   - `LookupsController` uses it for the lookup GET endpoints that previously sent long `max-age` headers.
   - Other response paths that still use `DYNAMIC_LOOKUP_CACHE_SECONDS` (e.g. file/stream handlers) are unchanged.
   - E2E: categories and venue-presets expect `no-store` or `no-cache` instead of `public`.

2. **React Query keys (calendar-ui):** Single factory for lookup-related query keys.
   - Added `lib/lookupQueryKeys.ts` with `root` and per-route factories aligned to `/lookups/<segment>`.
   - `useLookups` and inline `useQuery` call sites (Global History filters, activity form, venue preset form, team modal) use the same keys where applicable.
   - Reports list uses `['lookups', 'reports']` via `useReports()`; removed duplicate `fetchReportsList` from `reportsApi`.
   - `ReportResponse` type import in `reportsApi` points at `lookup.schema` (aligned with lookup reports fetch).

3. **Settings lookup admin (calendar-ui):** `GenericLookupAdmin` takes the full query key (not a string segment), `refetchOnMount: 'always'`, and a shared `invalidateListCaches` helper for create/update/delete.
   - `LookupAdmins` pass keys from `lookupQueryKeys` (including `tags` / `tagsAdmin` and extra invalidation for non-admin tag consumers).

## Testing

- No database migrations or `build:packages` required for this PR.
- `npm run typecheck` — passed for `calendar-ui` and `calendar-service`.
- E2E updates in `calendar-service/test/lookups.e2e-spec.ts` (Cache-Control expectations).
- Recommend: run `lookups` e2e locally if you change `cache-control.ts` or deploy env for `NODE_ENV`.
- Optional manual smoke: open Settings lookup sections and Reports page; confirm lists load and edits refresh consumer views (e.g. tags on activities).
