### PR TITLE
Feat/corpcal 223 review exempt fields

### DIFF
--- a/calendar-service/docs/ACTIVITY.md
+++ b/calendar-service/docs/ACTIVITY.md
@@ -7,6 +7,7 @@ This is the root document for activity-domain service docs. Use it as the entry 
 - [ACTIVITY_STATUS_FLOW.md](./ACTIVITY_STATUS_FLOW.md) - status definitions, transitions, who can perform each action, and lock/restore behavior.
 - [ACTIVITY_EDIT_ELIGIBILITY.md](./ACTIVITY_EDIT_ELIGIBILITY.md) - who may edit, permission guards, and related UI/API edit constraints.
 - [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) - "changed since last review" snapshot model, versioning, diff behavior, and backfill details.
+- [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md) - review-exempt fields (code + admin settings, API, UI, and maintenance when the form changes).
 
 ## Field-Add Playbook (Activity Form)
 
@@ -17,8 +18,13 @@ Use this checklist whenever you add, remove, rename, or materially change an `Ac
 3. Set the canonical empty value in `packages/shared/src/utils/activity-review-diff.ts` (`getEmptyReviewBaseline`).
 4. Confirm canonicalization/diff behavior in `packages/shared/src/utils/activity-form-canonicalize.ts` and `packages/shared/src/utils/activity-review-diff.ts` (`diffReviewFields`) matches intended semantics (ordering, null/empty normalization, object keying).
 5. If the field has a user-visible review badge label/path mapping, update `packages/shared/src/utils/activity-field-labels.ts`.
-6. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
-7. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
+6. **Review impact (review-exempt list):** If the new field is a **top-level** `ActivityFormData` key, decide whether it should ever be **review-exempt** (edits that do not force Reviewed → Changed or show in `changedFieldsSinceReview`). Update `packages/shared/src/review-exempt-settings.ts`:
+   - If it should be **configurable** by System Admins in Settings, add it to the appropriate `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` group (order aligned with `ActivityFormBody` / section components in `calendar-ui`). Ensure it is **not** listed in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` if admins should control it.
+   - If it should **always** be exempt (product rule, not admin-toggleable), add it to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and do **not** add it to the configurable sections. Rebuild `@corpcal/shared` so `review-exempt-field-keys.schema.ts` stays aligned.
+   - If the field must **never** be exempt (e.g. primary content or compliance-sensitive), do not add it to either list; it will always affect review state when it changes. Fields that are **system-only** in the diff (see `EXCLUDED_FIELDS` in `activity-review-diff.ts`) are not admin options.
+7. For full details and API reference, see [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md).
+8. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
+9. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
 
 ### When to update `buildReviewDiffLookups()`
 

--- a/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
+++ b/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
@@ -1,0 +1,46 @@
+# Admin-configurable review-exempt activity fields
+
+This document describes which activity form fields can be marked **review-exempt**: editors may change them without moving a **Reviewed** activity to **Changed**, and those changes do not appear in `changedFieldsSinceReview` (reviewer “changed since last review” paths).
+
+It complements [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) (snapshot model) and [ACTIVITY.md](./ACTIVITY.md) (field-add playbook).
+
+## Behavior summary
+
+- **Review diff and status** use `diffReviewFields` in `packages/shared/src/utils/activity-review-diff.ts` with an **effective exempt set**:
+  - **Code-exempt** — always in the set, not toggleable: `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` in `packages/shared/src/review-exempt-settings.ts` (e.g. summary, scheduling-related top-level keys).
+  - **Admin-configurable** — stored in the database, merged with the code set: `buildEffectiveReviewExemptKeys` uses keys from `application_settings` under `ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING` (default seed: `visibility`, `sharedWithTeamIds`).
+
+- **RHF “dirty” / local “Changed”** behaviour on the form is unchanged; exemption applies only to **review workflow** (status transition and `changedFieldsSinceReview`).
+
+## API
+
+- `GET /settings/review-exempt-fields` — returns `{ fieldKeys: string[] }` (configurable keys only, after server validation).
+- `PATCH /settings/review-exempt-fields` — body `{ fieldKeys: string[] }` (allowlisted values only; duplicates removed).
+
+**Permission:** `settings.manage.review_exempt_fields` (intended for **System Admin**; see `packages/database/seeds/0010_20260422_review_exempt_fields_seed.sql`).
+
+**Implementation:** `ReviewExemptFieldsController` in `calendar-service`, persistence in `ApplicationSettingsService` (`getReviewExemptFieldKeys` / `setReviewExemptFieldKeys`).
+
+## UI
+
+- **Settings** page, section “Review-exempt fields”: `ReviewExemptFieldsSettingsAdmin` in `calendar-ui` renders `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` as grouped checkboxes; labels use `getActivityFieldLabel` / `ACTIVITY_FIELD_LABELS` from shared.
+
+## When you change the activity form or schema
+
+Adding, removing, or renaming a **top-level** `ActivityFormData` field that should be **available** in the admin “review-exempt” list (or that must be **code**-exempt) requires **manual** updates in shared—there is no codegen from the Zod form schema today. Follow the [Field-Add Playbook in ACTIVITY.md](./ACTIVITY.md#field-add-playbook-activity-form), including the review-exempt step.
+
+**Files to touch (review-exempt-specific):**
+
+| File                                                             | What to do                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/shared/src/review-exempt-settings.ts`                  | For a new **configurable** field: add the key to the correct entry in `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` (and ensure it is not in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` unless it should be fixed in code). For a new **code-only** exempt field: add to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and **remove** it from the configurable section list if it was listed. |
+| `packages/shared/src/schemas/review-exempt-field-keys.schema.ts` | The allowlist is derived from the same configurable keys; ensure the `z.enum` input stays consistent after edits to `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS` (rebuild shared).                                                                                                                                                                                            |
+| `packages/shared/src/utils/activity-review-diff.ts`              | If the field affects `getEmptyReviewBaseline` or comparison rules, follow the main playbook.                                                                                                                                                                                                                                                                                |
+
+**Deployment:** no extra migration for the setting row beyond seed; if you add new allowed keys, existing DB values remain valid; unknown keys in stored JSON are stripped on read/save.
+
+## Related code references
+
+- Effective merge: `buildEffectiveReviewExemptKeys` — `review-exempt-settings.ts`
+- Server use: `ActivitiesService.getEffectiveReviewExemptFieldKeys` — `calendar-service/src/activities/services/activities.service.ts`
+- Zod: `reviewExemptFieldKeysSettingsSchema` — `packages/shared/src/schemas/review-exempt-field-keys.schema.ts`

--- a/calendar-service/docs/ACTIVITY_REVIEW_SNAPSHOT.md
+++ b/calendar-service/docs/ACTIVITY_REVIEW_SNAPSHOT.md
@@ -117,15 +117,30 @@ This rewrites `reviewed_field_snapshot` using the updated mapping (with lookups)
 
 For production environments, do not use this CLI command. If historical snapshot realignment is needed, ship a reviewed migration/runbook specifically for production data handling.
 
-## Excluded Fields
+## Excluded and review-exempt fields
 
-The following fields are excluded from the review diff (they are system-managed, not user-editable):
+`diffReviewFields` (used for both `changedFieldsSinceReview` and for deciding whether a save moves **Reviewed** → **Changed**) takes an **effective review-exempt** set, passed in from the server. Two mechanisms apply:
+
+### System-excluded keys (`EXCLUDED_FIELDS`)
+
+The following top-level keys are **never** compared in the review diff (they are system- or workflow-managed, not free-form “content” the reviewer compares):
 
 - `activityStatusId`
 - `markAsReviewed`
 - `activityHistoryNotes`
 - `commsContactLeadId`
 - `leadMinistryId`
+
+Defined in `packages/shared/src/utils/activity-review-diff.ts`.
+
+### Review-exempt keys (code + admin)
+
+Additional top-level keys may be **omitted** from the diff: edits to those keys do not produce paths in `changedFieldsSinceReview` and do not, by themselves, cause a **Reviewed** activity to move to **Changed**. That set is the union of:
+
+- **Code-exempt** — `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` in `packages/shared/src/review-exempt-settings.ts`
+- **Admin-configurable** — stored in `application_settings`, validated allowlist; defaults include sharing/visibility–style fields
+
+**Documentation:** [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md) (API, permissions, settings UI, and what to update when the form schema changes).
 
 ## Future: List Page Highlighting
 

--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -1718,6 +1718,174 @@ describe('ActivitiesService', () => {
       ).toBe('updated');
     });
 
+    describe('review-impact exempt fields (sharing/visibility)', () => {
+      const reviewedStatusId = 2;
+      const changedStatusId = 3;
+
+      /**
+       * Select mock covering: the initial activity select, status-name/id
+       * lookups, and the {@link getReviewDiffLookups} calls used by the
+       * reviewed-preservation gate (multi-key selects whose `.where()` is
+       * awaited directly, resolving to empty lookup rows).
+       */
+      const mockSelectForReviewedGate = (
+        existingActivity: Activity,
+        updatedActivity: Activity,
+        currentStatusName: 'reviewed',
+        targetStatusId: number
+      ) => {
+        let noArgsCallCount = 0;
+        return vi.fn((...args: unknown[]) => {
+          if (args.length === 0) {
+            noArgsCallCount++;
+            return createMockQueryChain(
+              noArgsCallCount === 1 ? [existingActivity] : [updatedActivity]
+            );
+          }
+          const selectArg = (args[0] ?? {}) as Record<string, unknown>;
+          const keys = Object.keys(selectArg);
+          const isLookupQuery =
+            keys.length >= 2 && 'id' in selectArg && 'name' in selectArg;
+          if (isLookupQuery) {
+            return {
+              from: vi.fn().mockReturnThis(),
+              where: vi.fn().mockResolvedValue([]),
+              leftJoin: vi.fn().mockReturnThis(),
+              innerJoin: vi.fn().mockReturnThis(),
+            };
+          }
+          const isStatusNameQuery = keys.length === 1 && 'name' in selectArg;
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            limit: vi
+              .fn()
+              .mockResolvedValue(
+                isStatusNameQuery
+                  ? [{ name: currentStatusName }]
+                  : [{ id: targetStatusId }]
+              ),
+          };
+        });
+      };
+
+      const makeTxMock = (updatedActivity: Activity) =>
+        vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            update: vi.fn().mockReturnValue({
+              set: vi.fn().mockReturnThis(),
+              where: vi.fn().mockReturnThis(),
+              returning: vi.fn().mockResolvedValue([updatedActivity]),
+            }),
+            select: vi.fn().mockReturnValue(createMockQueryChain([])),
+            delete: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue(undefined),
+            }),
+          };
+          return await callback(tx);
+        });
+
+      it('keeps status Reviewed when only sharedWithTeamIds changes', async () => {
+        const existingActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+        });
+        const updatedActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+        });
+
+        mockDatabaseService.db.transaction = makeTxMock(updatedActivity);
+        mockDatabaseService.db.select = mockSelectForReviewedGate(
+          existingActivity,
+          updatedActivity,
+          'reviewed',
+          reviewedStatusId
+        );
+
+        const result = await service.update(
+          1,
+          { sharedWithTeamIds: [42] } as UpdateActivityRequest,
+          1,
+          {
+            permissions: [PERMISSIONS.ACTIVITIES.EDIT],
+            roleName: 'Editor',
+          }
+        );
+
+        expect(result.activityStatusId).toBe(reviewedStatusId);
+      });
+
+      it('keeps status Reviewed when only visibility changes', async () => {
+        const existingActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+          visibility: 'global',
+        });
+        const updatedActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+          visibility: 'team',
+        });
+
+        mockDatabaseService.db.transaction = makeTxMock(updatedActivity);
+        mockDatabaseService.db.select = mockSelectForReviewedGate(
+          existingActivity,
+          updatedActivity,
+          'reviewed',
+          reviewedStatusId
+        );
+
+        const result = await service.update(
+          1,
+          { visibility: 'team' } as UpdateActivityRequest,
+          1,
+          {
+            permissions: [PERMISSIONS.ACTIVITIES.EDIT],
+            roleName: 'Editor',
+          }
+        );
+
+        expect(result.activityStatusId).toBe(reviewedStatusId);
+      });
+
+      it('falls back to Changed when a non-exempt field changes', async () => {
+        const existingActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+          title: 'Before',
+        });
+        const updatedActivity = createMockActivity({
+          id: 1,
+          activityStatusId: changedStatusId,
+          title: 'After',
+        });
+
+        mockDatabaseService.db.transaction = makeTxMock(updatedActivity);
+        mockDatabaseService.db.select = mockSelectForReviewedGate(
+          existingActivity,
+          updatedActivity,
+          'reviewed',
+          changedStatusId
+        );
+
+        const result = await service.update(
+          1,
+          {
+            title: 'After',
+            sharedWithTeamIds: [42],
+          } as UpdateActivityRequest,
+          1,
+          {
+            permissions: [PERMISSIONS.ACTIVITIES.EDIT],
+            roleName: 'Editor',
+          }
+        );
+
+        expect(result.activityStatusId).toBe(changedStatusId);
+      });
+    });
+
     it('should throw ConflictException when activity status is delete_requested', async () => {
       const existingActivity = createMockActivity({
         id: 1,

--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -22,6 +22,7 @@ import {
   createMockUpdateRequest,
 } from '../common/test-utils';
 import { DatabaseService } from '../database/database.service';
+import { ApplicationSettingsService } from '../locks/application-settings.service';
 import { LocksService } from '../locks/locks.service';
 import { PolicyService } from '../policy/policy.service';
 import { getVisibleTagIds } from '../policy/tag-scoping.helper';
@@ -194,6 +195,12 @@ describe('ActivitiesService', () => {
     findCommsContactCandidates: vi.fn().mockResolvedValue([]),
   };
 
+  const mockApplicationSettings = {
+    getReviewExemptFieldKeys: vi
+      .fn()
+      .mockResolvedValue(['visibility', 'sharedWithTeamIds']),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -234,6 +241,10 @@ describe('ActivitiesService', () => {
         {
           provide: TeamsService,
           useValue: mockTeamsService,
+        },
+        {
+          provide: ApplicationSettingsService,
+          useValue: mockApplicationSettings,
         },
       ],
     }).compile();

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -62,6 +62,7 @@ import type {
   VenueAddressBase,
 } from '@corpcal/shared/schemas';
 import {
+  applyUpdateActivityRequestToFormData,
   buildReviewDiffLookups,
   buildReviewSnapshot,
   diffReviewFields,
@@ -295,6 +296,36 @@ export class ActivitiesService {
       ? (snapshot as ReturnType<typeof buildReviewSnapshot>)
       : getEmptyReviewBaseline();
     return diffReviewFields(currentFormData, baseline);
+  }
+
+  /**
+   * Decide whether an update to a currently-Reviewed activity should keep the
+   * status as Reviewed rather than transitioning it to Changed.
+   *
+   * Builds the "before" form representation from the current persisted row,
+   * merges the partial DTO on top to get the "after" shape, and runs the
+   * review-diff comparison. Fields in
+   * {@link ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS} (e.g. sharing/visibility)
+   * are ignored by {@link diffReviewFields}, so updates that touch only
+   * exempt fields preserve Reviewed.
+   */
+  private async shouldPreserveReviewedStatus(
+    activityId: number,
+    oldActivity: Activity,
+    dto: UpdateActivityRequest
+  ): Promise<boolean> {
+    const lookups = await this.getReviewDiffLookups();
+    const related = await this.fetchRelatedForActivityIds(
+      [activityId],
+      [oldActivity]
+    );
+    const beforeResponse = this.mapFetchedActivityToResponseDto(
+      oldActivity,
+      related
+    );
+    const beforeForm = mapResponseToFormData(beforeResponse, lookups);
+    const afterForm = applyUpdateActivityRequestToFormData(beforeForm, dto);
+    return diffReviewFields(afterForm, beforeForm).length === 0;
   }
 
   /**
@@ -1856,6 +1887,13 @@ export class ActivitiesService {
       newStatusName = 'new';
     } else if (currentStatusName === 'completed' && canComplete) {
       newStatusName = 'completed';
+    } else if (
+      currentStatusName === 'reviewed' &&
+      (await this.shouldPreserveReviewedStatus(id, oldActivity, dto))
+    ) {
+      // Updates that touch only review-exempt fields (e.g. sharing/visibility)
+      // must not regress a Reviewed activity back to Changed.
+      newStatusName = 'reviewed';
     } else {
       newStatusName = 'changed';
     }

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -42,6 +42,8 @@ import {
 } from '@corpcal/database/schema';
 import type { Activity, Category } from '@corpcal/database/types';
 import {
+  buildEffectiveReviewExemptKeys,
+  DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS,
   isManualCompleteEligible,
   normalizeActivityStatusLabel,
   PERMISSIONS,
@@ -77,6 +79,7 @@ import {
 
 import type { DrizzleDbExecutor } from '../../database/database.provider';
 import { DatabaseService } from '../../database/database.service';
+import { ApplicationSettingsService } from '../../locks/application-settings.service';
 import { LocksService } from '../../locks/locks.service';
 import { getVisibleCategoryIds } from '../../policy/category-scoping.helper';
 import type { RequestContext as RequestContextType } from '../../policy/dto/user-context.dto';
@@ -102,9 +105,18 @@ export class ActivitiesService {
     private readonly mapperService: ActivityMapperService,
     private readonly utilsService: ActivityUtilsService,
     private readonly locksService: LocksService,
+    private readonly applicationSettings: ApplicationSettingsService,
     private readonly policyService: PolicyService,
     private readonly teamsService: TeamsService
   ) {}
+
+  private async getEffectiveReviewExemptFieldKeys(
+    executor?: DrizzleDbExecutor
+  ): Promise<ReadonlySet<string>> {
+    const fromDb =
+      await this.applicationSettings.getReviewExemptFieldKeys(executor);
+    return buildEffectiveReviewExemptKeys(fromDb);
+  }
 
   /**
    * Normalize venue address data by trimming whitespace and converting empty strings to null.
@@ -283,7 +295,10 @@ export class ActivitiesService {
     response: ActivityResponse,
     snapshot: unknown,
     snapshotVersion: number,
-    lookups?: MapResponseToFormDataLookups
+    lookups?: MapResponseToFormDataLookups,
+    exemptFieldKeys: ReadonlySet<string> = buildEffectiveReviewExemptKeys(
+      DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS
+    )
   ): string[] | undefined {
     if (snapshotVersion !== REVIEW_SNAPSHOT_VERSION) {
       return undefined;
@@ -295,7 +310,7 @@ export class ActivitiesService {
     const baseline = snapshot
       ? (snapshot as ReturnType<typeof buildReviewSnapshot>)
       : getEmptyReviewBaseline();
-    return diffReviewFields(currentFormData, baseline);
+    return diffReviewFields(currentFormData, baseline, { exemptFieldKeys });
   }
 
   /**
@@ -304,17 +319,19 @@ export class ActivitiesService {
    *
    * Builds the "before" form representation from the current persisted row,
    * merges the partial DTO on top to get the "after" shape, and runs the
-   * review-diff comparison. Fields in
-   * {@link ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS} (e.g. sharing/visibility)
-   * are ignored by {@link diffReviewFields}, so updates that touch only
-   * exempt fields preserve Reviewed.
+   * review-diff comparison. Code- and admin-configured review-exempt top-level
+   * fields are ignored by {@link diffReviewFields}, so updates that touch only
+   * those fields preserve Reviewed.
    */
   private async shouldPreserveReviewedStatus(
     activityId: number,
     oldActivity: Activity,
     dto: UpdateActivityRequest
   ): Promise<boolean> {
-    const lookups = await this.getReviewDiffLookups();
+    const [lookups, exemptFieldKeys] = await Promise.all([
+      this.getReviewDiffLookups(),
+      this.getEffectiveReviewExemptFieldKeys(),
+    ]);
     const related = await this.fetchRelatedForActivityIds(
       [activityId],
       [oldActivity]
@@ -325,7 +342,9 @@ export class ActivitiesService {
     );
     const beforeForm = mapResponseToFormData(beforeResponse, lookups);
     const afterForm = applyUpdateActivityRequestToFormData(beforeForm, dto);
-    return diffReviewFields(afterForm, beforeForm).length === 0;
+    return (
+      diffReviewFields(afterForm, beforeForm, { exemptFieldKeys }).length === 0
+    );
   }
 
   /**
@@ -418,15 +437,24 @@ export class ActivitiesService {
       .from(activities)
       .where(eq(activities.activityStatusId, changedId));
 
-    const lookups = await this.getReviewDiffLookups();
+    const [lookups, reviewExemptFieldKeys] = await Promise.all([
+      this.getReviewDiffLookups(),
+      this.getEffectiveReviewExemptFieldKeys(),
+    ]);
     let updated = 0;
     for (const row of targets) {
       const related = await this.fetchRelatedForActivityIds([row.id], [row]);
       const response = this.mapFetchedActivityToResponseDto(row, related);
       const currentForm = mapResponseToFormData(response, lookups);
-      const priorForm = this.buildMockPriorReviewForm(currentForm, row.id);
+      const priorForm = this.buildMockPriorReviewForm(
+        currentForm,
+        row.id,
+        reviewExemptFieldKeys
+      );
       const snapshot = buildReviewSnapshot(priorForm);
-      const diff = diffReviewFields(currentForm, snapshot);
+      const diff = diffReviewFields(currentForm, snapshot, {
+        exemptFieldKeys: reviewExemptFieldKeys,
+      });
       if (diff.length === 0) {
         continue;
       }
@@ -475,7 +503,8 @@ export class ActivitiesService {
    */
   private buildMockPriorReviewForm(
     current: ActivityFormData,
-    activityId: number
+    activityId: number,
+    exemptFieldKeys: ReadonlySet<string>
   ): ActivityFormData {
     const prior = structuredClone(current);
     const targetCount = 1 + (activityId % 6);
@@ -565,11 +594,12 @@ export class ActivitiesService {
     }
 
     const snap = buildReviewSnapshot(prior);
-    const diff = diffReviewFields(current, snap);
+    const diff = diffReviewFields(current, snap, { exemptFieldKeys });
     if (diff.length === 0) {
-      prior.summary = tipTapDocJsonFromPlainText(
-        `[Prior reviewed text] ${plainTextFromActivityRichField(current.summary)}`
-      );
+      const t = current.title;
+      prior.title = t.endsWith('(prior title)')
+        ? t
+        : `${t.slice(0, Math.min(120, t.length))} (prior title)`;
     }
 
     return prior;
@@ -1576,9 +1606,12 @@ export class ActivitiesService {
       ctx?.user?.permissions?.includes(PERMISSIONS.ACTIVITIES.EDIT) ?? false;
     const canReview =
       ctx?.user?.permissions?.includes(PERMISSIONS.ACTIVITIES.REVIEW) ?? false;
-    const [related, reviewLookups] = await Promise.all([
+    const [related, reviewLookups, reviewExemptFieldKeys] = await Promise.all([
       this.fetchRelatedForActivityIds(activityIds, activityResults),
       canReview ? this.getReviewDiffLookups() : Promise.resolve(undefined),
+      canReview
+        ? this.getEffectiveReviewExemptFieldKeys()
+        : Promise.resolve(undefined),
     ]);
     const { namesMap: categoriesMap, idsMap: categoryIdsMap } =
       related.categoriesResult;
@@ -1639,7 +1672,8 @@ export class ActivitiesService {
             response,
             activity.reviewedFieldSnapshot,
             activity.reviewedFieldSnapshotVersion,
-            reviewLookups
+            reviewLookups,
+            reviewExemptFieldKeys
           );
       }
       return response;
@@ -1699,9 +1733,12 @@ export class ActivitiesService {
     // Fetch related data
     const canReview =
       ctx?.user?.permissions?.includes(PERMISSIONS.ACTIVITIES.REVIEW) ?? false;
-    const [related, reviewLookups] = await Promise.all([
+    const [related, reviewLookups, reviewExemptFieldKeys] = await Promise.all([
       this.fetchRelatedForActivityIds([id], [activity]),
       canReview ? this.getReviewDiffLookups() : Promise.resolve(undefined),
+      canReview
+        ? this.getEffectiveReviewExemptFieldKeys()
+        : Promise.resolve(undefined),
     ]);
     const commsContacts = related.commsContactsMap.get(id) ?? [];
     const hasEditPermission =
@@ -1726,7 +1763,8 @@ export class ActivitiesService {
         response,
         activity.reviewedFieldSnapshot,
         activity.reviewedFieldSnapshotVersion,
-        reviewLookups
+        reviewLookups,
+        reviewExemptFieldKeys
       );
     }
 

--- a/calendar-service/src/locks/application-settings.service.ts
+++ b/calendar-service/src/locks/application-settings.service.ts
@@ -5,10 +5,13 @@ import { applicationSettings } from '@corpcal/database/schema';
 import {
   ACTIVITY_COMPLETION_BUFFER_KEY,
   ACTIVITY_COMPLETION_SCHEDULE_KEY,
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET,
+  ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING,
   COMPLETION_BUFFER_OPTIONS,
   COMPLETION_SCHEDULES,
   DEFAULT_COMPLETION_BUFFER_MINUTES,
   DEFAULT_COMPLETION_SCHEDULE,
+  DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS,
   invalidStoredLookAheadResetWindowDays,
   LOOK_AHEAD_RESET_WINDOW_DAYS_KEY,
   MAX_LOOK_AHEAD_RESET_WINDOW_DAYS,
@@ -181,6 +184,75 @@ export class ApplicationSettingsService {
         target: applicationSettings.key,
         set: {
           value: String(windowDaysAfterToday),
+          updatedAt: now,
+        },
+      });
+  }
+
+  // --------------------------------------------------------------------------
+  // Review-exempt form fields (admin-configurable, JSON array in value)
+  // --------------------------------------------------------------------------
+
+  async getReviewExemptFieldKeys(
+    executor: DrizzleDbExecutor = this.databaseService.db
+  ): Promise<string[]> {
+    const [row] = await executor
+      .select()
+      .from(applicationSettings)
+      .where(
+        eq(applicationSettings.key, ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING)
+      )
+      .limit(1);
+
+    if (!row?.value) {
+      return [...DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS];
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(row.value);
+      if (!Array.isArray(parsed)) {
+        this.logger.warn(
+          `Invalid ${ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING} (not array), using default`
+        );
+        return [...DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS];
+      }
+      const out: string[] = [];
+      for (const item of parsed) {
+        if (
+          typeof item === 'string' &&
+          ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET.has(item)
+        ) {
+          out.push(item);
+        }
+      }
+      return out.length > 0
+        ? out
+        : [...DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS];
+    } catch {
+      this.logger.warn(
+        `Invalid JSON for ${ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING}, using default`
+      );
+      return [...DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS];
+    }
+  }
+
+  async setReviewExemptFieldKeys(fieldKeys: string[]): Promise<void> {
+    const filtered = fieldKeys.filter((k) =>
+      ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET.has(k)
+    );
+    const unique = [...new Set(filtered)];
+    const now = new Date();
+    await this.databaseService.db
+      .insert(applicationSettings)
+      .values({
+        key: ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING,
+        value: JSON.stringify(unique),
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: applicationSettings.key,
+        set: {
+          value: JSON.stringify(unique),
           updatedAt: now,
         },
       });

--- a/calendar-service/src/locks/locks.module.ts
+++ b/calendar-service/src/locks/locks.module.ts
@@ -8,6 +8,7 @@ import { LockHandoffDeadlineKickService } from './lock-handoff-deadline-kick.ser
 import { LockHandoffPoller } from './lock-handoff-poller.service';
 import { LocksController } from './locks.controller';
 import { LocksService } from './locks.service';
+import { ReviewExemptFieldsController } from './review-exempt-fields.controller';
 
 @Module({
   imports: [DatabaseModule, AuthModule, forwardRef(() => ActivitiesModule)],
@@ -17,7 +18,7 @@ import { LocksService } from './locks.service';
     LocksService,
     LockHandoffPoller,
   ],
-  controllers: [LocksController],
+  controllers: [LocksController, ReviewExemptFieldsController],
   exports: [LocksService, ApplicationSettingsService],
 })
 export class LocksModule {}

--- a/calendar-service/src/locks/review-exempt-fields.controller.ts
+++ b/calendar-service/src/locks/review-exempt-fields.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { PERMISSIONS } from '@corpcal/shared';
+import {
+  reviewExemptFieldKeysSettingsSchema,
+  type ReviewExemptFieldKeysSettings,
+} from '@corpcal/shared/schemas';
+
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { RequirePermission } from '../policy/decorators/require-permission.decorator';
+import { ApplicationSettingsService } from './application-settings.service';
+
+@ApiTags('settings')
+@Controller('settings/review-exempt-fields')
+@UseGuards(JwtAuthGuard)
+export class ReviewExemptFieldsController {
+  constructor(
+    private readonly applicationSettings: ApplicationSettingsService
+  ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get admin-configurable review-exempt form field keys',
+  })
+  @ApiResponse({ status: 200, description: 'Field keys' })
+  @HttpCode(HttpStatus.OK)
+  @RequirePermission(PERMISSIONS.SETTINGS.MANAGE_REVIEW_EXEMPT_FIELDS)
+  async getSettings(): Promise<{
+    success: true;
+    data: ReviewExemptFieldKeysSettings;
+  }> {
+    const fieldKeys = await this.applicationSettings.getReviewExemptFieldKeys();
+    return { success: true, data: { fieldKeys } };
+  }
+
+  @Patch()
+  @ApiOperation({ summary: 'Update review-exempt form field keys' })
+  @ApiResponse({ status: 200, description: 'Updated keys' })
+  @HttpCode(HttpStatus.OK)
+  @RequirePermission(PERMISSIONS.SETTINGS.MANAGE_REVIEW_EXEMPT_FIELDS)
+  async patchSettings(
+    @Body(new ZodValidationPipe(reviewExemptFieldKeysSettingsSchema))
+    body: ReviewExemptFieldKeysSettings
+  ): Promise<{ success: true; data: ReviewExemptFieldKeysSettings }> {
+    await this.applicationSettings.setReviewExemptFieldKeys(body.fieldKeys);
+    return { success: true, data: { fieldKeys: body.fieldKeys } };
+  }
+}

--- a/calendar-ui/src/api/reviewExemptSettingsApi.ts
+++ b/calendar-ui/src/api/reviewExemptSettingsApi.ts
@@ -1,0 +1,21 @@
+import type { ReviewExemptFieldKeysSettings } from '@corpcal/shared/schemas';
+
+import api from './axios';
+
+export async function fetchReviewExemptFieldSettings(): Promise<ReviewExemptFieldKeysSettings> {
+  const res = await api.get<{
+    success: boolean;
+    data: ReviewExemptFieldKeysSettings;
+  }>('/settings/review-exempt-fields');
+  return res.data.data;
+}
+
+export async function patchReviewExemptFieldSettings(
+  body: ReviewExemptFieldKeysSettings
+): Promise<ReviewExemptFieldKeysSettings> {
+  const res = await api.patch<{
+    success: boolean;
+    data: ReviewExemptFieldKeysSettings;
+  }>('/settings/review-exempt-fields', body);
+  return res.data.data;
+}

--- a/calendar-ui/src/components/admin/ADMIN_ARCHITECTURE.md
+++ b/calendar-ui/src/components/admin/ADMIN_ARCHITECTURE.md
@@ -386,6 +386,15 @@ All components follow WCAG 2.1 AA standards:
 - ✅ ARIA labels
 - ✅ Color contrast ratios
 
+## System settings (non–lookup) sections
+
+The Settings page also includes **infrastructure and workflow** admin blocks that are not built with `GenericLookupAdmin`, for example:
+
+- `BannerSettingsAdmin`, `EditLockIdleSettingsAdmin`, `ActivityCompletionSettingsAdmin`
+- `ReviewExemptFieldsSettingsAdmin` — which top-level activity form fields are **review-exempt** (see `calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md` and `packages/shared/src/review-exempt-settings.ts`).
+
+When adding a similar custom section, follow the existing pattern: `AdminSection` + `usePermission` + TanStack Query + API module under `src/api/`.
+
 ## Future Enhancements
 
 1. **Bulk operations** - Select multiple items for batch delete/update

--- a/calendar-ui/src/components/admin/ReviewExemptFieldsSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/ReviewExemptFieldsSettingsAdmin.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -17,12 +18,26 @@ import {
 } from '@/api/reviewExemptSettingsApi';
 import { AdminSection } from '@/components/admin';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxSeparator,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '@/components/ui/combobox';
 import { usePermission } from '@/hooks/usePermissions';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { showErrorToast, showSuccessToast } from '@/lib/error-toast';
-import { cn } from '@/lib/utils';
+import type { OptionItem } from '@/schemas/types';
 
 const DESCRIPTION =
   'Choose which form fields can change without moving a Reviewed activity to Changed. ' +
@@ -30,10 +45,31 @@ const DESCRIPTION =
 
 export function ReviewExemptFieldsSettingsAdmin(): ReactElement | null {
   const queryClient = useQueryClient();
+  const comboboxAnchorRef = useComboboxAnchor();
   const canManage = usePermission(
     PERMISSIONS.SETTINGS.MANAGE_REVIEW_EXEMPT_FIELDS
   );
   const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const { allFieldOptions, sectionsWithOptions } = useMemo(() => {
+    const sections = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.map(
+      (section) => ({
+        id: section.id,
+        title: section.title,
+        options: section.keys.map((key) => {
+          const k = String(key);
+          return {
+            value: k,
+            label: getActivityFieldLabel(k),
+          } satisfies OptionItem;
+        }),
+      })
+    );
+    return {
+      sectionsWithOptions: sections,
+      allFieldOptions: sections.flatMap((s) => s.options),
+    };
+  }, []);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['settings', 'review-exempt-fields'],
@@ -65,16 +101,13 @@ export function ReviewExemptFieldsSettingsAdmin(): ReactElement | null {
     return false;
   }, [data, initial, selected]);
 
-  const toggleKey = useCallback((key: string, checked: boolean) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (checked) {
-        next.add(key);
-      } else {
-        next.delete(key);
-      }
-      return next;
-    });
+  const selectedOptions = useMemo(
+    () => allFieldOptions.filter((o) => selected.has(o.value)),
+    [allFieldOptions, selected]
+  );
+
+  const onExemptFieldsChange = useCallback((opts: OptionItem[]) => {
+    setSelected(new Set(opts.map((o) => o.value)));
   }, []);
 
   const saveMutation = useMutation({
@@ -100,7 +133,13 @@ export function ReviewExemptFieldsSettingsAdmin(): ReactElement | null {
       headerAction={
         <Button
           type="button"
-          onClick={() => saveMutation.mutate({ fieldKeys: [...selected] })}
+          onClick={() =>
+            saveMutation.mutate({
+              fieldKeys: allFieldOptions
+                .filter((o) => selected.has(o.value))
+                .map((o) => o.value),
+            })
+          }
           disabled={!hasChanges || saveMutation.isPending}
         >
           Save
@@ -111,40 +150,50 @@ export function ReviewExemptFieldsSettingsAdmin(): ReactElement | null {
         <p className="text-destructive text-sm">Could not load settings.</p>
       )}
       {!isLoading && !error && data && (
-        <div className="max-w-4xl space-y-8">
-          {ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.map((section) => (
-            <div key={section.id} className="space-y-3">
-              <h3 className="text-foreground text-sm font-semibold">
-                {section.title}
-              </h3>
-              <div
-                className={cn(
-                  'grid grid-cols-1 gap-3 sm:grid-cols-2',
-                  'md:grid-cols-2 lg:max-w-3xl'
+        <div className="max-w-4xl">
+          <Combobox
+            items={allFieldOptions}
+            multiple
+            value={selectedOptions}
+            onValueChange={onExemptFieldsChange}
+            itemToStringValue={(o) => o.label}
+            disabled={saveMutation.isPending}
+          >
+            <ComboboxChips ref={comboboxAnchorRef} className="w-full">
+              <ComboboxValue>
+                {(values: OptionItem[]) => (
+                  <>
+                    {values.map((option) => (
+                      <ComboboxChip key={option.value}>
+                        {option.label}
+                      </ComboboxChip>
+                    ))}
+                    <ComboboxChipsInput placeholder="Search or add exempt fields..." />
+                  </>
                 )}
-              >
-                {section.keys.map((key) => {
-                  const k = String(key);
-                  return (
-                    <div key={k} className="flex items-center gap-2">
-                      <Checkbox
-                        id={`review-exempt-${section.id}-${k}`}
-                        checked={selected.has(k)}
-                        onCheckedChange={(c) => toggleKey(k, c === true)}
-                        disabled={saveMutation.isPending}
-                      />
-                      <Label
-                        htmlFor={`review-exempt-${section.id}-${k}`}
-                        className="text-sm leading-none font-normal"
-                      >
-                        {getActivityFieldLabel(k)}
-                      </Label>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+              </ComboboxValue>
+            </ComboboxChips>
+            <ComboboxContent anchor={comboboxAnchorRef} className="max-h-72">
+              <ComboboxEmpty>No fields match.</ComboboxEmpty>
+              <ComboboxList>
+                {sectionsWithOptions.map((section, idx) => (
+                  <Fragment key={section.id}>
+                    {idx > 0 ? <ComboboxSeparator className="my-1" /> : null}
+                    <ComboboxGroup items={section.options}>
+                      <ComboboxLabel>{section.title}</ComboboxLabel>
+                      <ComboboxCollection>
+                        {(option: OptionItem) => (
+                          <ComboboxItem key={option.value} value={option}>
+                            {option.label}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxCollection>
+                    </ComboboxGroup>
+                  </Fragment>
+                ))}
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
         </div>
       )}
     </AdminSection>

--- a/calendar-ui/src/components/admin/ReviewExemptFieldsSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/ReviewExemptFieldsSettingsAdmin.tsx
@@ -1,0 +1,152 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+} from 'react';
+
+import {
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS,
+  PERMISSIONS,
+} from '@corpcal/shared';
+import {
+  fetchReviewExemptFieldSettings,
+  patchReviewExemptFieldSettings,
+} from '@/api/reviewExemptSettingsApi';
+import { AdminSection } from '@/components/admin';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { usePermission } from '@/hooks/usePermissions';
+import { getActivityFieldLabel } from '@/lib/activity-form-labels';
+import { showErrorToast, showSuccessToast } from '@/lib/error-toast';
+import { cn } from '@/lib/utils';
+
+const DESCRIPTION =
+  'Choose which form fields can change without moving a Reviewed activity to Changed. ' +
+  'Summary and scheduling fields (e.g. dates, times, date/time status) are always exempt and are not listed here.';
+
+export function ReviewExemptFieldsSettingsAdmin(): ReactElement | null {
+  const queryClient = useQueryClient();
+  const canManage = usePermission(
+    PERMISSIONS.SETTINGS.MANAGE_REVIEW_EXEMPT_FIELDS
+  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['settings', 'review-exempt-fields'],
+    queryFn: fetchReviewExemptFieldSettings,
+    retry: false,
+    enabled: canManage,
+  });
+
+  useEffect(() => {
+    if (data?.fieldKeys) {
+      setSelected(new Set([...data.fieldKeys]));
+    }
+  }, [data]);
+
+  const initial = useMemo(
+    () => (data ? new Set([...data.fieldKeys]) : new Set<string>()),
+    [data]
+  );
+
+  const hasChanges = useMemo(() => {
+    if (!data) return false;
+    if (initial.size !== selected.size) return true;
+    for (const k of initial) {
+      if (!selected.has(k)) return true;
+    }
+    for (const k of selected) {
+      if (!initial.has(k)) return true;
+    }
+    return false;
+  }, [data, initial, selected]);
+
+  const toggleKey = useCallback((key: string, checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const saveMutation = useMutation({
+    mutationFn: patchReviewExemptFieldSettings,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['settings', 'review-exempt-fields'],
+      });
+      showSuccessToast('Review-exempt field settings updated');
+    },
+    onError: (err: unknown) => {
+      showErrorToast(err);
+    },
+  });
+
+  if (!canManage) return null;
+
+  return (
+    <AdminSection
+      title="Review-exempt activity fields"
+      description={DESCRIPTION}
+      isLoading={isLoading}
+      headerAction={
+        <Button
+          type="button"
+          onClick={() => saveMutation.mutate({ fieldKeys: [...selected] })}
+          disabled={!hasChanges || saveMutation.isPending}
+        >
+          Save
+        </Button>
+      }
+    >
+      {error && (
+        <p className="text-destructive text-sm">Could not load settings.</p>
+      )}
+      {!isLoading && !error && data && (
+        <div className="max-w-4xl space-y-8">
+          {ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.map((section) => (
+            <div key={section.id} className="space-y-3">
+              <h3 className="text-foreground text-sm font-semibold">
+                {section.title}
+              </h3>
+              <div
+                className={cn(
+                  'grid grid-cols-1 gap-3 sm:grid-cols-2',
+                  'md:grid-cols-2 lg:max-w-3xl'
+                )}
+              >
+                {section.keys.map((key) => {
+                  const k = String(key);
+                  return (
+                    <div key={k} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`review-exempt-${section.id}-${k}`}
+                        checked={selected.has(k)}
+                        onCheckedChange={(c) => toggleKey(k, c === true)}
+                        disabled={saveMutation.isPending}
+                      />
+                      <Label
+                        htmlFor={`review-exempt-${section.id}-${k}`}
+                        className="text-sm leading-none font-normal"
+                      >
+                        {getActivityFieldLabel(k)}
+                      </Label>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </AdminSection>
+  );
+}

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import {
   Eraser,
   FileText,
   FolderTree,
+  ListChecks,
   Lock,
   MapPin,
   Megaphone,
@@ -31,12 +32,14 @@ import {
   ThemesAdmin,
   VenuePresetsAdmin,
 } from '@/components/admin/LookupAdmins';
+import { ReviewExemptFieldsSettingsAdmin } from '@/components/admin/ReviewExemptFieldsSettingsAdmin';
 
 type Section =
   | 'banner'
   | 'edit-lock-idle'
   | 'activity-completion'
   | 'look-ahead-reset'
+  | 'review-exempt-fields'
   | 'ministry-groups'
   | 'categories'
   | 'cities'
@@ -64,6 +67,11 @@ const sections = [
     id: 'look-ahead-reset' as Section,
     label: 'Look Ahead reset',
     icon: Eraser,
+  },
+  {
+    id: 'review-exempt-fields' as Section,
+    label: 'Review-exempt fields',
+    icon: ListChecks,
   },
   {
     id: 'ministry-groups' as Section,
@@ -162,6 +170,10 @@ export function Settings() {
 
           <div id="section-look-ahead-reset">
             <LookAheadResetSettingsAdmin />
+          </div>
+
+          <div id="section-review-exempt-fields">
+            <ReviewExemptFieldsSettingsAdmin />
           </div>
 
           <div id="section-ministry-groups">

--- a/packages/database/seeds/0010_20260422_review_exempt_fields_seed.sql
+++ b/packages/database/seeds/0010_20260422_review_exempt_fields_seed.sql
@@ -1,0 +1,27 @@
+-- Review-exempt field settings: permission (System Admin only) + default application_settings row
+-- Idempotent: uses ON CONFLICT where applicable
+
+-- ============================================================================
+-- NEW PERMISSION
+-- settings.manage.review_exempt_fields - configure review-exempt activity form fields
+-- ============================================================================
+
+INSERT INTO permissions (key, display_name, category, subcategory, resource, action, sort_order) VALUES
+  ('settings.manage.review_exempt_fields', 'Manage review-exempt activity fields', 'Settings', 'Admin', 'settings', 'manage', 63)
+ON CONFLICT (key) DO NOTHING;
+
+-- System Admin only (not granted to Admin role)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'System Admin' AND p.key = 'settings.manage.review_exempt_fields'
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+-- Default configurable review-exempt keys (JSON array; must match DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS in @corpcal/shared)
+INSERT INTO application_settings (key, value, updated_at)
+VALUES (
+  'activity_review_exempt_field_keys',
+  '["visibility","sharedWithTeamIds"]',
+  now()
+)
+ON CONFLICT (key) DO NOTHING;

--- a/packages/database/src/schema/docs/SCHEMA_README.md
+++ b/packages/database/src/schema/docs/SCHEMA_README.md
@@ -30,6 +30,10 @@ These are **hand-maintained** (see file headers in `packages/shared`). They defi
 
 Field transformations (dates/times as ISO strings, etc.) are implemented in the service mapper, not by a generated `drizzle-zod` pipeline.
 
+#### Review-exempt form fields (workflow, not a separate table)
+
+`application_settings` stores an optional key `activity_review_exempt_field_keys` (JSON array of top-level form field names). That list is **not** part of the Drizzle `activities` table; it configures which fields System Admins may mark as review-exempt. Shared allowlist and product rules: `packages/shared/src/review-exempt-settings.ts`. **When you add or change top-level activity form fields,** update that file (and the field playbook) as described in [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](../../../../../calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md) in `calendar-service/docs`.
+
 #### Recent database-facing changes
 
 See [SCHEMA_CHANGELOG.md](./SCHEMA_CHANGELOG.md) (e.g. nullable `significance`, category rules on create).

--- a/packages/shared/src/auth/constants.ts
+++ b/packages/shared/src/auth/constants.ts
@@ -141,6 +141,11 @@ export const PERMISSIONS = {
     MANAGE_ACTIVITY_COMPLETE: 'settings.manage.activity_complete',
     /** Configure Look Ahead status reset window and run manual clear. */
     MANAGE_LOOK_AHEAD_RESET: 'settings.manage.look_ahead_reset',
+    /**
+     * Configure which top-level activity form fields are review-exempt (in addition
+     * to product-defined code-exempt fields). System Admin only.
+     */
+    MANAGE_REVIEW_EXEMPT_FIELDS: 'settings.manage.review_exempt_fields',
   },
   SYSTEM: {
     VIEW_LOGS: 'system.view_logs',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './activity-filter-state';
 export * from './activity-completion';
 export * from './look-ahead-reset';
+export * from './review-exempt-settings';
 export * from './schemas';
 export * from './utils';
 

--- a/packages/shared/src/review-exempt-settings.ts
+++ b/packages/shared/src/review-exempt-settings.ts
@@ -1,0 +1,147 @@
+import type { ActivityFormData } from './schemas/activity.schema';
+
+/**
+ * `application_settings.key` for JSON array of admin-configurable review-exempt
+ * top-level form field names.
+ */
+export const ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS_SETTING =
+  'activity_review_exempt_field_keys' as const;
+
+/**
+ * When no row exists or JSON is invalid, the server and diff defaults use this
+ * list (must match the seed in packages/database/seeds).
+ */
+export const DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS = [
+  'visibility',
+  'sharedWithTeamIds',
+] as const satisfies ReadonlyArray<keyof ActivityFormData>;
+
+/**
+ * Top-level form keys that are always review-exempt (not admin-toggleable).
+ * Merged with configurable keys from application settings.
+ */
+export const ACTIVITY_REVIEW_EXEMPT_CODE_KEYS: ReadonlySet<string> = new Set([
+  'summary',
+  'startDate',
+  'endDate',
+  'startTime',
+  'endTime',
+  'isAllDay',
+  'dateStatusId',
+  'timeStatusId',
+  'venueStatusId',
+  'pitchDate',
+]);
+
+/**
+ * Admin UI + server allowlist, grouped to mirror {@link ActivityFormBody} section
+ * order (left: Overview, Comms; right: Reports, Schedule, Event, Sharing).
+ * Keep in sync when form sections or top-level field sets change.
+ */
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS = [
+  {
+    id: 'overview' as const,
+    title: 'Overview',
+    keys: [
+      'title',
+      'categoryIds',
+      'tagIds',
+      'leadTeamId',
+      'leadOrgId',
+      'significance',
+      'isIssue',
+      'isConfidential',
+      'notes',
+      'pitchRequiredStatusId',
+    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
+  },
+  {
+    id: 'comms' as const,
+    title: 'Comms',
+    keys: [
+      'commsContacts',
+      'strategy',
+      'commsMaterialIds',
+      'newsReleaseId',
+      'newsReleaseOriginId',
+      'newsReleaseDistributionId',
+      'translationsRequiredStatusId',
+      'translationLanguageIds',
+    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
+  },
+  {
+    id: 'reports' as const,
+    title: 'Reports',
+    keys: [
+      'reportSettings',
+      'executiveSummary',
+      'lookAheadStatus',
+      'lookAheadSection',
+    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
+  },
+  {
+    id: 'schedule' as const,
+    title: 'Schedule',
+    keys: ['schedulingNotes'] as const satisfies ReadonlyArray<
+      keyof ActivityFormData
+    >,
+  },
+  {
+    id: 'event' as const,
+    title: 'Event',
+    keys: [
+      'venueAddress',
+      'premierRequestedId',
+      'representatives',
+      'eventPlanners',
+    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
+  },
+  {
+    id: 'sharing' as const,
+    title: 'Sharing',
+    keys: ['visibility', 'sharedWithTeamIds'] as const satisfies ReadonlyArray<
+      keyof ActivityFormData
+    >,
+  },
+] as const;
+
+const CONFIGURABLE_FLAT: string[] = [];
+for (const s of ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS) {
+  for (const k of s.keys) {
+    CONFIGURABLE_FLAT.push(k);
+  }
+}
+
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET: ReadonlySet<string> =
+  new Set(CONFIGURABLE_FLAT);
+
+/** Flat allowlist in stable order (section order) for zod/validation. */
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS: readonly string[] =
+  CONFIGURABLE_FLAT;
+
+const ZOD_ENUM = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS as [
+  string,
+  ...string[],
+];
+
+/**
+ * Merges code-exempt keys with allowlisted configurable keys (typically from DB).
+ * Unknown strings are dropped.
+ */
+export function buildEffectiveReviewExemptKeys(
+  configurableFromDb: readonly string[]
+): Set<string> {
+  const out = new Set<string>(ACTIVITY_REVIEW_EXEMPT_CODE_KEYS);
+  for (const k of configurableFromDb) {
+    if (ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET.has(k)) {
+      out.add(k);
+    }
+  }
+  return out;
+}
+
+/**
+ * For `z.enum` — all configurable keys as a non-empty string tuple.
+ */
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_ENUM_TUPLE =
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS as [string, ...string[]];

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -10,6 +10,7 @@ export * from './lookup.schema';
 export * from './ministry-groups.schema';
 export * from './report-config.schema';
 export * from './query-params.schema';
+export * from './review-exempt-field-keys.schema';
 export * from './saved-filter.schema';
 export * from './user.schema';
 export * from './team.schema';

--- a/packages/shared/src/schemas/review-exempt-field-keys.schema.ts
+++ b/packages/shared/src/schemas/review-exempt-field-keys.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_ENUM_TUPLE } from '../review-exempt-settings';
+
+const KEY_ENUM = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_ENUM_TUPLE;
+
+/**
+ * Read/update payload: unique allowlisted top-level form keys (admin only).
+ * Order is not significant; the transform de-duplicates.
+ */
+export const reviewExemptFieldKeysSettingsSchema = z
+  .object({
+    fieldKeys: z.array(z.enum(KEY_ENUM)).transform((arr) => [...new Set(arr)]),
+  })
+  .strict();
+
+export type ReviewExemptFieldKeysSettings = z.infer<
+  typeof reviewExemptFieldKeysSettingsSchema
+>;

--- a/packages/shared/src/utils/activity-review-diff.spec.ts
+++ b/packages/shared/src/utils/activity-review-diff.spec.ts
@@ -128,12 +128,12 @@ describe('diffReviewFields', () => {
     );
   });
 
-  it('empty baseline vs filled form flags all user fields', () => {
+  it('empty baseline vs filled form flags non–code-exempt user fields', () => {
     const baseline = getEmptyReviewBaseline();
     const form = minimalForm({ title: 'Test', summary: 'Desc' });
     const result = diffReviewFields(form, baseline);
     expect(result).toContain('title');
-    expect(result).toContain('summary');
+    expect(result).not.toContain('summary');
     expect(result).toContain('categoryIds');
     expect(result).toContain('leadTeamId');
   });

--- a/packages/shared/src/utils/activity-review-diff.spec.ts
+++ b/packages/shared/src/utils/activity-review-diff.spec.ts
@@ -171,14 +171,6 @@ describe('diffReviewFields', () => {
       );
     });
 
-    it('detects sharedWithTeamIds change', () => {
-      const baseline = minimalForm({ sharedWithTeamIds: [] });
-      const current = minimalForm({ sharedWithTeamIds: [30] });
-      expect(diffReviewFields(current, baseline)).toContain(
-        'sharedWithTeamIds'
-      );
-    });
-
     it('does not flag junction fields when both empty', () => {
       const baseline = minimalForm({
         commsMaterialIds: [],
@@ -193,6 +185,39 @@ describe('diffReviewFields', () => {
       const result = diffReviewFields(current, baseline);
       expect(result).not.toContain('commsMaterialIds');
       expect(result).not.toContain('translationLanguageIds');
+      expect(result).not.toContain('sharedWithTeamIds');
+    });
+  });
+
+  describe('review-impact exempt fields', () => {
+    it('does not flag sharedWithTeamIds changes', () => {
+      const baseline = minimalForm({ sharedWithTeamIds: [] });
+      const current = minimalForm({ sharedWithTeamIds: [30, 31] });
+      expect(diffReviewFields(current, baseline)).not.toContain(
+        'sharedWithTeamIds'
+      );
+    });
+
+    it('does not flag visibility changes', () => {
+      const baseline = minimalForm({ visibility: 'global' });
+      const current = minimalForm({ visibility: 'team' });
+      expect(diffReviewFields(current, baseline)).not.toContain('visibility');
+    });
+
+    it('still flags non-exempt changes alongside exempt changes', () => {
+      const baseline = minimalForm({
+        title: 'Original',
+        visibility: 'global',
+        sharedWithTeamIds: [],
+      });
+      const current = minimalForm({
+        title: 'Updated',
+        visibility: 'team',
+        sharedWithTeamIds: [30],
+      });
+      const result = diffReviewFields(current, baseline);
+      expect(result).toContain('title');
+      expect(result).not.toContain('visibility');
       expect(result).not.toContain('sharedWithTeamIds');
     });
   });

--- a/packages/shared/src/utils/activity-review-diff.ts
+++ b/packages/shared/src/utils/activity-review-diff.ts
@@ -17,6 +17,20 @@ const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Top-level {@link ActivityFormData} keys that editors may change without
+ * counting as a "review impact": they do not appear in
+ * {@link diffReviewFields} output and do not flip a Reviewed activity to
+ * Changed on save. Editors still see RHF dirty state and "Changed" badges for
+ * these fields; the exemption is purely about review workflow.
+ *
+ * Extend this set when product expands the rule to additional fields.
+ */
+export const ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS: ReadonlySet<string> = new Set([
+  'visibility',
+  'sharedWithTeamIds',
+]);
+
+/**
  * Canonical empty baseline representing a brand-new form with no data.
  * Used when no prior Reviewed snapshot exists (e.g. New activities).
  */
@@ -119,6 +133,7 @@ export function diffReviewFields(
 
   for (const key of allKeys) {
     if (EXCLUDED_FIELDS.has(key)) continue;
+    if (ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS.has(key)) continue;
 
     const curVal = (currentCanon as Record<string, unknown>)[key];
     const baseVal = (baselineCanon as Record<string, unknown>)[key];

--- a/packages/shared/src/utils/activity-review-diff.ts
+++ b/packages/shared/src/utils/activity-review-diff.ts
@@ -1,3 +1,7 @@
+import {
+  buildEffectiveReviewExemptKeys,
+  DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS,
+} from '../review-exempt-settings';
 import type { ActivityFormData } from '../schemas/activity.schema';
 import { canonicalizeActivityFormData } from './activity-form-canonicalize';
 import { normalizeVenueAddressForForm } from './activity-form-mapper';
@@ -16,19 +20,13 @@ const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   'leadMinistryId',
 ]);
 
-/**
- * Top-level {@link ActivityFormData} keys that editors may change without
- * counting as a "review impact": they do not appear in
- * {@link diffReviewFields} output and do not flip a Reviewed activity to
- * Changed on save. Editors still see RHF dirty state and "Changed" badges for
- * these fields; the exemption is purely about review workflow.
- *
- * Extend this set when product expands the rule to additional fields.
- */
-export const ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS: ReadonlySet<string> = new Set([
-  'visibility',
-  'sharedWithTeamIds',
-]);
+export type DiffReviewFieldsOptions = {
+  /** Merged set of code + admin review-exempt top-level form keys. */
+  exemptFieldKeys: ReadonlySet<string>;
+};
+
+const DEFAULT_REVIEW_EXEMPT_FOR_DIFF: ReadonlySet<string> =
+  buildEffectiveReviewExemptKeys(DEFAULT_CONFIGURABLE_REVIEW_EXEMPT_FIELD_KEYS);
 
 /**
  * Canonical empty baseline representing a brand-new form with no data.
@@ -120,8 +118,12 @@ function sortObjectArray<T extends Record<string, unknown>>(
  */
 export function diffReviewFields(
   current: ActivityFormData,
-  baseline: ActivityFormData
+  baseline: ActivityFormData,
+  options: DiffReviewFieldsOptions = {
+    exemptFieldKeys: DEFAULT_REVIEW_EXEMPT_FOR_DIFF,
+  }
 ): string[] {
+  const { exemptFieldKeys } = options;
   const changed: string[] = [];
   const currentCanon = canonicalizeActivityFormData(current);
   const baselineCanon = canonicalizeActivityFormData(baseline);
@@ -133,7 +135,7 @@ export function diffReviewFields(
 
   for (const key of allKeys) {
     if (EXCLUDED_FIELDS.has(key)) continue;
-    if (ACTIVITY_REVIEW_EXEMPT_FIELD_KEYS.has(key)) continue;
+    if (exemptFieldKeys.has(key)) continue;
 
     const curVal = (currentCanon as Record<string, unknown>)[key];
     const baseVal = (baselineCanon as Record<string, unknown>)[key];

--- a/packages/shared/src/utils/apply-update-activity-request.spec.ts
+++ b/packages/shared/src/utils/apply-update-activity-request.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ActivityFormData,
+  UpdateActivityRequest,
+} from '../schemas/activity.schema';
+import { applyUpdateActivityRequestToFormData } from './apply-update-activity-request';
+
+function baseForm(overrides: Partial<ActivityFormData> = {}): ActivityFormData {
+  return {
+    title: 'Original',
+    summary: 'Original summary',
+    dateStatusId: 1,
+    timeStatusId: 1,
+    isIssue: false,
+    isAllDay: false,
+    isConfidential: false,
+    visibility: 'global',
+    leadTeamId: 5,
+    categoryIds: [1],
+    sharedWithTeamIds: [],
+    ...overrides,
+  } as ActivityFormData;
+}
+
+describe('applyUpdateActivityRequestToFormData', () => {
+  it('returns a new object without mutating the base', () => {
+    const base = baseForm();
+    const result = applyUpdateActivityRequestToFormData(base, {
+      title: 'Updated',
+    });
+    expect(result).not.toBe(base);
+    expect(base.title).toBe('Original');
+    expect(result.title).toBe('Updated');
+  });
+
+  it('overrides only fields present in the DTO', () => {
+    const base = baseForm({ title: 'Original', summary: 'Keep me' });
+    const result = applyUpdateActivityRequestToFormData(base, {
+      title: 'New',
+    });
+    expect(result.title).toBe('New');
+    expect(result.summary).toBe('Keep me');
+  });
+
+  it('ignores undefined DTO values', () => {
+    const base = baseForm({ title: 'Keep' });
+    const result = applyUpdateActivityRequestToFormData(base, {
+      title: undefined,
+    } as UpdateActivityRequest);
+    expect(result.title).toBe('Keep');
+  });
+
+  it('applies exempt-field changes (visibility, sharedWithTeamIds)', () => {
+    const base = baseForm({ visibility: 'global', sharedWithTeamIds: [] });
+    const result = applyUpdateActivityRequestToFormData(base, {
+      visibility: 'team',
+      sharedWithTeamIds: [10, 11],
+    });
+    expect(result.visibility).toBe('team');
+    expect(result.sharedWithTeamIds).toEqual([10, 11]);
+  });
+
+  it('does not merge workflow-intent keys into the form shape', () => {
+    const base = baseForm();
+    const result = applyUpdateActivityRequestToFormData(base, {
+      markAsReviewed: true,
+      markAsCompleted: false,
+    } as UpdateActivityRequest);
+    expect(
+      (result as unknown as Record<string, unknown>).markAsReviewed
+    ).toBeUndefined();
+    expect(
+      (result as unknown as Record<string, unknown>).markAsCompleted
+    ).toBeUndefined();
+  });
+
+  it('supports replacing arrays wholesale', () => {
+    const base = baseForm({ categoryIds: [1, 2] });
+    const result = applyUpdateActivityRequestToFormData(base, {
+      categoryIds: [3],
+    });
+    expect(result.categoryIds).toEqual([3]);
+  });
+});

--- a/packages/shared/src/utils/apply-update-activity-request.ts
+++ b/packages/shared/src/utils/apply-update-activity-request.ts
@@ -1,0 +1,39 @@
+import type {
+  ActivityFormData,
+  UpdateActivityRequest,
+} from '../schemas/activity.schema';
+
+/**
+ * Keys on {@link UpdateActivityRequest} that are workflow intents rather than
+ * form fields. They must never be merged into the form-data representation
+ * used for review-diff comparisons.
+ */
+const NON_FORM_DTO_KEYS: ReadonlySet<string> = new Set([
+  'markAsReviewed',
+  'markAsCompleted',
+]);
+
+/**
+ * Applies a partial {@link UpdateActivityRequest} on top of a baseline
+ * {@link ActivityFormData} and returns the resulting post-update form shape.
+ *
+ * Used server-side to diff "before" and "after" form representations with
+ * {@link diffReviewFields} using identical normalisation rules, without
+ * needing a second database round-trip to re-hydrate the updated row.
+ *
+ * Only own DTO keys whose value is not `undefined` overwrite the baseline.
+ * Workflow-intent keys ({@link NON_FORM_DTO_KEYS}) are ignored.
+ */
+export function applyUpdateActivityRequestToFormData(
+  base: ActivityFormData,
+  dto: UpdateActivityRequest
+): ActivityFormData {
+  const merged: Record<string, unknown> = { ...base };
+  for (const key of Object.keys(dto)) {
+    if (NON_FORM_DTO_KEYS.has(key)) continue;
+    const value = (dto as Record<string, unknown>)[key];
+    if (value === undefined) continue;
+    merged[key] = value;
+  }
+  return merged as ActivityFormData;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './schema-helpers';
 export * from './activity-form-mapper';
 export * from './activity-form-canonicalize';
 export * from './activity-review-diff';
+export * from './apply-update-activity-request';
 export * from './activity-field-labels';
 export * from './build-review-diff-lookups';
 export * from './report-settings';


### PR DESCRIPTION
# PR: CORPCAL-223 — review-exempt activity fields (stacked)

## Summary

**Stacked PR:** This description matches **only the commits from `ab7e639` through `HEAD`** on top of the parent feature branch (ministry groups / quick-share land elsewhere). It adds **admin-configurable review-exempt form fields**: shared diff + status rules, `application_settings` storage, settings API, and Settings UI. **Reviewed** activities stay **Reviewed** when updates touch only exempt fields (including code-always-exempt keys like schedule-related fields); reviewers see `changedFieldsSinceReview` using the same exempt set.

## Important

- **Base branch:** Merge or review against the underlying feature branch first; this PR does **not** include ministry-groups schema or UI from that stack.
- **Database (this PR):** New seed `packages/database/seeds/0010_20260422_review_exempt_fields_seed.sql` (permission `settings.manage.review_exempt_fields`, default `activity_review_exempt_field_keys`). After pulling with base already applied: `npm run seed -w calendar-service` (or your usual seed pipeline).
- **Packages:** Shared types/schemas/utils changed — `npm run build:packages` if consumers see stale `@corpcal/shared` types.
- **RBAC:** Seed grants the new settings permission to System Admin; non-seeded envs need an explicit grant.


<img width="1159" height="238" alt="Screenshot 2026-04-22 at 4 42 27 PM" src="https://github.com/user-attachments/assets/815118b2-6ac6-476d-8c7b-38663cbf970e" />

Dropdown includes fields that can be exempted (restricted fields not eligible for exemption can be defined in code)
<img width="913" height="352" alt="Screenshot 2026-04-22 at 4 43 15 PM" src="https://github.com/user-attachments/assets/00d5a29a-237e-4ec2-b645-c7b7efc7d9f6" />

## Changes

1. **Shared (`packages/shared`):** `review-exempt-settings.ts` (code vs configurable allowlists, `buildEffectiveReviewExemptKeys`), Zod `review-exempt-field-keys.schema.ts`, `applyUpdateActivityRequestToFormData` + tests, `diffReviewFields` wired to merged exempt keys + tests, `PERMISSIONS.SETTINGS.MANAGE_REVIEW_EXEMPT_FIELDS`.
   - Default configurable exempt keys: `visibility`, `sharedWithTeamIds` (matches seed).

2. **API (`calendar-service`):** `ReviewExemptFieldsController` (`GET`/`PATCH` `/settings/review-exempt-fields`), `ApplicationSettingsService` read/write for JSON field-key array (allowlist-filtered), `ActivitiesService` uses `shouldPreserveReviewedStatus` + DB-driven exempt keys for status and `changedFieldsSinceReview`.
   - Docs: `ACTIVITY_REVIEW_EXEMPT_SETTINGS.md`; updates to `ACTIVITY.md`, `ACTIVITY_REVIEW_SNAPSHOT.md`.

3. **UI (`calendar-ui`):** `ReviewExemptFieldsSettingsAdmin` (multi-select combobox), `reviewExemptSettingsApi`, Settings page section; `ADMIN_ARCHITECTURE.md` touch.

4. **Database docs:** `SCHEMA_README.md` note for `activity_review_exempt_field_keys`.

5. **Tests:** `activities.service.spec.ts` reviewed-gate / exempt-field scenarios; shared specs for review diff and apply-update helper.

## Testing

- `npm run typecheck` (root) — passed (full branch).
- `npm run test --workspace=packages/shared -- --run src/utils/activity-review-diff.spec.ts src/utils/apply-update-activity-request.spec.ts` — passed.
- Recommended: `npm run test --workspace=calendar-service` with focus on `activities.service.spec.ts`; smoke Settings → Review-exempt fields, PATCH settings, then edit a **Reviewed** activity changing only exempt fields and confirm status stays **Reviewed** and reviewer diff omits those paths.