### PR TITLE
fix(config): align dependency build target to es2022

### DIFF
--- a/calendar-ui/vite.config.ts
+++ b/calendar-ui/vite.config.ts
@@ -3,6 +3,11 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig, type PluginOption } from 'vite';
 
+// Dev (optimizeDeps) and prod (build) must use the same esbuild target. Default
+// legacy targets cause "Transforming destructuring ... is not supported yet" when
+// pre-bundling modern dependencies (@base-ui/react, reselect, etc.).
+const buildTarget = 'es2022';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -29,13 +34,16 @@ export default defineConfig({
       },
     },
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: buildTarget,
+    },
+  },
   build: {
     outDir: 'dist',
     sourcemap: true,
-    // React Compiler can emit patterns that esbuild 0.28+ fails to lower for default
-    // legacy targets ("Transforming destructuring ... is not supported yet"). Align
-    // with modern evergreen browsers (see calendar-ui package.json browserslist).
-    target: 'es2022',
+    // React Compiler and deps assume modern runtimes.
+    target: buildTarget,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Summary

The recent fix to add a build target did not include a target for dependencies, resulting in the same build errors related to updating ESBuild to 0.28. This PR adds a build target for dependencies using a constant to keep project and dependency target aligned in the future.

- build.target only affects the production Rollup build
- The dev server still pre-bundles dependencies with esbuild’s default legacy targets
- Set optimizeDeps.esbuildOptions.target to that value so dev pre-bundling matches prod

## Testing

Build and dev server now compile correctly.