### PR TITLE
Feat/corpcal 227 login modal

### DIFF
--- a/calendar-service/src/activities/activities.gateway.ts
+++ b/calendar-service/src/activities/activities.gateway.ts
@@ -321,4 +321,9 @@ export class ActivitiesGateway
   ): void {
     this.server.to(`user:${userId}`).emit('lockHandoffResolved', payload);
   }
+
+  broadcastLoginModalSettingsUpdated(): void {
+    this.logger.log('Broadcasting login modal settings updated');
+    this.server.emit('loginModalSettingsUpdated');
+  }
 }

--- a/calendar-service/src/app.module.ts
+++ b/calendar-service/src/app.module.ts
@@ -18,6 +18,7 @@ import { CorrelationIdMiddleware } from './common/middleware/correlation-id.midd
 import { DatabaseModule } from './database/database.module';
 import { DraftsModule } from './drafts/drafts.module';
 import { LocksModule } from './locks/locks.module';
+import { LoginModalModule } from './login-modal/login-modal.module';
 import { LookAheadResetModule } from './look-ahead-reset/look-ahead-reset.module';
 import { LookAheadModule } from './look-ahead/look-ahead.module';
 import { LookupsModule } from './lookups/lookups.module';
@@ -55,6 +56,7 @@ function resolveRootEnvPath(): string {
     PolicyModule,
     AuthModule,
     BannerModule,
+    LoginModalModule,
     ActivitiesModule,
     ActivityCompletionModule,
     LookAheadResetModule,

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -302,7 +302,14 @@ export class AuthController {
   private getPostLoginRedirectUrl(): string {
     const configuredRedirect = process.env.POST_LOGIN_REDIRECT_URL?.trim();
     const base = configuredRedirect || '/';
-    const separator = base.includes('?') ? '&' : '?';
-    return `${base}${separator}login=1`;
+    // Use a dummy origin so that relative URLs (e.g. '/') are handled by the
+    // URL API. searchParams.set() deduplicates any existing 'login' param.
+    const dummyOrigin = 'https://placeholder.invalid';
+    const url = new URL(base, dummyOrigin);
+    url.searchParams.set('login', '1');
+    // Strip the dummy origin for relative URLs; keep it for absolute URLs.
+    return base.startsWith('http')
+      ? url.toString()
+      : `${url.pathname}${url.search}`;
   }
 }

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -301,6 +301,8 @@ export class AuthController {
 
   private getPostLoginRedirectUrl(): string {
     const configuredRedirect = process.env.POST_LOGIN_REDIRECT_URL?.trim();
-    return configuredRedirect || '/';
+    const base = configuredRedirect || '/';
+    const separator = base.includes('?') ? '&' : '?';
+    return `${base}${separator}login=1`;
   }
 }

--- a/calendar-service/src/common/dto/index.ts
+++ b/calendar-service/src/common/dto/index.ts
@@ -7,5 +7,6 @@ export * from './activity.dto';
 export * from './activity-response.dto';
 export * from './activity-update.dto';
 export * from './banner.dto';
+export * from './login-modal.dto';
 export * from './lookup.dto';
 export * from './health.dto';

--- a/calendar-service/src/common/dto/login-modal.dto.ts
+++ b/calendar-service/src/common/dto/login-modal.dto.ts
@@ -1,0 +1,23 @@
+import { createZodDto } from 'nestjs-zod';
+
+import {
+  createResponseWrapperSchema,
+  loginModalSettingsSchema,
+  upsertLoginModalSettingsRequestSchema,
+} from '@corpcal/shared/schemas';
+
+export class UpsertLoginModalSettingsDto extends createZodDto(
+  upsertLoginModalSettingsRequestSchema
+) {}
+
+export class LoginModalSettingsDto extends createZodDto(
+  loginModalSettingsSchema
+) {}
+
+export class LoginModalSettingsResponseWrapperDto extends createZodDto(
+  createResponseWrapperSchema(loginModalSettingsSchema)
+) {}
+
+export class LoginModalSettingsNullableResponseWrapperDto extends createZodDto(
+  createResponseWrapperSchema(loginModalSettingsSchema.nullable())
+) {}

--- a/calendar-service/src/login-modal/login-modal.controller.spec.ts
+++ b/calendar-service/src/login-modal/login-modal.controller.spec.ts
@@ -1,0 +1,86 @@
+import { ForbiddenException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SYSTEM_ROLE_IDS, type AuthUser } from '@corpcal/shared';
+
+import { UpsertLoginModalSettingsDto } from '../common/dto';
+import { LoginModalController } from './login-modal.controller';
+import { LoginModalService } from './login-modal.service';
+
+describe('LoginModalController', () => {
+  let controller: LoginModalController;
+  const mockLoginModalService: Partial<LoginModalService> = {
+    upsert: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new LoginModalController(
+      mockLoginModalService as unknown as LoginModalService
+    );
+  });
+
+  it('throws ForbiddenException when non-System-Admin attempts to upsert settings', async () => {
+    const body: UpsertLoginModalSettingsDto = {
+      isActive: true,
+      title: 'Notice',
+      content: '<p>Hello</p>',
+      startDateTime: null,
+      endDateTime: null,
+    };
+
+    const nonSystemAdminUser: AuthUser = {
+      id: 1,
+      username: 'user1',
+      displayName: 'User One',
+      email: 'user1@example.com',
+      roleId: 5,
+      roleName: 'Editor',
+      permissions: [],
+      teamIds: [],
+    };
+
+    await expect(
+      controller.upsertSettings(body, nonSystemAdminUser)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('calls upsert and returns wrapped result for System Admin', async () => {
+    const body: UpsertLoginModalSettingsDto = {
+      isActive: true,
+      title: 'Notice',
+      content: '<p>Hello</p>',
+      startDateTime: null,
+      endDateTime: null,
+    };
+
+    const systemAdminUser: AuthUser = {
+      id: 2,
+      username: 'admin',
+      displayName: 'Admin User',
+      email: 'admin@example.com',
+      roleId: SYSTEM_ROLE_IDS.SYSTEM_ADMIN,
+      roleName: 'System Admin',
+      permissions: [],
+      teamIds: [],
+    };
+
+    const mockResult = {
+      id: 1,
+      isActive: true,
+      title: 'Notice',
+      content: '<p>Hello</p>',
+      startDateTime: null,
+      endDateTime: null,
+      createdDateTime: new Date().toISOString(),
+      lastUpdatedDateTime: new Date().toISOString(),
+    };
+
+    vi.mocked(mockLoginModalService.upsert!).mockResolvedValue(mockResult);
+
+    const result = await controller.upsertSettings(body, systemAdminUser);
+
+    expect(result).toEqual({ success: true, data: mockResult });
+    expect(mockLoginModalService.upsert).toHaveBeenCalledWith(body, 2);
+  });
+});

--- a/calendar-service/src/login-modal/login-modal.controller.ts
+++ b/calendar-service/src/login-modal/login-modal.controller.ts
@@ -1,0 +1,84 @@
+import { Body, Controller, ForbiddenException, Get, Put } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import {
+  PERMISSIONS,
+  SYSTEM_ROLE_IDS,
+  type AuthUser,
+  type ResponseWrapper,
+} from '@corpcal/shared';
+import type { LoginModalSettings } from '@corpcal/shared/api/types';
+import { upsertLoginModalSettingsRequestSchema } from '@corpcal/shared/schemas';
+
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  LoginModalSettingsNullableResponseWrapperDto,
+  LoginModalSettingsResponseWrapperDto,
+  UpsertLoginModalSettingsDto,
+} from '../common/dto';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { RequirePermission } from '../policy/decorators/require-permission.decorator';
+import { LoginModalService } from './login-modal.service';
+
+@ApiTags('login-modal')
+@Controller('login-modal')
+export class LoginModalController {
+  constructor(private readonly loginModalService: LoginModalService) {}
+
+  private ensureSystemAdmin(user: AuthUser): void {
+    if (user.roleId !== SYSTEM_ROLE_IDS.SYSTEM_ADMIN) {
+      throw new ForbiddenException(
+        'Only System Admin users can manage the login modal.'
+      );
+    }
+  }
+
+  @ApiOperation({
+    summary: 'Get active login modal',
+    description:
+      'Returns the currently active login modal for authenticated users, or null when none should be shown.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Active login modal retrieved successfully',
+    type: LoginModalSettingsNullableResponseWrapperDto,
+  })
+  @Get()
+  async getActive(): Promise<ResponseWrapper<LoginModalSettings | null>> {
+    const data = await this.loginModalService.getActive();
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Get current login modal settings' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current login modal settings retrieved successfully',
+    type: LoginModalSettingsNullableResponseWrapperDto,
+  })
+  @RequirePermission(PERMISSIONS.SETTINGS.VIEW)
+  @Get('settings')
+  async getSettings(): Promise<ResponseWrapper<LoginModalSettings | null>> {
+    const data = await this.loginModalService.getCurrentSettings();
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Create or update login modal settings' })
+  @ApiResponse({
+    status: 200,
+    description: 'Login modal settings saved successfully',
+    type: LoginModalSettingsResponseWrapperDto,
+  })
+  @ApiBody({ type: UpsertLoginModalSettingsDto })
+  @RequirePermission(PERMISSIONS.SETTINGS.MANAGE)
+  @Put('settings')
+  async upsertSettings(
+    @Body(new ZodValidationPipe(upsertLoginModalSettingsRequestSchema))
+    body: UpsertLoginModalSettingsDto,
+    @CurrentUser() user: AuthUser
+  ): Promise<ResponseWrapper<LoginModalSettings>> {
+    this.ensureSystemAdmin(user);
+
+    const data = await this.loginModalService.upsert(body, user.id);
+    return { success: true, data };
+  }
+}

--- a/calendar-service/src/login-modal/login-modal.module.ts
+++ b/calendar-service/src/login-modal/login-modal.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { ActivitiesModule } from '../activities/activities.module';
 import { DatabaseModule } from '../database/database.module';
 import { LoginModalController } from './login-modal.controller';
 import { LoginModalService } from './login-modal.service';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, ActivitiesModule],
   controllers: [LoginModalController],
   providers: [LoginModalService],
   exports: [LoginModalService],

--- a/calendar-service/src/login-modal/login-modal.module.ts
+++ b/calendar-service/src/login-modal/login-modal.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { DatabaseModule } from '../database/database.module';
+import { LoginModalController } from './login-modal.controller';
+import { LoginModalService } from './login-modal.service';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [LoginModalController],
+  providers: [LoginModalService],
+  exports: [LoginModalService],
+})
+export class LoginModalModule {}

--- a/calendar-service/src/login-modal/login-modal.service.ts
+++ b/calendar-service/src/login-modal/login-modal.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common';
+import { desc, eq } from 'drizzle-orm';
+
+import { loginModalSettings } from '@corpcal/database';
+import type {
+  LoginModalSettings,
+  UpsertLoginModalSettingsBody,
+} from '@corpcal/shared/schemas';
+
+import { DatabaseService } from '../database/database.service';
+
+type LoginModalSettingsRow = typeof loginModalSettings.$inferSelect;
+
+@Injectable()
+export class LoginModalService {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async getCurrentSettings(): Promise<LoginModalSettings | null> {
+    const row = await this.getLatestRow();
+    return row ? this.mapRow(row) : null;
+  }
+
+  async getActive(): Promise<LoginModalSettings | null> {
+    const row = await this.getLatestRow();
+
+    if (!row || !row.isActive) {
+      return null;
+    }
+
+    const now = new Date();
+
+    if (row.startDateTime && row.startDateTime > now) {
+      return null;
+    }
+
+    if (row.endDateTime && row.endDateTime <= now) {
+      return null;
+    }
+
+    return this.mapRow(row);
+  }
+
+  async upsert(
+    body: UpsertLoginModalSettingsBody,
+    userId: number
+  ): Promise<LoginModalSettings> {
+    const now = new Date();
+    const payload = {
+      isActive: body.isActive,
+      title: body.title.trim(),
+      content: body.content.trim(),
+      startDateTime: body.startDateTime ? new Date(body.startDateTime) : null,
+      endDateTime: body.endDateTime ? new Date(body.endDateTime) : null,
+      lastUpdatedDateTime: now,
+      lastUpdatedBy: userId,
+    };
+
+    const existing = await this.getLatestRow();
+
+    if (existing) {
+      const [updated] = await this.databaseService.db
+        .update(loginModalSettings)
+        .set(payload)
+        .where(eq(loginModalSettings.id, existing.id))
+        .returning();
+
+      return this.mapRow(updated);
+    }
+
+    const [created] = await this.databaseService.db
+      .insert(loginModalSettings)
+      .values({
+        ...payload,
+        createdDateTime: now,
+        createdBy: userId,
+      })
+      .returning();
+
+    return this.mapRow(created);
+  }
+
+  private async getLatestRow(): Promise<LoginModalSettingsRow | null> {
+    const [row] = await this.databaseService.db
+      .select()
+      .from(loginModalSettings)
+      .orderBy(
+        desc(loginModalSettings.lastUpdatedDateTime),
+        desc(loginModalSettings.id)
+      )
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  private mapRow(row: LoginModalSettingsRow): LoginModalSettings {
+    return {
+      id: row.id,
+      isActive: row.isActive,
+      title: row.title,
+      content: row.content,
+      startDateTime: row.startDateTime?.toISOString() ?? null,
+      endDateTime: row.endDateTime?.toISOString() ?? null,
+      createdDateTime: row.createdDateTime.toISOString(),
+      lastUpdatedDateTime: row.lastUpdatedDateTime.toISOString(),
+    };
+  }
+}

--- a/calendar-service/src/login-modal/login-modal.service.ts
+++ b/calendar-service/src/login-modal/login-modal.service.ts
@@ -7,13 +7,17 @@ import type {
   UpsertLoginModalSettingsBody,
 } from '@corpcal/shared/schemas';
 
+import { ActivitiesGateway } from '../activities/activities.gateway';
 import { DatabaseService } from '../database/database.service';
 
 type LoginModalSettingsRow = typeof loginModalSettings.$inferSelect;
 
 @Injectable()
 export class LoginModalService {
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly activitiesGateway: ActivitiesGateway
+  ) {}
 
   async getCurrentSettings(): Promise<LoginModalSettings | null> {
     const row = await this.getLatestRow();
@@ -57,6 +61,8 @@ export class LoginModalService {
 
     const existing = await this.getLatestRow();
 
+    let result: LoginModalSettings;
+
     if (existing) {
       const [updated] = await this.databaseService.db
         .update(loginModalSettings)
@@ -64,19 +70,25 @@ export class LoginModalService {
         .where(eq(loginModalSettings.id, existing.id))
         .returning();
 
-      return this.mapRow(updated);
+      result = this.mapRow(updated);
+    } else {
+      const [created] = await this.databaseService.db
+        .insert(loginModalSettings)
+        .values({
+          ...payload,
+          createdDateTime: now,
+          createdBy: userId,
+        })
+        .returning();
+
+      result = this.mapRow(created);
     }
 
-    const [created] = await this.databaseService.db
-      .insert(loginModalSettings)
-      .values({
-        ...payload,
-        createdDateTime: now,
-        createdBy: userId,
-      })
-      .returning();
+    setImmediate(() => {
+      this.activitiesGateway.broadcastLoginModalSettingsUpdated();
+    });
 
-    return this.mapRow(created);
+    return result;
   }
 
   private async getLatestRow(): Promise<LoginModalSettingsRow | null> {

--- a/calendar-service/test/login-modal.api-permissions.spec.ts
+++ b/calendar-service/test/login-modal.api-permissions.spec.ts
@@ -1,0 +1,81 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { createAuthRequest, e2eLogin } from './test-helpers';
+
+describe('Login Modal API permissions', () => {
+  let app: INestApplication;
+  let nonAdminToken: string;
+  let systemAdminToken: string;
+
+  const upsertBody = {
+    isActive: true,
+    title: 'Test Notice',
+    content: 'This is a test notice.',
+    startDateTime: null,
+    endDateTime: null,
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    nonAdminToken = await e2eLogin(app, 'thomas.garcia');
+    systemAdminToken = await e2eLogin(app, 'daniel.robinson');
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /login-modal', () => {
+    it('returns active modal (or null) for authenticated users', async () => {
+      const res = await createAuthRequest(app, nonAdminToken)
+        .get('/login-modal')
+        .expect(200);
+
+      expect(res.body).toHaveProperty('success', true);
+      expect(res.body).toHaveProperty('data');
+    });
+  });
+
+  describe('GET /login-modal/settings', () => {
+    it('allows users with SETTINGS.VIEW permission to read settings', async () => {
+      const res = await createAuthRequest(app, systemAdminToken)
+        .get('/login-modal/settings')
+        .expect(200);
+
+      expect(res.body).toHaveProperty('success', true);
+      expect(res.body).toHaveProperty('data');
+    });
+  });
+
+  describe('PUT /login-modal/settings', () => {
+    it('forbids non-admin users from updating login modal settings', async () => {
+      await createAuthRequest(app, nonAdminToken)
+        .put('/login-modal/settings')
+        .send(upsertBody)
+        .expect(403);
+    });
+
+    it('allows system admins to update login modal settings', async () => {
+      const res = await createAuthRequest(app, systemAdminToken)
+        .put('/login-modal/settings')
+        .send(upsertBody)
+        .expect(200);
+
+      expect(res.body).toHaveProperty('success', true);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body.data).toHaveProperty('title', upsertBody.title);
+      expect(res.body.data).toHaveProperty('content', upsertBody.content);
+      expect(res.body.data).toHaveProperty('isActive', upsertBody.isActive);
+    });
+  });
+});

--- a/calendar-ui/src/App.tsx
+++ b/calendar-ui/src/App.tsx
@@ -1,15 +1,19 @@
 import { Route, Routes } from 'react-router-dom';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
+import type { LoginModalSettings } from '@corpcal/shared/api/types';
 import {
   GlobalErrorBoundary,
   Layout,
+  LoginModal,
   ProtectedRoute,
 } from '@/components/layout';
 
+import { fetchActiveLoginModal } from './api/loginModalApi';
 import { Toaster } from './components/ui/sonner';
 import { AuthProvider } from './contexts/AuthContext';
+import { useAuth } from './hooks/useAuth';
 import { lazyWithRetry } from './lib/lazy-with-retry';
 
 import './styles/App.css';
@@ -57,9 +61,41 @@ const Users = lazyWithRetry(() =>
   import('./pages/UserManagement').then((m) => ({ default: m.Users }))
 );
 
+function LoginModalContainer() {
+  const { isAuthenticated, isLoading, pendingLoginModal, dismissLoginModal } =
+    useAuth();
+  const [modal, setModal] = useState<LoginModalSettings | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || !pendingLoginModal) return;
+    fetchActiveLoginModal()
+      .then((data) => {
+        if (data) {
+          setModal(data);
+          setOpen(true);
+        } else {
+          dismissLoginModal();
+        }
+      })
+      .catch(() => {
+        dismissLoginModal();
+      });
+  }, [isLoading, isAuthenticated, pendingLoginModal, dismissLoginModal]);
+
+  const handleDismiss = () => {
+    setOpen(false);
+    dismissLoginModal();
+  };
+
+  if (!modal) return null;
+  return <LoginModal modal={modal} open={open} onDismiss={handleDismiss} />;
+}
+
 function App() {
   return (
     <AuthProvider>
+      <LoginModalContainer />
       <GlobalErrorBoundary>
         <Toaster position="top-right" />
         <Suspense

--- a/calendar-ui/src/api/loginModalApi.ts
+++ b/calendar-ui/src/api/loginModalApi.ts
@@ -1,0 +1,34 @@
+import type {
+  LoginModalSettings,
+  UpsertLoginModalSettingsBody,
+} from '@corpcal/shared/api/types';
+
+import api from './axios';
+
+type WrappedResponse<T> = {
+  success: true;
+  data: T;
+};
+
+export async function fetchActiveLoginModal(): Promise<LoginModalSettings | null> {
+  const res =
+    await api.get<WrappedResponse<LoginModalSettings | null>>('/login-modal');
+  return res.data.data;
+}
+
+export async function fetchLoginModalSettings(): Promise<LoginModalSettings | null> {
+  const res = await api.get<WrappedResponse<LoginModalSettings | null>>(
+    '/login-modal/settings'
+  );
+  return res.data.data;
+}
+
+export async function upsertLoginModalSettings(
+  data: UpsertLoginModalSettingsBody
+): Promise<LoginModalSettings> {
+  const res = await api.put<WrappedResponse<LoginModalSettings>>(
+    '/login-modal/settings',
+    data
+  );
+  return res.data.data;
+}

--- a/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
@@ -218,17 +218,30 @@ export function LoginModalSettingsAdmin() {
             </div>
           </div>
 
-          {/* Active toggle */}
-          <div className="flex items-center gap-3">
-            <Checkbox
-              id="modal-is-active"
-              checked={formData.isActive}
-              onCheckedChange={(checked) =>
-                setFormData((f) => ({ ...f, isActive: !!checked }))
-              }
-              disabled={!canManage}
-            />
-            <Label htmlFor="modal-is-active">Active</Label>
+          {/* Active toggle + current status */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="flex items-center gap-3">
+              <Checkbox
+                id="modal-is-active"
+                checked={formData.isActive}
+                onCheckedChange={(checked) =>
+                  setFormData((f) => ({ ...f, isActive: !!checked }))
+                }
+                disabled={!canManage}
+              />
+              <Label htmlFor="modal-is-active">Active</Label>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-slate-900">
+                Current Status
+              </Label>
+              <p className="mt-1 text-sm text-slate-600">
+                Login modal is currently{' '}
+                {formData.isActive
+                  ? 'active — will show after login'
+                  : 'inactive'}
+              </p>
+            </div>
           </div>
 
           {/* Title */}

--- a/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
@@ -19,6 +19,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
+import { useLoginModalSettingsWebSocket } from '@/hooks/useLoginModalSettingsWebSocket';
 import { usePermission } from '@/hooks/usePermissions';
 import { showErrorToast, showSuccessToast } from '@/lib/error-toast';
 
@@ -94,6 +95,14 @@ export function LoginModalSettingsAdmin() {
     () => toFormData(settings ?? null),
     [settings]
   );
+
+  useLoginModalSettingsWebSocket({
+    onSettingsUpdated: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['login-modal', 'settings'],
+      });
+    },
+  });
 
   useEffect(() => {
     setFormData(initialFormData);
@@ -228,6 +237,7 @@ export function LoginModalSettingsAdmin() {
                   setFormData((f) => ({ ...f, isActive: !!checked }))
                 }
                 disabled={!canManage}
+                data-testid="checkbox-login-modal-active"
               />
               <Label htmlFor="modal-is-active">Active</Label>
             </div>
@@ -256,6 +266,7 @@ export function LoginModalSettingsAdmin() {
               disabled={!canManage}
               maxLength={200}
               placeholder="Notice"
+              data-testid="input-login-modal-title"
             />
           </div>
 
@@ -271,6 +282,7 @@ export function LoginModalSettingsAdmin() {
               disabled={!canManage}
               rows={6}
               placeholder="Enter modal content…"
+              data-testid="textarea-login-modal-content"
             />
           </div>
 

--- a/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
@@ -1,0 +1,303 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { LogIn } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { PERMISSIONS, SYSTEM_ROLE_IDS } from '@corpcal/shared';
+import type {
+  LoginModalSettings,
+  UpsertLoginModalSettingsBody,
+} from '@corpcal/shared/api/types';
+import {
+  fetchLoginModalSettings,
+  upsertLoginModalSettings,
+} from '@/api/loginModalApi';
+import { AdminSection } from '@/components/admin';
+import { LoginModal } from '@/components/layout/LoginModal';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/hooks/useAuth';
+import { usePermission } from '@/hooks/usePermissions';
+import { showErrorToast, showSuccessToast } from '@/lib/error-toast';
+
+type ModalFormData = {
+  isActive: boolean;
+  title: string;
+  content: string;
+  startDateTime: string;
+  endDateTime: string;
+};
+
+const DEFAULT_FORM_DATA: ModalFormData = {
+  isActive: false,
+  title: 'Notice',
+  content: '',
+  startDateTime: '',
+  endDateTime: '',
+};
+
+function toLocalDateTimeValue(value: string | null): string {
+  if (!value) return '';
+  const date = new Date(value);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function toFormData(settings: LoginModalSettings | null): ModalFormData {
+  if (!settings) return DEFAULT_FORM_DATA;
+  return {
+    isActive: settings.isActive,
+    title: settings.title,
+    content: settings.content,
+    startDateTime: toLocalDateTimeValue(settings.startDateTime),
+    endDateTime: toLocalDateTimeValue(settings.endDateTime),
+  };
+}
+
+function toRequestBody(formData: ModalFormData): UpsertLoginModalSettingsBody {
+  return {
+    isActive: formData.isActive,
+    title: formData.title.trim(),
+    content: formData.content.trim(),
+    startDateTime: formData.startDateTime
+      ? new Date(formData.startDateTime).toISOString()
+      : null,
+    endDateTime: formData.endDateTime
+      ? new Date(formData.endDateTime).toISOString()
+      : null,
+  };
+}
+
+export function LoginModalSettingsAdmin() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const hasSettingsManage = usePermission(PERMISSIONS.SETTINGS.MANAGE);
+  const isSystemAdmin = user?.roleId === SYSTEM_ROLE_IDS.SYSTEM_ADMIN;
+  const canManage = hasSettingsManage && isSystemAdmin;
+
+  const [formData, setFormData] = useState<ModalFormData>(DEFAULT_FORM_DATA);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const {
+    data: settings,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['login-modal', 'settings'],
+    queryFn: fetchLoginModalSettings,
+    retry: false,
+  });
+
+  const initialFormData = useMemo(
+    () => toFormData(settings ?? null),
+    [settings]
+  );
+
+  useEffect(() => {
+    setFormData(initialFormData);
+  }, [initialFormData]);
+
+  const hasChanges = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(initialFormData),
+    [formData, initialFormData]
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: (data: ModalFormData) =>
+      upsertLoginModalSettings(toRequestBody(data)),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(['login-modal', 'settings'], saved);
+      showSuccessToast('Login modal settings saved');
+    },
+    onError: (err) => {
+      showErrorToast(err);
+    },
+  });
+
+  const handleSave = () => {
+    if (!formData.title.trim()) {
+      showErrorToast(new Error('Title cannot be empty'));
+      return;
+    }
+    if (!formData.content.trim()) {
+      showErrorToast(new Error('Content cannot be empty'));
+      return;
+    }
+    if (
+      formData.startDateTime &&
+      formData.endDateTime &&
+      new Date(formData.endDateTime) <= new Date(formData.startDateTime)
+    ) {
+      showErrorToast(new Error('End date/time must be after start date/time'));
+      return;
+    }
+    saveMutation.mutate(formData);
+  };
+
+  const previewModal = useMemo<LoginModalSettings | null>(() => {
+    if (!formData.content.trim()) return null;
+    return {
+      id: settings?.id ?? 0,
+      isActive: formData.isActive,
+      title: formData.title || 'Notice',
+      content: formData.content,
+      startDateTime: formData.startDateTime
+        ? new Date(formData.startDateTime).toISOString()
+        : null,
+      endDateTime: formData.endDateTime
+        ? new Date(formData.endDateTime).toISOString()
+        : null,
+      createdDateTime: settings?.createdDateTime ?? new Date().toISOString(),
+      lastUpdatedDateTime:
+        settings?.lastUpdatedDateTime ?? new Date().toISOString(),
+    };
+  }, [settings, formData]);
+
+  if (!isSystemAdmin) {
+    return null;
+  }
+
+  return (
+    <>
+      <AdminSection
+        title="Login Modal"
+        description="Configure a notice modal shown to users the first time they sign in each session."
+        isLoading={isLoading}
+        headerAction={
+          canManage ? (
+            <div className="flex items-center gap-2">
+              {previewModal && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setPreviewOpen(true)}
+                >
+                  Preview
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setFormData(initialFormData)}
+                disabled={!hasChanges || saveMutation.isPending}
+              >
+                Reset
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={!hasChanges || saveMutation.isPending}
+              >
+                Save
+              </Button>
+            </div>
+          ) : null
+        }
+      >
+        {error && (
+          <div className="text-destructive mb-4 text-sm">
+            Error loading login modal settings.
+          </div>
+        )}
+
+        {!canManage && (
+          <div className="mb-4 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+            You can view the current configuration, but only System Admin users
+            can update it.
+          </div>
+        )}
+
+        <div className="space-y-5">
+          <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-slate-50 p-3">
+            <LogIn className="h-5 w-5 text-slate-600" />
+            <div className="text-sm text-slate-700">
+              The modal is shown once per session, the first time a user signs
+              in. HTML content is supported.
+            </div>
+          </div>
+
+          {/* Active toggle */}
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="modal-is-active"
+              checked={formData.isActive}
+              onCheckedChange={(checked) =>
+                setFormData((f) => ({ ...f, isActive: !!checked }))
+              }
+              disabled={!canManage}
+            />
+            <Label htmlFor="modal-is-active">Active</Label>
+          </div>
+
+          {/* Title */}
+          <div className="space-y-2">
+            <Label htmlFor="modal-title">Title</Label>
+            <Input
+              id="modal-title"
+              value={formData.title}
+              onChange={(e) =>
+                setFormData((f) => ({ ...f, title: e.target.value }))
+              }
+              disabled={!canManage}
+              maxLength={200}
+              placeholder="Notice"
+            />
+          </div>
+
+          {/* Content */}
+          <div className="space-y-2">
+            <Label htmlFor="modal-content">Content (HTML supported)</Label>
+            <Textarea
+              id="modal-content"
+              value={formData.content}
+              onChange={(e) =>
+                setFormData((f) => ({ ...f, content: e.target.value }))
+              }
+              disabled={!canManage}
+              rows={6}
+              placeholder="Enter modal content…"
+            />
+          </div>
+
+          {/* Date range */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="modal-start">Start date/time (optional)</Label>
+              <Input
+                id="modal-start"
+                type="datetime-local"
+                value={formData.startDateTime}
+                onChange={(e) =>
+                  setFormData((f) => ({ ...f, startDateTime: e.target.value }))
+                }
+                disabled={!canManage}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="modal-end">End date/time (optional)</Label>
+              <Input
+                id="modal-end"
+                type="datetime-local"
+                value={formData.endDateTime}
+                onChange={(e) =>
+                  setFormData((f) => ({ ...f, endDateTime: e.target.value }))
+                }
+                disabled={!canManage}
+              />
+            </div>
+          </div>
+        </div>
+      </AdminSection>
+
+      {previewModal && (
+        <LoginModal
+          modal={previewModal}
+          open={previewOpen}
+          onDismiss={() => setPreviewOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
+++ b/calendar-ui/src/components/admin/LoginModalSettingsAdmin.tsx
@@ -72,6 +72,17 @@ function toRequestBody(formData: ModalFormData): UpsertLoginModalSettingsBody {
 }
 
 export function LoginModalSettingsAdmin() {
+  const { user } = useAuth();
+  const isSystemAdmin = user?.roleId === SYSTEM_ROLE_IDS.SYSTEM_ADMIN;
+
+  if (!isSystemAdmin) {
+    return null;
+  }
+
+  return <LoginModalSettingsAdminInner />;
+}
+
+function LoginModalSettingsAdminInner() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const hasSettingsManage = usePermission(PERMISSIONS.SETTINGS.MANAGE);
@@ -163,10 +174,6 @@ export function LoginModalSettingsAdmin() {
         settings?.lastUpdatedDateTime ?? new Date().toISOString(),
     };
   }, [settings, formData]);
-
-  if (!isSystemAdmin) {
-    return null;
-  }
 
   return (
     <>
@@ -282,6 +289,7 @@ export function LoginModalSettingsAdmin() {
               disabled={!canManage}
               rows={6}
               placeholder="Enter modal content…"
+              maxLength={5000}
               data-testid="textarea-login-modal-content"
             />
           </div>

--- a/calendar-ui/src/components/admin/__tests__/LoginModalSettingsAdmin.test.tsx
+++ b/calendar-ui/src/components/admin/__tests__/LoginModalSettingsAdmin.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, waitFor } from '@/test/test-utils';
+
+const mockFetchLoginModalSettings = vi.fn();
+const mockUseAuth = vi.fn();
+
+vi.mock('@/api/loginModalApi', () => ({
+  fetchLoginModalSettings: () => mockFetchLoginModalSettings(),
+  upsertLoginModalSettings: () => Promise.resolve(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('@/hooks/useLoginModalSettingsWebSocket', () => ({
+  useLoginModalSettingsWebSocket: () => undefined,
+}));
+
+const SYSTEM_ADMIN_ROLE_ID = 6;
+
+const baseSettings = {
+  id: 1,
+  isActive: false,
+  title: 'Notice',
+  content: 'Test content',
+  startDateTime: null,
+  endDateTime: null,
+  createdDateTime: new Date().toISOString(),
+  lastUpdatedDateTime: new Date().toISOString(),
+};
+
+describe('LoginModalSettingsAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders for System Admin users', async () => {
+    mockFetchLoginModalSettings.mockResolvedValue(baseSettings);
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, roleId: SYSTEM_ADMIN_ROLE_ID },
+      hasPermission: () => true,
+      hasAnyPermission: () => true,
+      hasAllPermissions: () => true,
+    });
+
+    const { LoginModalSettingsAdmin } =
+      await import('../LoginModalSettingsAdmin');
+    render(<LoginModalSettingsAdmin />);
+
+    await waitFor(
+      () => expect(mockFetchLoginModalSettings).toHaveBeenCalled(),
+      {
+        timeout: 20000,
+      }
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /Login Modal/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('input-login-modal-title')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('textarea-login-modal-content')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('checkbox-login-modal-active')
+    ).toBeInTheDocument();
+  }, 20000);
+
+  it('does not render for non-System-Admin users', async () => {
+    mockFetchLoginModalSettings.mockResolvedValue(null);
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, roleId: 5 },
+      hasPermission: () => true,
+      hasAnyPermission: () => true,
+      hasAllPermissions: () => true,
+    });
+
+    const { LoginModalSettingsAdmin } =
+      await import('../LoginModalSettingsAdmin');
+    const { container } = render(<LoginModalSettingsAdmin />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows Current Status as inactive when isActive is false', async () => {
+    mockFetchLoginModalSettings.mockResolvedValue({
+      ...baseSettings,
+      isActive: false,
+    });
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, roleId: SYSTEM_ADMIN_ROLE_ID },
+      hasPermission: () => true,
+      hasAnyPermission: () => true,
+      hasAllPermissions: () => true,
+    });
+
+    const { LoginModalSettingsAdmin } =
+      await import('../LoginModalSettingsAdmin');
+    render(<LoginModalSettingsAdmin />);
+
+    await waitFor(
+      () => expect(mockFetchLoginModalSettings).toHaveBeenCalled(),
+      {
+        timeout: 20000,
+      }
+    );
+
+    expect(screen.getByText(/currently\s+inactive/i)).toBeInTheDocument();
+  }, 20000);
+});

--- a/calendar-ui/src/components/admin/index.ts
+++ b/calendar-ui/src/components/admin/index.ts
@@ -1,6 +1,7 @@
 export { AdminSection } from './AdminSection';
 export { AdminModal } from './AdminModal';
 export { BannerSettingsAdmin } from './BannerSettingsAdmin';
+export { LoginModalSettingsAdmin } from './LoginModalSettingsAdmin';
 export { LookupForm, type FormField } from './LookupForm';
 
 /** Sentinel value used in Radix Select fields to represent "no selection" (null).

--- a/calendar-ui/src/components/layout/LoginModal.tsx
+++ b/calendar-ui/src/components/layout/LoginModal.tsx
@@ -1,0 +1,41 @@
+import * as Dialog from '@radix-ui/react-dialog';
+
+import type { LoginModalSettings } from '@corpcal/shared/api/types';
+import { Button } from '@/components/ui/button';
+import { sanitizeBannerHtml } from '@/lib/banner-html';
+
+interface LoginModalProps {
+  modal: LoginModalSettings;
+  open: boolean;
+  onDismiss: () => void;
+}
+
+export function LoginModal({ modal, open, onDismiss }: LoginModalProps) {
+  const sanitizedContent = sanitizeBannerHtml(modal.content);
+
+  return (
+    <Dialog.Root open={open}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          className="fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg sm:rounded-lg"
+          onInteractOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          aria-describedby="login-modal-content"
+        >
+          <Dialog.Title className="text-lg font-semibold text-slate-900">
+            {modal.title}
+          </Dialog.Title>
+          <div
+            id="login-modal-content"
+            className="text-sm text-slate-700 [&_a]:text-blue-600 [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
+            dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+          />
+          <div className="flex justify-end">
+            <Button onClick={onDismiss}>Dismiss</Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/calendar-ui/src/components/layout/LoginModal.tsx
+++ b/calendar-ui/src/components/layout/LoginModal.tsx
@@ -1,7 +1,13 @@
-import * as Dialog from '@radix-ui/react-dialog';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 import type { LoginModalSettings } from '@corpcal/shared/api/types';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { sanitizeBannerHtml } from '@/lib/banner-html';
 
 interface LoginModalProps {
@@ -14,18 +20,19 @@ export function LoginModal({ modal, open, onDismiss }: LoginModalProps) {
   const sanitizedContent = sanitizeBannerHtml(modal.content);
 
   return (
-    <Dialog.Root open={open}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content
-          className="fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg sm:rounded-lg"
+    <Dialog open={open}>
+      <DialogPortal>
+        <DialogOverlay />
+        {/* DialogContent from shadcn always renders a close button, so we use
+            the Radix primitive directly here — the modal must be explicitly
+            dismissed and cannot be closed via the X, Escape, or outside click. */}
+        <DialogPrimitive.Content
+          className="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg"
           onInteractOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
           aria-describedby="login-modal-content"
         >
-          <Dialog.Title className="text-lg font-semibold text-slate-900">
-            {modal.title}
-          </Dialog.Title>
+          <DialogTitle>{modal.title}</DialogTitle>
           <div
             id="login-modal-content"
             className="text-sm text-slate-700 [&_a]:text-blue-600 [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
@@ -34,8 +41,8 @@ export function LoginModal({ modal, open, onDismiss }: LoginModalProps) {
           <div className="flex justify-end">
             <Button onClick={onDismiss}>Dismiss</Button>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
   );
 }

--- a/calendar-ui/src/components/layout/LoginModal.tsx
+++ b/calendar-ui/src/components/layout/LoginModal.tsx
@@ -31,15 +31,24 @@ export function LoginModal({ modal, open, onDismiss }: LoginModalProps) {
           onInteractOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
           aria-describedby="login-modal-content"
+          data-testid="login-modal-dialog"
         >
-          <DialogTitle>{modal.title}</DialogTitle>
+          <DialogTitle data-testid="login-modal-title">
+            {modal.title}
+          </DialogTitle>
           <div
             id="login-modal-content"
             className="text-sm text-slate-700 [&_a]:text-blue-600 [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
             dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+            data-testid="login-modal-content"
           />
           <div className="flex justify-end">
-            <Button onClick={onDismiss}>Dismiss</Button>
+            <Button
+              onClick={onDismiss}
+              data-testid="login-modal-dismiss-button"
+            >
+              Dismiss
+            </Button>
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/calendar-ui/src/components/layout/index.ts
+++ b/calendar-ui/src/components/layout/index.ts
@@ -1,6 +1,7 @@
 export { GlobalErrorBoundary } from './GlobalErrorBoundary';
 export { default as Header } from './Header';
 export { Layout } from './Layout';
+export { LoginModal } from './LoginModal';
 export { PageContainer, PAGE_CONTAINER_DEFAULT_LAYOUT } from './PageContainer';
 export { PageHeader } from './PageHeader';
 export { ProtectedRoute } from './ProtectedRoute';

--- a/calendar-ui/src/contexts/AuthContext.tsx
+++ b/calendar-ui/src/contexts/AuthContext.tsx
@@ -15,13 +15,17 @@ import type { AuthUser, PermissionKey } from '@corpcal/shared';
 
 import * as authApi from '../api/authApi';
 
+export const LOGIN_MODAL_SESSION_KEY = 'corpcal_show_login_modal';
+
 export interface AuthContextType {
   user: AuthUser | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  pendingLoginModal: boolean;
   login: (username: string, password?: string) => Promise<void>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  dismissLoginModal: () => void;
   hasPermission: (permissionKey: PermissionKey) => boolean;
   hasAnyPermission: (...permissionKeys: PermissionKey[]) => boolean;
   hasAllPermissions: (...permissionKeys: PermissionKey[]) => boolean;
@@ -38,6 +42,9 @@ interface AuthProviderProps {
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [pendingLoginModal, setPendingLoginModal] = useState(
+    () => sessionStorage.getItem(LOGIN_MODAL_SESSION_KEY) === '1'
+  );
 
   /**
    * Refresh user by calling GET /auth/me
@@ -61,6 +68,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const initAuth = async () => {
       setIsLoading(true);
       try {
+        // Detect Azure SSO post-login redirect (?login=1) and set the modal flag
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('login') === '1') {
+          sessionStorage.setItem(LOGIN_MODAL_SESSION_KEY, '1');
+          setPendingLoginModal(true);
+          params.delete('login');
+          const newSearch = params.toString();
+          const newUrl =
+            window.location.pathname +
+            (newSearch ? `?${newSearch}` : '') +
+            window.location.hash;
+          history.replaceState(null, '', newUrl);
+        }
         await refreshUser();
       } finally {
         setIsLoading(false);
@@ -75,6 +95,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
    */
   const login = useCallback(async (username: string, password?: string) => {
     const response = await authApi.login({ username, password });
+    sessionStorage.setItem(LOGIN_MODAL_SESSION_KEY, '1');
+    setPendingLoginModal(true);
     setUser(response.user);
   }, []);
 
@@ -85,8 +107,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       await authApi.logout();
     } finally {
+      sessionStorage.removeItem(LOGIN_MODAL_SESSION_KEY);
+      setPendingLoginModal(false);
       setUser(null);
     }
+  }, []);
+
+  const dismissLoginModal = useCallback(() => {
+    sessionStorage.removeItem(LOGIN_MODAL_SESSION_KEY);
+    setPendingLoginModal(false);
   }, []);
 
   /**
@@ -125,9 +154,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
     user,
     isLoading,
     isAuthenticated: !!user,
+    pendingLoginModal,
     login,
     logout,
     refreshUser,
+    dismissLoginModal,
     hasPermission,
     hasAnyPermission,
     hasAllPermissions,

--- a/calendar-ui/src/hooks/useLoginModalSettingsWebSocket.ts
+++ b/calendar-ui/src/hooks/useLoginModalSettingsWebSocket.ts
@@ -1,0 +1,33 @@
+import { io } from 'socket.io-client';
+import { useEffect } from 'react';
+
+import {
+  CALENDAR_SOCKET_IO_OPTIONS,
+  getCalendarSocketUrl,
+} from '@/lib/calendar-socket';
+
+interface UseLoginModalSettingsWebSocketOptions {
+  onSettingsUpdated?: () => void;
+}
+
+/**
+ * Subscribes to the `loginModalSettingsUpdated` WebSocket event so that any
+ * admin viewing the Login Modal settings panel picks up changes saved by
+ * another admin without needing to refresh.
+ */
+export function useLoginModalSettingsWebSocket({
+  onSettingsUpdated,
+}: UseLoginModalSettingsWebSocketOptions = {}): void {
+  useEffect(() => {
+    const socket = io(getCalendarSocketUrl(), CALENDAR_SOCKET_IO_OPTIONS);
+
+    socket.on('loginModalSettingsUpdated', () => {
+      onSettingsUpdated?.();
+    });
+
+    return () => {
+      socket.off('loginModalSettingsUpdated');
+      socket.disconnect();
+    };
+  }, [onSettingsUpdated]);
+}

--- a/calendar-ui/src/hooks/useLoginModalSettingsWebSocket.ts
+++ b/calendar-ui/src/hooks/useLoginModalSettingsWebSocket.ts
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import {
   CALENDAR_SOCKET_IO_OPTIONS,
@@ -14,20 +14,26 @@ interface UseLoginModalSettingsWebSocketOptions {
  * Subscribes to the `loginModalSettingsUpdated` WebSocket event so that any
  * admin viewing the Login Modal settings panel picks up changes saved by
  * another admin without needing to refresh.
+ *
+ * The callback is kept in a ref so the socket connection is stable across
+ * renders — changing the callback will not reconnect the socket.
  */
 export function useLoginModalSettingsWebSocket({
   onSettingsUpdated,
 }: UseLoginModalSettingsWebSocketOptions = {}): void {
+  const callbackRef = useRef(onSettingsUpdated);
+  callbackRef.current = onSettingsUpdated;
+
   useEffect(() => {
     const socket = io(getCalendarSocketUrl(), CALENDAR_SOCKET_IO_OPTIONS);
 
     socket.on('loginModalSettingsUpdated', () => {
-      onSettingsUpdated?.();
+      callbackRef.current?.();
     });
 
     return () => {
       socket.off('loginModalSettingsUpdated');
       socket.disconnect();
     };
-  }, [onSettingsUpdated]);
+  }, []);
 }

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import {
   FileText,
   FolderTree,
   Lock,
+  LogIn,
   MapPin,
   Megaphone,
   Palette,
@@ -18,6 +19,7 @@ import {
 import { BannerSettingsAdmin } from '@/components/admin';
 import { ActivityCompletionSettingsAdmin } from '@/components/admin/ActivityCompletionSettingsAdmin';
 import { EditLockIdleSettingsAdmin } from '@/components/admin/EditLockIdleSettingsAdmin';
+import { LoginModalSettingsAdmin } from '@/components/admin/LoginModalSettingsAdmin';
 import { LookAheadResetSettingsAdmin } from '@/components/admin/LookAheadResetSettingsAdmin';
 import {
   ActivityStatusesAdmin,
@@ -34,6 +36,7 @@ import {
 
 type Section =
   | 'banner'
+  | 'login-modal'
   | 'edit-lock-idle'
   | 'activity-completion'
   | 'look-ahead-reset'
@@ -50,6 +53,7 @@ type Section =
 
 const sections = [
   { id: 'banner' as Section, label: 'System Banner', icon: Megaphone },
+  { id: 'login-modal' as Section, label: 'Login Modal', icon: LogIn },
   {
     id: 'edit-lock-idle' as Section,
     label: 'Edit lock idle',
@@ -150,6 +154,10 @@ export function Settings() {
         <div className="space-y-8">
           <div id="section-banner">
             <BannerSettingsAdmin />
+          </div>
+
+          <div id="section-login-modal">
+            <LoginModalSettingsAdmin />
           </div>
 
           <div id="section-edit-lock-idle">

--- a/packages/database/migrations/0006_add_login_modal_settings.sql
+++ b/packages/database/migrations/0006_add_login_modal_settings.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "login_modal_settings" (
+  "id" serial PRIMARY KEY,
+  "is_active" boolean NOT NULL DEFAULT false,
+  "title" varchar(200) NOT NULL DEFAULT 'Notice',
+  "content" text NOT NULL,
+  "start_date_time" timestamptz,
+  "end_date_time" timestamptz,
+  "created_date_time" timestamptz NOT NULL DEFAULT now(),
+  "created_by" integer NOT NULL REFERENCES "users"("id"),
+  "last_updated_date_time" timestamptz NOT NULL DEFAULT now(),
+  "last_updated_by" integer NOT NULL REFERENCES "users"("id")
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -19,5 +19,6 @@ export * from './editLockPendingHandoffs';
 export * from './applicationSettings';
 export * from './sessions';
 export * from './bannerSettings';
+export * from './loginModalSettings';
 export * from './activitySavedFilters';
 export * from './userActivitySavedFilterDefaults';

--- a/packages/database/src/schema/loginModalSettings.ts
+++ b/packages/database/src/schema/loginModalSettings.ts
@@ -1,0 +1,34 @@
+import {
+  boolean,
+  integer,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+import { users } from './user';
+
+export const loginModalSettings = pgTable('login_modal_settings', {
+  id: serial('id').primaryKey(),
+  isActive: boolean('is_active').notNull().default(false),
+  title: varchar('title', { length: 200 }).notNull().default('Notice'),
+  content: text('content').notNull(),
+  startDateTime: timestamp('start_date_time', { withTimezone: true }),
+  endDateTime: timestamp('end_date_time', { withTimezone: true }),
+  createdDateTime: timestamp('created_date_time', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  createdBy: integer('created_by')
+    .notNull()
+    .references(() => users.id),
+  lastUpdatedDateTime: timestamp('last_updated_date_time', {
+    withTimezone: true,
+  })
+    .notNull()
+    .defaultNow(),
+  lastUpdatedBy: integer('last_updated_by')
+    .notNull()
+    .references(() => users.id),
+});

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -15,6 +15,10 @@ export type {
   BannerSettings,
   UpsertBannerSettingsBody,
 } from '../schemas/banner.schema';
+export type {
+  LoginModalSettings,
+  UpsertLoginModalSettingsBody,
+} from '../schemas/login-modal.schema';
 
 // Query params types - re-exported from query-params schema
 export type { LookupQueryParams } from '../schemas/query-params.schema';

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -5,6 +5,7 @@ export * from './look-ahead-reset.schema';
 export * from './activity-response.schema';
 export * from './activity-junction.schema';
 export * from './banner.schema';
+export * from './login-modal.schema';
 export * from './history.schema';
 export * from './lookup.schema';
 export * from './ministry-groups.schema';

--- a/packages/shared/src/schemas/login-modal.schema.ts
+++ b/packages/shared/src/schemas/login-modal.schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const nullableDateTimeSchema = z.string().datetime().nullable();
+
+export const loginModalSettingsSchema = z.object({
+  id: z.number().int(),
+  isActive: z.boolean(),
+  title: z.string(),
+  content: z.string(),
+  startDateTime: nullableDateTimeSchema,
+  endDateTime: nullableDateTimeSchema,
+  createdDateTime: z.string().datetime(),
+  lastUpdatedDateTime: z.string().datetime(),
+});
+
+export const upsertLoginModalSettingsRequestSchema = z
+  .object({
+    isActive: z.boolean(),
+    title: z.string().trim().min(1, 'Title is required').max(200),
+    content: z.string().trim().min(1, 'Content is required'),
+    startDateTime: nullableDateTimeSchema.default(null),
+    endDateTime: nullableDateTimeSchema.default(null),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.startDateTime || !value.endDateTime) {
+      return;
+    }
+    if (new Date(value.endDateTime) <= new Date(value.startDateTime)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['endDateTime'],
+        message: 'End date/time must be after start date/time',
+      });
+    }
+  });
+
+export type LoginModalSettings = z.infer<typeof loginModalSettingsSchema>;
+export type UpsertLoginModalSettingsBody = z.infer<
+  typeof upsertLoginModalSettingsRequestSchema
+>;

--- a/packages/shared/src/schemas/login-modal.schema.ts
+++ b/packages/shared/src/schemas/login-modal.schema.ts
@@ -17,7 +17,11 @@ export const upsertLoginModalSettingsRequestSchema = z
   .object({
     isActive: z.boolean(),
     title: z.string().trim().min(1, 'Title is required').max(200),
-    content: z.string().trim().min(1, 'Content is required'),
+    content: z
+      .string()
+      .trim()
+      .min(1, 'Content is required')
+      .max(5000, 'Content must be 5000 characters or fewer'),
     startDateTime: nullableDateTimeSchema.default(null),
     endDateTime: nullableDateTimeSchema.default(null),
   })


### PR DESCRIPTION
Summary
Implements a configurable post-login modal for Calendar, modeled after the equivalent feature in media-hub-app. System administrators can author a notice message that is shown to users once per session, the first time they sign in. The modal cannot be dismissed by clicking outside it or pressing Escape — the user must click the Dismiss button.

Changes
Database

New login_modal_settings table with fields for active flag, title, HTML content, optional start/end scheduling window, and audit columns
0006_add_login_modal_settings.sql added to the migration journal


