### PR TITLE
fix(config): set deleteOutDir: true in nest-cli.json

### DIFF
--- a/calendar-service/nest-cli.json
+++ b/calendar-service/nest-cli.json
@@ -3,7 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": false,
+    "deleteOutDir": true,
     "webpack": true,
     "tsConfigPath": "tsconfig.build.json"
   }


### PR DESCRIPTION
## Summary

This sets Nest config deleteOutDir back to true in nest-cli.json. This tells the Nest CLI to remove the compilation output directory ./dist before each new build. This was switched to false previously because Nest would sometimes not build in time; however, this workaround can cause issues with partially stale builds and unexpected results.

## Test

Application builds successfully and dev environment running as expected. Continue to monitor possible issues with ./dist not being generated in time.