### PR TITLE
Fix/corpcal 228 fix activity list dates

### DIFF
--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -99,6 +99,7 @@ import {
   formatExactDate,
   formatRelativeTime,
   formatTime12h,
+  parseDateOnlyString,
 } from '@/lib/datetime-utils';
 import { getFriendlyErrorMessage } from '@/lib/error-toast';
 import { getSavedFilterAutoApplyDecision } from '@/lib/savedFilterAutoApplyDecision';
@@ -434,7 +435,9 @@ function SchedulingCell({ row }: { row: ActivityTableRow }) {
     row.startDate && row.endDate && row.endDate !== row.startDate
       ? formatDateRange(row.startDate, row.endDate)
       : row.startDate
-        ? formatExactDate(new Date(row.startDate), { includeYear: 'auto' })
+        ? formatExactDate(parseDateOnlyString(row.startDate), {
+            includeYear: 'auto',
+          })
         : '';
 
   return (

--- a/calendar-ui/src/components/reports/DateGroupedTable.tsx
+++ b/calendar-ui/src/components/reports/DateGroupedTable.tsx
@@ -10,7 +10,9 @@ import { Badge } from '../ui/badge';
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '–';
-  const d = new Date(dateStr);
+  const parts = dateStr.split('-').map(Number);
+  const [y, m, day] = parts;
+  const d = new Date(y, (m ?? 1) - 1, day ?? 1);
   return d.toLocaleDateString('en-CA', {
     weekday: 'short',
     month: 'short',

--- a/calendar-ui/src/components/reports/ReportRow.tsx
+++ b/calendar-ui/src/components/reports/ReportRow.tsx
@@ -4,7 +4,11 @@ import { tableBodyRow, tableTd } from '@/components/table/tableConstants';
 import { ActivityRichTextContent } from '@/components/ui/activity-rich-text-content';
 import { Badge } from '@/components/ui/badge';
 import { CopyableText } from '@/components/ui/copyable-text';
-import { formatExactDate, formatTime12h } from '@/lib/datetime-utils';
+import {
+  formatExactDate,
+  formatTime12h,
+  parseDateOnlyString,
+} from '@/lib/datetime-utils';
 import { cn } from '@/lib/utils';
 
 /** Matches Activity List table cells: light stroke + white fill (Fluent NeutralStroke1.Rest / #FFF via Tailwind). */
@@ -33,7 +37,9 @@ export function ReportRow({ activity, className }: ReportRowProps) {
   const displayIdText = activity.displayId ?? String(activity.id);
 
   // Convert ISO date string to Date object for formatting
-  const startDate = activity.startDate ? new Date(activity.startDate) : null;
+  const startDate = activity.startDate
+    ? parseDateOnlyString(activity.startDate)
+    : null;
   const formattedDate = startDate ? formatExactDate(startDate) : '–';
   const formattedTime = activity.startTime
     ? formatTime12h(activity.startTime)

--- a/calendar-ui/src/lib/datetime-utils.test.ts
+++ b/calendar-ui/src/lib/datetime-utils.test.ts
@@ -195,9 +195,9 @@ describe('formatDateRange', () => {
   });
 
   it('accepts ISO date strings', () => {
-    expect(
-      formatDateRange('2027-01-23T12:00:00Z', '2027-02-01T12:00:00Z')
-    ).toBe('Jan 23 – Feb 1, 2027');
+    expect(formatDateRange('2027-01-23', '2027-02-01')).toBe(
+      'Jan 23 – Feb 1, 2027'
+    );
   });
 });
 

--- a/calendar-ui/src/lib/datetime-utils.ts
+++ b/calendar-ui/src/lib/datetime-utils.ts
@@ -103,6 +103,17 @@ export type FormatExactDateOptions = {
 };
 
 /**
+ * Parse a YYYY-MM-DD date-only string as local midnight, avoiding the UTC-to-local
+ * timezone shift that `new Date("YYYY-MM-DD")` introduces (ISO date-only strings are
+ * parsed as UTC, which shifts the date back one day in timezones behind UTC).
+ */
+export function parseDateOnlyString(dateStr: string): Date {
+  const parts = dateStr.split('-').map(Number);
+  const [y, m, d] = parts;
+  return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+/**
  * Exact date (and optional time) for "Updated Jan 23, 2026" or "Updated Jan 23, 2026 at 2:00 PM".
  * Call site adds context prefix, e.g. "Updated " + formatExactDate(date).
  */
@@ -180,8 +191,9 @@ export function formatDateRange(
   start: Date | string,
   end: Date | string
 ): string {
-  const startDate = typeof start === 'string' ? new Date(start) : start;
-  const endDate = typeof end === 'string' ? new Date(end) : end;
+  const startDate =
+    typeof start === 'string' ? parseDateOnlyString(start) : start;
+  const endDate = typeof end === 'string' ? parseDateOnlyString(end) : end;
   const startYear = startDate.getFullYear();
   const endYear = endDate.getFullYear();
 

--- a/calendar-ui/src/lib/datetime-utils.ts
+++ b/calendar-ui/src/lib/datetime-utils.ts
@@ -108,6 +108,9 @@ export type FormatExactDateOptions = {
  * parsed as UTC, which shifts the date back one day in timezones behind UTC).
  */
 export function parseDateOnlyString(dateStr: string): Date {
+  if (dateStr.includes('T')) {
+    return new Date(dateStr);
+  }
   const parts = dateStr.split('-').map(Number);
   const [y, m, d] = parts;
   return new Date(y, (m ?? 1) - 1, d ?? 1);

--- a/calendar-ui/src/lib/datetime-utils.ts
+++ b/calendar-ui/src/lib/datetime-utils.ts
@@ -108,9 +108,6 @@ export type FormatExactDateOptions = {
  * parsed as UTC, which shifts the date back one day in timezones behind UTC).
  */
 export function parseDateOnlyString(dateStr: string): Date {
-  if (dateStr.includes('T')) {
-    return new Date(dateStr);
-  }
   const parts = dateStr.split('-').map(Number);
   const [y, m, d] = parts;
   return new Date(y, (m ?? 1) - 1, d ?? 1);


### PR DESCRIPTION
fixed the off-by-one date error in the activity list view and a few other locations. It looks like (probably) Copilot new Date("string") instead of parsing dates, leading to UTC time zone issues.