### PR TITLE
fix(calendar-ui): parse date

### DIFF
--- a/calendar-ui/src/components/activity/ActivityTable/activityTableSort.ts
+++ b/calendar-ui/src/components/activity/ActivityTable/activityTableSort.ts
@@ -1,4 +1,5 @@
 import type { SortLevel } from '@/components/table/SortDropdown';
+import { parseDateOnlyString } from '@/lib/datetime-utils';
 
 import type { ActivityTableRow } from './activityTableRow';
 
@@ -55,8 +56,8 @@ const byLookAheadStatus: RowComparator = (a, b) =>
   compareByOrder(LOOK_AHEAD_SORT_ORDER, a.lookAheadStatus, b.lookAheadStatus);
 
 const byStartDate: RowComparator = (a, b) => {
-  const ta = a.startDate ? new Date(a.startDate).getTime() : 0;
-  const tb = b.startDate ? new Date(b.startDate).getTime() : 0;
+  const ta = a.startDate ? parseDateOnlyString(a.startDate).getTime() : 0;
+  const tb = b.startDate ? parseDateOnlyString(b.startDate).getTime() : 0;
   return ta - tb;
 };
 

--- a/calendar-ui/src/components/reports/DateGroupedTable.tsx
+++ b/calendar-ui/src/components/reports/DateGroupedTable.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import type { ActivityResponse } from '@corpcal/shared/api/types';
 import { plainTextFromActivityRichField } from '@corpcal/shared/utils';
 import { ActivityRichTextContent } from '@/components/ui/activity-rich-text-content';
+import { parseDateOnlyString } from '@/lib/datetime-utils';
 import { sortLookAheadActivities } from '@/lib/look-ahead-sort';
 import { cn } from '@/lib/utils';
 
@@ -10,9 +11,7 @@ import { Badge } from '../ui/badge';
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '–';
-  const parts = dateStr.split('-').map(Number);
-  const [y, m, day] = parts;
-  const d = new Date(y, (m ?? 1) - 1, day ?? 1);
+  const d = parseDateOnlyString(dateStr);
   return d.toLocaleDateString('en-CA', {
     weekday: 'short',
     month: 'short',
@@ -30,7 +29,7 @@ function formatTime(dateStr: string | null, timeStr: string | null): string {
     return `${h12}:${minute} ${ampm}`;
   }
   if (dateStr) {
-    const d = new Date(dateStr);
+    const d = parseDateOnlyString(dateStr);
     return d.toLocaleTimeString('en-CA', {
       hour: 'numeric',
       minute: '2-digit',


### PR DESCRIPTION
## Summary

Just reuses the function Alex added to parse dates correctly where new Date was still used.