### PR TITLE
fix: replace 'sign in/out' with 'log in/out' across UI

### DIFF
--- a/calendar-ui/src/components/layout/Header.tsx
+++ b/calendar-ui/src/components/layout/Header.tsx
@@ -227,7 +227,7 @@ const Header = () => {
                     onClick={handleLogout}
                   >
                     <LogOut className="mr-2 h-4 w-4" />
-                    Sign out
+                    Log out
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/calendar-ui/src/components/shared/AutosaveIndicator.tsx
+++ b/calendar-ui/src/components/shared/AutosaveIndicator.tsx
@@ -24,7 +24,7 @@ export const AutosaveIndicator: FC<AutosaveIndicatorProps> = ({
   if (!isAuthenticated) {
     return (
       <div className="text-sm">
-        <span className="text-slate-400">Sign in to enable draft saving</span>
+        <span className="text-slate-400">Log in to enable draft saving</span>
       </div>
     );
   }

--- a/calendar-ui/src/pages/Login.test.tsx
+++ b/calendar-ui/src/pages/Login.test.tsx
@@ -79,7 +79,7 @@ describe('Login page — Azure AD', () => {
       await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
 
       expect(
-        screen.queryByRole('button', { name: /log in with idir/i })
+        screen.queryByRole('button', { name: /log in with microsoft/i })
       ).not.toBeInTheDocument();
     });
 
@@ -88,7 +88,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       expect(
-        await screen.findByRole('button', { name: /log in with idir/i })
+        await screen.findByRole('button', { name: /log in with microsoft/i })
       ).toBeInTheDocument();
     });
 
@@ -99,7 +99,7 @@ describe('Login page — Azure AD', () => {
       await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
 
       expect(
-        screen.queryByRole('button', { name: /log in with idir/i })
+        screen.queryByRole('button', { name: /log in with microsoft/i })
       ).not.toBeInTheDocument();
     });
   });
@@ -162,7 +162,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       const button = await screen.findByRole('button', {
-        name: /log in with idir/i,
+        name: /log in with microsoft/i,
       });
       await userEvent.click(button);
 
@@ -176,7 +176,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       const button = await screen.findByRole('button', {
-        name: /log in with idir/i,
+        name: /log in with microsoft/i,
       });
       await userEvent.click(button);
 

--- a/calendar-ui/src/pages/Login.test.tsx
+++ b/calendar-ui/src/pages/Login.test.tsx
@@ -79,7 +79,7 @@ describe('Login page — Azure AD', () => {
       await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
 
       expect(
-        screen.queryByRole('button', { name: /sign in with idir/i })
+        screen.queryByRole('button', { name: /log in with idir/i })
       ).not.toBeInTheDocument();
     });
 
@@ -88,7 +88,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       expect(
-        await screen.findByRole('button', { name: /sign in with idir/i })
+        await screen.findByRole('button', { name: /log in with idir/i })
       ).toBeInTheDocument();
     });
 
@@ -99,7 +99,7 @@ describe('Login page — Azure AD', () => {
       await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
 
       expect(
-        screen.queryByRole('button', { name: /sign in with idir/i })
+        screen.queryByRole('button', { name: /log in with idir/i })
       ).not.toBeInTheDocument();
     });
   });
@@ -162,7 +162,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       const button = await screen.findByRole('button', {
-        name: /sign in with idir/i,
+        name: /log in with idir/i,
       });
       await userEvent.click(button);
 
@@ -176,7 +176,7 @@ describe('Login page — Azure AD', () => {
       renderLogin();
 
       const button = await screen.findByRole('button', {
-        name: /sign in with idir/i,
+        name: /log in with idir/i,
       });
       await userEvent.click(button);
 

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -20,6 +20,23 @@ import { Label } from '../components/ui/label';
 import { useAuth } from '../hooks/useAuth';
 import { getFriendlyErrorMessage } from '../lib/error-toast';
 
+const MicrosoftLogo = ({
+  className = 'mr-2 h-4 w-4',
+}: {
+  className?: string;
+}) => (
+  <svg
+    className={className}
+    viewBox="0 0 21 21"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="0" y="0" width="10" height="10" fill="#F25022" />
+    <rect x="11" y="0" width="10" height="10" fill="#7FBA00" />
+    <rect x="0" y="11" width="10" height="10" fill="#00A4EF" />
+    <rect x="11" y="11" width="10" height="10" fill="#FFB900" />
+  </svg>
+);
+
 export function Login() {
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -94,8 +111,8 @@ export function Login() {
       <Card className="w-full max-w-md border-0 shadow-xl">
         <CardHeader className="space-y-4 pb-2 text-center">
           <div className="flex flex-col items-center space-y-4">
-            <div className="bg-primary/10 flex h-16 w-16 items-center justify-center rounded-full">
-              <Lock className="text-primary h-8 w-8" />
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-400 shadow-md">
+              <Lock className="h-8 w-8 text-white" />
             </div>
             <div>
               <CardTitle className="text-2xl font-bold text-slate-800">
@@ -109,79 +126,96 @@ export function Login() {
         </CardHeader>
 
         <CardContent className="pt-6">
-          <form onSubmit={handleSubmit} className="space-y-5">
-            {configLoaded && !azureEnabled && (
-              <>
-                <div className="space-y-2">
-                  <Label
-                    htmlFor="username"
-                    className="text-sm font-medium text-slate-700"
-                  >
-                    Username
-                  </Label>
-                  <div className="relative">
-                    <User className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                    <Input
-                      id="username"
-                      type="text"
-                      placeholder="Enter your username"
-                      value={username}
-                      onChange={(e) => setUsername(e.target.value)}
-                      className="h-11 pl-10"
-                      autoComplete="username"
-                      autoFocus
-                      disabled={isLoading}
-                      required
-                    />
-                  </div>
-                </div>
+          {error && (
+            <div className="mb-5 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
 
-                <div className="space-y-2">
-                  <Label
-                    htmlFor="password"
-                    className="text-sm font-medium text-slate-700"
-                  >
-                    Password
-                  </Label>
-                  <div className="relative">
-                    <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                    <Input
-                      id="password"
-                      type={showPassword ? 'text' : 'password'}
-                      placeholder="Enter your password (optional for dev)"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      className="h-11 pr-10 pl-10"
-                      autoComplete="current-password"
-                      disabled={isLoading}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-600"
-                      tabIndex={-1}
-                    >
-                      {showPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                  <p className="text-xs text-slate-500">
-                    In development mode, password is optional
-                  </p>
-                </div>
-              </>
-            )}
+          {configLoaded && azureEnabled && (
+            <Button
+              type="button"
+              className="h-11 w-full font-medium"
+              disabled={isAzureLoading}
+              onClick={handleAzureLogin}
+            >
+              {isAzureLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Redirecting to Microsoft...
+                </>
+              ) : (
+                <>
+                  <MicrosoftLogo />
+                  Log in with Microsoft
+                </>
+              )}
+            </Button>
+          )}
 
-            {error && (
-              <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-                {error}
+          {configLoaded && !azureEnabled && (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="username"
+                  className="text-sm font-medium text-slate-700"
+                >
+                  Username
+                </Label>
+                <div className="relative">
+                  <User className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    id="username"
+                    type="text"
+                    placeholder="Enter your username"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className="h-11 pl-10"
+                    autoComplete="username"
+                    autoFocus
+                    disabled={isLoading}
+                    required
+                  />
+                </div>
               </div>
-            )}
 
-            {configLoaded && !azureEnabled && (
+              <div className="space-y-2">
+                <Label
+                  htmlFor="password"
+                  className="text-sm font-medium text-slate-700"
+                >
+                  Password
+                </Label>
+                <div className="relative">
+                  <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="Enter your password (optional for dev)"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="h-11 pr-10 pl-10"
+                    autoComplete="current-password"
+                    disabled={isLoading}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-600"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+                <p className="text-xs text-slate-500">
+                  In development mode, password is optional
+                </p>
+              </div>
+
               <Button
                 type="submit"
                 className="h-11 w-full font-medium"
@@ -196,26 +230,8 @@ export function Login() {
                   'Log In'
                 )}
               </Button>
-            )}
-
-            {configLoaded && azureEnabled && (
-              <Button
-                type="button"
-                className="h-11 w-full"
-                disabled={isLoading || isAzureLoading}
-                onClick={handleAzureLogin}
-              >
-                {isAzureLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Redirecting to Microsoft...
-                  </>
-                ) : (
-                  'Log in with IDIR'
-                )}
-              </Button>
-            )}
-          </form>
+            </form>
+          )}
 
           <div className="mt-8 border-t pt-6 text-center">
             <p className="text-xs text-slate-400">

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -102,7 +102,7 @@ export function Login() {
                 Corporate Calendar
               </CardTitle>
               <CardDescription className="mt-2 text-slate-500">
-                Sign in to access the calendar management system
+                Log in to access the calendar management system
               </CardDescription>
             </div>
           </div>
@@ -190,10 +190,10 @@ export function Login() {
                 {isLoading ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Signing in...
+                    Logging in...
                   </>
                 ) : (
-                  'Sign In'
+                  'Log In'
                 )}
               </Button>
             )}
@@ -211,7 +211,7 @@ export function Login() {
                     Redirecting to Microsoft...
                   </>
                 ) : (
-                  'Sign in with IDIR'
+                  'Log in with IDIR'
                 )}
               </Button>
             )}


### PR DESCRIPTION
I rolled the visual changes to match Hub's component into this PR, the Windows logo, wording, etc. into this as well. 

Update all user-facing button labels and messages to use the organization-preferred 'log in' / 'log out' terminology:

- Login page: 'Sign in to access...'  'Log in to access...', 'Signing in...'  'Logging in...', 'Sign In 'Log In', 'Sign in with IDIR' 'Log in with IDIR'
- Header dropdown: 'Sign out' 'Log out'
- Autosave indicator: 'Sign in to enable draft saving' → 'Log in to enable draft saving'
- Login tests: updated button name queries to match new label