### PR TITLE
Fix/corpcal 231 hide sysadmin links from admins

### DIFF
--- a/calendar-ui/src/pages/Settings.test.tsx
+++ b/calendar-ui/src/pages/Settings.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/test/test-utils';
+
+// Mock every child admin section so the test only exercises Settings itself.
+vi.mock('@/components/admin', () => ({
+  BannerSettingsAdmin: () => <div data-testid="banner-section">Banner</div>,
+}));
+vi.mock('@/components/admin/ActivityCompletionSettingsAdmin', () => ({
+  ActivityCompletionSettingsAdmin: () => (
+    <div data-testid="activity-completion-section">ActivityCompletion</div>
+  ),
+}));
+vi.mock('@/components/admin/EditLockIdleSettingsAdmin', () => ({
+  EditLockIdleSettingsAdmin: () => (
+    <div data-testid="edit-lock-section">EditLockIdle</div>
+  ),
+}));
+vi.mock('@/components/admin/LoginModalSettingsAdmin', () => ({
+  LoginModalSettingsAdmin: () => (
+    <div data-testid="login-modal-section">LoginModal</div>
+  ),
+}));
+vi.mock('@/components/admin/LookAheadResetSettingsAdmin', () => ({
+  LookAheadResetSettingsAdmin: () => (
+    <div data-testid="look-ahead-section">LookAheadReset</div>
+  ),
+}));
+vi.mock('@/components/admin/ReviewExemptFieldsSettingsAdmin', () => ({
+  ReviewExemptFieldsSettingsAdmin: () => (
+    <div data-testid="review-exempt-section">ReviewExemptFields</div>
+  ),
+}));
+vi.mock('@/components/admin/LookupAdmins', () => ({
+  ActivityStatusesAdmin: () => <div>ActivityStatuses</div>,
+  CategoriesAdmin: () => <div>Categories</div>,
+  CitiesAdmin: () => <div>Cities</div>,
+  CommsMaterialsAdmin: () => <div>CommsMaterials</div>,
+  GovernmentRepresentativesAdmin: () => <div>GovernmentRepresentatives</div>,
+  MinistriesAdmin: () => <div>Ministries</div>,
+  MinistryGroupsAdmin: () => <div>MinistryGroups</div>,
+  TagsAdmin: () => <div>Tags</div>,
+  ThemesAdmin: () => <div>Themes</div>,
+  VenuePresetsAdmin: () => <div>VenuePresets</div>,
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const SYSTEM_ADMIN_ROLE_ID = 6;
+const ADMIN_ROLE_ID = 5;
+
+const SYSTEM_ADMIN_ONLY_LINKS = [
+  'System Banner',
+  'Login Modal',
+  'Edit lock idle',
+  'Activity completion',
+  'Look Ahead reset',
+  'Review-exempt fields',
+];
+
+const LOOKUP_LINKS = [
+  'Ministry groups',
+  'Ministries',
+  'Government Representatives',
+  'Categories',
+  'Cities',
+  'Communications Materials',
+  'Tags',
+  'Activity Statuses',
+  'Themes',
+  'Venue Presets',
+];
+
+describe('Settings quick navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('as System Admin', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 1, roleId: SYSTEM_ADMIN_ROLE_ID },
+        hasPermission: () => true,
+      });
+    });
+
+    it('shows all system-admin-only quick nav links', async () => {
+      const { Settings } = await import('./Settings');
+      render(<Settings />);
+
+      for (const label of SYSTEM_ADMIN_ONLY_LINKS) {
+        expect(
+          screen.getByRole('link', { name: new RegExp(label, 'i') })
+        ).toBeInTheDocument();
+      }
+    });
+
+    it('shows all lookup quick nav links', async () => {
+      const { Settings } = await import('./Settings');
+      render(<Settings />);
+
+      for (const label of LOOKUP_LINKS) {
+        expect(
+          screen.getByRole('link', { name: new RegExp(label, 'i') })
+        ).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('as Admin (not System Admin)', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 2, roleId: ADMIN_ROLE_ID },
+        hasPermission: () => true,
+      });
+    });
+
+    it('hides system-admin-only quick nav links', async () => {
+      const { Settings } = await import('./Settings');
+      render(<Settings />);
+
+      for (const label of SYSTEM_ADMIN_ONLY_LINKS) {
+        expect(
+          screen.queryByRole('link', { name: new RegExp(label, 'i') })
+        ).not.toBeInTheDocument();
+      }
+    });
+
+    it('still shows all lookup quick nav links', async () => {
+      const { Settings } = await import('./Settings');
+      render(<Settings />);
+
+      for (const label of LOOKUP_LINKS) {
+        expect(
+          screen.getByRole('link', { name: new RegExp(label, 'i') })
+        ).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Users,
 } from 'lucide-react';
 
+import { SYSTEM_ROLE_IDS } from '@corpcal/shared';
 import { BannerSettingsAdmin } from '@/components/admin';
 import { ActivityCompletionSettingsAdmin } from '@/components/admin/ActivityCompletionSettingsAdmin';
 import { EditLockIdleSettingsAdmin } from '@/components/admin/EditLockIdleSettingsAdmin';
@@ -35,6 +36,7 @@ import {
   VenuePresetsAdmin,
 } from '@/components/admin/LookupAdmins';
 import { ReviewExemptFieldsSettingsAdmin } from '@/components/admin/ReviewExemptFieldsSettingsAdmin';
+import { useAuth } from '@/hooks/useAuth';
 
 type Section =
   | 'banner'
@@ -54,59 +56,78 @@ type Section =
   | 'themes'
   | 'venue-presets';
 
-const sections = [
-  { id: 'banner' as Section, label: 'System Banner', icon: Megaphone },
-  { id: 'login-modal' as Section, label: 'Login Modal', icon: LogIn },
-  {
-    id: 'edit-lock-idle' as Section,
-    label: 'Edit lock idle',
-    icon: Lock,
-  },
-  {
-    id: 'activity-completion' as Section,
-    label: 'Activity completion',
-    icon: Timer,
-  },
-  {
-    id: 'look-ahead-reset' as Section,
-    label: 'Look Ahead reset',
-    icon: Eraser,
-  },
-  {
-    id: 'review-exempt-fields' as Section,
-    label: 'Review-exempt fields',
-    icon: ListChecks,
-  },
-  {
-    id: 'ministry-groups' as Section,
-    label: 'Ministry groups',
-    icon: Share2,
-  },
-  { id: 'ministries' as Section, label: 'Ministries', icon: Building2 },
-  {
-    id: 'representatives' as Section,
-    label: 'Government Representatives',
-    icon: Users,
-  },
-  { id: 'categories' as Section, label: 'Categories', icon: FolderTree },
-  { id: 'cities' as Section, label: 'Cities', icon: MapPin },
-  { id: 'comms' as Section, label: 'Communications Materials', icon: FileText },
-  { id: 'tags' as Section, label: 'Tags', icon: Tag },
-  { id: 'statuses' as Section, label: 'Activity Statuses', icon: Activity },
-  { id: 'themes' as Section, label: 'Themes', icon: Palette },
-  {
-    id: 'venue-presets' as Section,
-    label: 'Venue Presets',
-    icon: Bookmark,
-  },
-];
-
 /**
  * Modern Settings Page
  * Manages all lookup data with a clean, organized interface.
  * Features quick navigation and modular admin sections.
  */
 export function Settings() {
+  const { user } = useAuth();
+  const isSystemAdmin = user?.roleId === SYSTEM_ROLE_IDS.SYSTEM_ADMIN;
+
+  const sections = [
+    {
+      id: 'banner' as Section,
+      label: 'System Banner',
+      icon: Megaphone,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'login-modal' as Section,
+      label: 'Login Modal',
+      icon: LogIn,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'edit-lock-idle' as Section,
+      label: 'Edit lock idle',
+      icon: Lock,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'activity-completion' as Section,
+      label: 'Activity completion',
+      icon: Timer,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'look-ahead-reset' as Section,
+      label: 'Look Ahead reset',
+      icon: Eraser,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'review-exempt-fields' as Section,
+      label: 'Review-exempt fields',
+      icon: ListChecks,
+      show: isSystemAdmin,
+    },
+    {
+      id: 'ministry-groups' as Section,
+      label: 'Ministry groups',
+      icon: Share2,
+    },
+    { id: 'ministries' as Section, label: 'Ministries', icon: Building2 },
+    {
+      id: 'representatives' as Section,
+      label: 'Government Representatives',
+      icon: Users,
+    },
+    { id: 'categories' as Section, label: 'Categories', icon: FolderTree },
+    { id: 'cities' as Section, label: 'Cities', icon: MapPin },
+    {
+      id: 'comms' as Section,
+      label: 'Communications Materials',
+      icon: FileText,
+    },
+    { id: 'tags' as Section, label: 'Tags', icon: Tag },
+    { id: 'statuses' as Section, label: 'Activity Statuses', icon: Activity },
+    { id: 'themes' as Section, label: 'Themes', icon: Palette },
+    { id: 'venue-presets' as Section, label: 'Venue Presets', icon: Bookmark },
+  ];
+
+  const visibleSections = sections.filter((s) => s.show !== false);
+
   const scrollToSection = (sectionId: Section) => {
     const element = document.getElementById(`section-${sectionId}`);
     if (element) {
@@ -137,7 +158,7 @@ export function Settings() {
           </div>
           <div className="p-4 sm:p-6">
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-              {sections.map((section) => {
+              {visibleSections.map((section) => {
                 const Icon = section.icon;
                 return (
                   <a


### PR DESCRIPTION
Hide quick nav links for items (non-system) admins may not see. Also, I created some unit tests around this behavior.