### PR TITLE
Fix/corpcal 000 always expose alt login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,3 @@ JWT_EXPIRES_IN=43200
 SESSION_SECRET=your-session-secret-change-in-production
 
 # Added a comment to trigger an deploy when committing.
-
-#Allow users to sign in with a "local account", using their email
-LOCAL_AUTH_ENABLED=true

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -79,25 +79,7 @@ export class AuthService {
     }
 
     // Local (email/password) login is always available for any non-mock strategy.
-    if (strategy === 'local' || this.isLocalAuthEnabled()) {
-      return this.loginLocal(body.username, body.password);
-    }
-
-    if (strategy === 'ad') {
-      throw new UnauthorizedException(
-        'AD strategy not yet implemented. Use AUTH_STRATEGY=mock for development.'
-      );
-    }
-
-    if (strategy === 'azure') {
-      throw new UnauthorizedException(
-        'Azure strategy uses OIDC redirect flow. Start at GET /auth/azure.'
-      );
-    }
-
-    throw new UnauthorizedException(
-      `Unknown AUTH_STRATEGY: ${strategy}. Use 'mock', 'local', 'ad', or 'azure'.`
-    );
+    return this.loginLocal(body.username, body.password);
   }
 
   async loginWithAzureClaims(claims: {

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -78,8 +78,7 @@ export class AuthService {
       return this.loginMock(body.username);
     }
 
-    // LOCAL_AUTH_ENABLED=true allows local email/password login alongside any
-    // primary strategy (e.g. AUTH_STRATEGY=azure + LOCAL_AUTH_ENABLED=true).
+    // Local (email/password) login is always available for any non-mock strategy.
     if (strategy === 'local' || this.isLocalAuthEnabled()) {
       return this.loginLocal(body.username, body.password);
     }
@@ -494,15 +493,12 @@ export class AuthService {
   }
 
   /** Whether local (email/password) auth is active.
-   * True when AUTH_STRATEGY=local OR LOCAL_AUTH_ENABLED=true (allows local
-   * login alongside a primary strategy such as azure).
+   * Always true for any strategy other than 'mock' (dev-only).
+   * No configuration required.
    */
   isLocalAuthEnabled(): boolean {
     const strategy = this.configService.get<string>('AUTH_STRATEGY', 'mock');
-    if (strategy === 'local') return true;
-    return (
-      this.configService.get<string>('LOCAL_AUTH_ENABLED', 'false') === 'true'
-    );
+    return strategy !== 'mock';
   }
 
   /** Whether the mock auth strategy is active (development only) */

--- a/docs/AUTH_AND_RBAC.md
+++ b/docs/AUTH_AND_RBAC.md
@@ -65,10 +65,10 @@ Configure authentication in your `.env` file:
 # 'azure' for OIDC (Azure AD / IDIR). Default: 'mock'
 AUTH_STRATEGY=mock
 
-# Enable local (email+password) auth alongside another primary strategy.
-# Set to 'true' when AUTH_STRATEGY is 'azure' and you also want the local
-# login form available (e.g. for admin or break-glass accounts).
-LOCAL_AUTH_ENABLED=false
+# Local (email+password) login is always available for any strategy other than
+# 'mock'. No extra flag is required — users will see the email/password form
+# alongside any primary strategy (e.g. AUTH_STRATEGY=azure).
+# LOCAL_AUTH_ENABLED is no longer used and can be omitted.
 
 # Azure AD settings (required when AUTH_STRATEGY=azure)
 AZURE_TENANT_ID=your-tenant-id
@@ -538,8 +538,7 @@ The `local` strategy allows users to log in with an email address and a bcrypt-h
 | Variable | Values | Meaning |
 |---|---|---|
 | `AUTH_STRATEGY` | `local` | Use email/password as the **only** login method |
-| `AUTH_STRATEGY` | `azure` + `LOCAL_AUTH_ENABLED=true` | Azure AD is primary; local login form also shown |
-| `LOCAL_AUTH_ENABLED` | `true` | Enable local form alongside any primary strategy |
+| `AUTH_STRATEGY` | `azure` | Azure AD is primary; local login form is **also always shown** (no extra flag needed) |
 
 ### Account lifecycle
 


### PR DESCRIPTION
Remove parameters that make the ability to login with email and password conditional. We can always add it back in if we need to. I also cleared up redundant code.