### PR TITLE
fix(CORPCAL-234): remove duplicate favourites tab trigger

### DIFF
--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -270,7 +270,6 @@ export const ActivityListPage = () => {
             )}
             <TabsTrigger value="my-activities">My activities</TabsTrigger>
             <TabsTrigger value="shared-with-me">Shared with me</TabsTrigger>
-            <TabsTrigger value="favourites">Favourite activities</TabsTrigger>
             <TabsTrigger value="assigned-to-me">Assigned to me</TabsTrigger>
             <TabsTrigger value="favourites">My watchlist</TabsTrigger>
           </TabsList>


### PR DESCRIPTION
Favourite activities TabsTrigger (value=favourites) was left behind when the tab was renamed to My watchlist, causing both tabs to appear selected simultaneously. Quick fix
