### PR TITLE
fix: clone activity writes only one history record (on the new activity)

### DIFF
--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -3358,7 +3358,7 @@ describe('ActivitiesService', () => {
       expect((dto as Record<string, unknown>).markAsReviewed).toBe(true);
     });
 
-    it('records a "cloned" history entry on the source with the same notes', async () => {
+    it('does not record a history entry on the source activity', async () => {
       const source = createMockActivityResponse({
         id: 100,
         displayId: 'GCPE-000100',
@@ -3382,20 +3382,7 @@ describe('ActivitiesService', () => {
         cloneContext
       );
 
-      expect(mockActivityHistoryService.recordChange).toHaveBeenCalledWith(
-        100,
-        42,
-        'cloned',
-        [
-          { field: 'clonedToActivityId', oldValue: null, newValue: 200 },
-          {
-            field: 'clonedToDisplayId',
-            oldValue: null,
-            newValue: 'GCPE-000200',
-          },
-        ],
-        'same note'
-      );
+      expect(mockActivityHistoryService.recordChange).not.toHaveBeenCalled();
     });
 
     it('omits advanced field paths not present in includeFieldPaths', async () => {

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -2567,10 +2567,9 @@ export class ActivitiesService {
    * - Field-level write scopes the user cannot edit are stripped.
    * - Initial activity status matches **create** rules: `new` or `reviewed` from
    *   `markAsReviewed` when the user has `activities.review` (see `create`).
-   * Two history entries are recorded with the same optional note:
-   * - `created` on the new activity (with source provenance in `changes`).
-   * - `cloned` on the source activity (with new-activity provenance in
-   *   `changes`).
+   * A single history entry is recorded on the new activity (`created`) with
+   * source provenance (`clonedFromActivityId` / `clonedFromDisplayId`) in
+   * `changes`. No history record is written to the source activity.
    */
   async clone(
     sourceId: number,
@@ -2651,25 +2650,6 @@ export class ActivitiesService {
     const created = await this.create(dto, userId, context, {
       extraCreateChanges: sourceProvenance,
     });
-
-    await this.activityHistoryService.recordChange(
-      sourceId,
-      userId,
-      'cloned',
-      [
-        {
-          field: 'clonedToActivityId',
-          oldValue: null,
-          newValue: created.id,
-        },
-        {
-          field: 'clonedToDisplayId',
-          oldValue: null,
-          newValue: created.displayId ?? null,
-        },
-      ],
-      body.activityHistoryNotes
-    );
 
     return created;
   }


### PR DESCRIPTION
Previously, cloning an activity created two history entries: a created record on the new activity and a cloned record on the source activity. The desired behaviour is a single entry on the new activity only.

Removed the ctivityHistoryService.recordChange call on the source activity in ActivitiesService.clone. Updated the JSDoc and the corresponding unit test to reflect the new single-record behaviour.