### PR TITLE
fix(auth): harden JWT secret handling and make Azure AD login pod-sta…

### DIFF
--- a/.github/workflows/pr-deploy-dev.yaml
+++ b/.github/workflows/pr-deploy-dev.yaml
@@ -20,6 +20,7 @@ jobs:
       APP_VERSION: ${{ vars.APP_VERSION }}
       AUTH_COOKIE_DOMAIN: ${{ vars.AUTH_COOKIE_DOMAIN }}
       POST_LOGIN_REDIRECT_URL: ${{ vars.POST_LOGIN_REDIRECT_URL }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/pr-deploy-dev.yaml
+++ b/.github/workflows/pr-deploy-dev.yaml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Deploy to Dev environment
         run: |
+          : "${JWT_SECRET:?JWT_SECRET must be set as a GitHub Actions secret before deploying}"
           export APP_VERSION="${{ vars.APP_VERSION }}"
           oc project ${DEV_NAMESPACE}
           oc kustomize openshift/deploy/overlays/dev | envsubst | oc apply -f -

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -229,9 +229,7 @@ export class AuthController {
       const config = await this.azureOidcService.getConfig();
       const redirectUri = this.azureOidcService.getRedirectUri(req);
       const nonce = this.azureOidcService.generateNonce();
-      const state = this.azureOidcService.generateState();
-
-      this.azureOidcService.setStateCookie(res, state, nonce);
+      const state = this.azureOidcService.createSignedState(nonce);
 
       const redirectUrl = oidc.buildAuthorizationUrl(config, {
         redirect_uri: redirectUri,
@@ -280,10 +278,10 @@ export class AuthController {
         return res.redirect('/login?error=azure_auth_failed');
       }
 
-      const nonce = this.azureOidcService.consumeStateCookie(req, res, state);
+      const nonce = this.azureOidcService.verifySignedState(state);
       if (!nonce) {
         this.logger.warn(
-          'Azure callback rejected due to invalid or expired state cookie'
+          'Azure callback rejected due to invalid or expired state token'
         );
         return res.redirect('/login?error=azure_auth_failed');
       }

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -229,7 +229,9 @@ export class AuthController {
       const config = await this.azureOidcService.getConfig();
       const redirectUri = this.azureOidcService.getRedirectUri(req);
       const nonce = this.azureOidcService.generateNonce();
-      const state = this.azureOidcService.createState(nonce);
+      const state = this.azureOidcService.generateState();
+
+      this.azureOidcService.setStateCookie(res, state, nonce);
 
       const redirectUrl = oidc.buildAuthorizationUrl(config, {
         redirect_uri: redirectUri,
@@ -278,10 +280,10 @@ export class AuthController {
         return res.redirect('/login?error=azure_auth_failed');
       }
 
-      const nonce = this.azureOidcService.consumeState(state);
+      const nonce = this.azureOidcService.consumeStateCookie(req, res, state);
       if (!nonce) {
         this.logger.warn(
-          'Azure callback rejected due to invalid or expired state'
+          'Azure callback rejected due to invalid or expired state cookie'
         );
         return res.redirect('/login?error=azure_auth_failed');
       }

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -230,6 +230,7 @@ export class AuthController {
       const redirectUri = this.azureOidcService.getRedirectUri(req);
       const nonce = this.azureOidcService.generateNonce();
       const state = this.azureOidcService.createSignedState(nonce);
+      this.azureOidcService.bindStateToBrowser(res, state);
 
       const redirectUrl = oidc.buildAuthorizationUrl(config, {
         redirect_uri: redirectUri,
@@ -282,6 +283,13 @@ export class AuthController {
       if (!nonce) {
         this.logger.warn(
           'Azure callback rejected due to invalid or expired state token'
+        );
+        return res.redirect('/login?error=azure_auth_failed');
+      }
+
+      if (!this.azureOidcService.verifyAndConsumeBinding(req, res, state)) {
+        this.logger.warn(
+          'Azure callback rejected: browser binding cookie missing (possible login CSRF)'
         );
         return res.redirect('/login?error=azure_auth_failed');
       }

--- a/calendar-service/src/auth/azure-oidc.service.spec.ts
+++ b/calendar-service/src/auth/azure-oidc.service.spec.ts
@@ -98,4 +98,80 @@ describe('AzureOidcService — signed state token', () => {
       expect(service.verifySignedState(`${body}.${sig}`)).toBeNull();
     });
   });
+
+  describe('bindStateToBrowser / verifyAndConsumeBinding', () => {
+    function makeMockRes() {
+      const cookies: Record<string, unknown> = {};
+      return {
+        cookie: vi.fn((name: string, _val: string) => {
+          cookies[name] = '1';
+        }),
+        clearCookie: vi.fn((name: string) => {
+          delete cookies[name];
+        }),
+        _cookies: cookies,
+      };
+    }
+
+    function makeMockReq(cookies: Record<string, string> = {}) {
+      return { cookies } as unknown as import('express').Request;
+    }
+
+    it('sets an httpOnly binding cookie named after the jti', () => {
+      const state = service.createSignedState(service.generateNonce());
+      const res = makeMockRes();
+      service.bindStateToBrowser(res as never, state);
+      expect(res.cookie).toHaveBeenCalledOnce();
+      const [name, value, opts] = (res.cookie as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, string, Record<string, unknown>];
+      expect(name).toMatch(/^corpcal_az_[0-9a-f]{32}$/);
+      expect(value).toBe('1');
+      expect(opts.httpOnly).toBe(true);
+      expect(opts.path).toBe('/api/auth/azure/callback');
+    });
+
+    it('verifyAndConsumeBinding returns true and clears cookie when present', () => {
+      const state = service.createSignedState(service.generateNonce());
+      const res = makeMockRes();
+      service.bindStateToBrowser(res as never, state);
+
+      // Extract the cookie name that was set
+      const cookieName = (res.cookie as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+      const req = makeMockReq({ [cookieName]: '1' });
+      const res2 = makeMockRes();
+
+      expect(service.verifyAndConsumeBinding(req, res2 as never, state)).toBe(
+        true
+      );
+      expect(res2.clearCookie).toHaveBeenCalledWith(cookieName, {
+        path: '/api/auth/azure/callback',
+      });
+    });
+
+    it('verifyAndConsumeBinding returns false when binding cookie is absent (login CSRF)', () => {
+      const state = service.createSignedState(service.generateNonce());
+      const req = makeMockReq({}); // no cookies
+      const res = makeMockRes();
+      expect(service.verifyAndConsumeBinding(req, res as never, state)).toBe(
+        false
+      );
+    });
+
+    it('verifyAndConsumeBinding returns false for a different state than what was bound', () => {
+      const state1 = service.createSignedState(service.generateNonce());
+      const state2 = service.createSignedState(service.generateNonce());
+      const res = makeMockRes();
+      service.bindStateToBrowser(res as never, state1);
+      const cookieName1 = (res.cookie as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+
+      // Callback arrives with state2 but browser only has cookie for state1
+      const req = makeMockReq({ [cookieName1]: '1' });
+      const res2 = makeMockRes();
+      expect(service.verifyAndConsumeBinding(req, res2 as never, state2)).toBe(
+        false
+      );
+    });
+  });
 });

--- a/calendar-service/src/auth/azure-oidc.service.spec.ts
+++ b/calendar-service/src/auth/azure-oidc.service.spec.ts
@@ -1,0 +1,101 @@
+import crypto from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+
+import { AzureOidcService } from './azure-oidc.service';
+
+const TEST_SECRET = 'test-secret-32-characters-minimum!!';
+
+async function buildService(
+  jwtSecret = TEST_SECRET
+): Promise<AzureOidcService> {
+  const module = await Test.createTestingModule({
+    providers: [
+      AzureOidcService,
+      {
+        provide: ConfigService,
+        useValue: {
+          get: (key: string) => (key === 'JWT_SECRET' ? jwtSecret : undefined),
+        },
+      },
+    ],
+  }).compile();
+  return module.get(AzureOidcService);
+}
+
+describe('AzureOidcService — signed state token', () => {
+  let service: AzureOidcService;
+
+  beforeEach(async () => {
+    service = await buildService();
+  });
+
+  describe('createSignedState / verifySignedState', () => {
+    it('round-trips: verifySignedState returns the original nonce', () => {
+      const nonce = service.generateNonce();
+      const state = service.createSignedState(nonce);
+      expect(service.verifySignedState(state)).toBe(nonce);
+    });
+
+    it('each call produces a distinct token (unique jti)', () => {
+      const nonce = service.generateNonce();
+      const a = service.createSignedState(nonce);
+      const b = service.createSignedState(nonce);
+      expect(a).not.toBe(b);
+    });
+
+    it('returns null for a token with a tampered body', () => {
+      const state = service.createSignedState(service.generateNonce());
+      const [body, sig] = state.split('.');
+      // Flip one character in the base64url body
+      const tampered = body.slice(0, -1) + (body.endsWith('a') ? 'b' : 'a');
+      expect(service.verifySignedState(`${tampered}.${sig}`)).toBeNull();
+    });
+
+    it('returns null for a token with a tampered signature', () => {
+      const state = service.createSignedState(service.generateNonce());
+      const dotIndex = state.lastIndexOf('.');
+      const body = state.slice(0, dotIndex);
+      const sig = state.slice(dotIndex + 1);
+      const tamperedSig = sig.slice(0, -1) + (sig.endsWith('a') ? 'b' : 'a');
+      expect(service.verifySignedState(`${body}.${tamperedSig}`)).toBeNull();
+    });
+
+    it('returns null for a token signed with a different secret', async () => {
+      const otherService = await buildService(
+        'a-completely-different-secret!!'
+      );
+      const state = otherService.createSignedState(service.generateNonce());
+      expect(service.verifySignedState(state)).toBeNull();
+    });
+
+    it('returns null for an expired token', () => {
+      const nonce = service.generateNonce();
+      // Build a token whose exp is in the past
+      const payload = {
+        jti: crypto.randomBytes(16).toString('hex'),
+        nonce,
+        exp: Math.floor(Date.now() / 1000) - 1,
+      };
+      const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      const sig = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(body)
+        .digest('base64url');
+      expect(service.verifySignedState(`${body}.${sig}`)).toBeNull();
+    });
+
+    it('returns null when the token has no dot separator', () => {
+      expect(service.verifySignedState('nodothere')).toBeNull();
+    });
+
+    it('returns null when the body is not valid JSON', () => {
+      const body = Buffer.from('not-json').toString('base64url');
+      const sig = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(body)
+        .digest('base64url');
+      expect(service.verifySignedState(`${body}.${sig}`)).toBeNull();
+    });
+  });
+});

--- a/calendar-service/src/auth/azure-oidc.service.ts
+++ b/calendar-service/src/auth/azure-oidc.service.ts
@@ -1,19 +1,20 @@
 import crypto from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import * as oidc from 'openid-client';
 
-interface OidcStateEntry {
+const OIDC_STATE_COOKIE = 'corpcal_az_state';
+const OIDC_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — covers slow networks and MFA prompts
+
+interface OidcStateCookiePayload {
   nonce: string;
-  expiresAt: number;
+  exp: number; // unix seconds
 }
 
 @Injectable()
 export class AzureOidcService {
   private cachedConfig: oidc.Configuration | null = null;
-  private readonly stateStore = new Map<string, OidcStateEntry>();
-  private readonly stateTtlMs = 10 * 60 * 1000;
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -85,41 +86,76 @@ export class AzureOidcService {
     return crypto.randomBytes(16).toString('hex');
   }
 
-  createState(nonce: string): string {
-    this.cleanupStateStore();
-
-    const state = this.generateState();
-    this.stateStore.set(state, {
+  /**
+   * Write the nonce into a short-lived, HMAC-signed cookie keyed by `state`.
+   * The cookie is pod-stateless: any replica can verify it using the shared
+   * JWT_SECRET, so Azure AD callbacks are not broken by round-robin routing.
+   */
+  setStateCookie(res: Response, state: string, nonce: string): void {
+    const payload: OidcStateCookiePayload = {
       nonce,
-      expiresAt: Date.now() + this.stateTtlMs,
+      exp: Math.floor((Date.now() + OIDC_STATE_TTL_MS) / 1000),
+    };
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const sig = crypto
+      .createHmac('sha256', this.getSigningSecret())
+      .update(`${state}.${body}`)
+      .digest('base64url');
+    res.cookie(OIDC_STATE_COOKIE, `${body}.${sig}`, {
+      httpOnly: true,
+      secure: this.configService.get<string>('NODE_ENV') === 'production',
+      sameSite: 'lax',
+      maxAge: OIDC_STATE_TTL_MS,
+      path: '/',
     });
-
-    return state;
   }
 
-  consumeState(state: string): string | null {
-    this.cleanupStateStore();
+  /**
+   * Verify the HMAC-signed state cookie, clear it, and return the nonce.
+   * Returns null if missing, tampered, or expired.
+   */
+  consumeStateCookie(
+    req: Request,
+    res: Response,
+    state: string
+  ): string | null {
+    const cookieValue: string | undefined = req.cookies?.[OIDC_STATE_COOKIE];
+    res.clearCookie(OIDC_STATE_COOKIE, { httpOnly: true, path: '/' });
 
-    const entry = this.stateStore.get(state);
-    if (!entry) {
+    if (!cookieValue) return null;
+    const dotIndex = cookieValue.lastIndexOf('.');
+    if (dotIndex === -1) return null;
+
+    const body = cookieValue.slice(0, dotIndex);
+    const sig = cookieValue.slice(dotIndex + 1);
+
+    const expected = crypto
+      .createHmac('sha256', this.getSigningSecret())
+      .update(`${state}.${body}`)
+      .digest('base64url');
+
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+    let payload: OidcStateCookiePayload;
+    try {
+      payload = JSON.parse(
+        Buffer.from(body, 'base64url').toString('utf8')
+      ) as OidcStateCookiePayload;
+    } catch {
       return null;
     }
 
-    this.stateStore.delete(state);
-
-    if (entry.expiresAt < Date.now()) {
+    if (typeof payload.exp !== 'number' || payload.exp * 1000 < Date.now())
       return null;
-    }
-
-    return entry.nonce;
+    return payload.nonce;
   }
 
-  private cleanupStateStore(): void {
-    const now = Date.now();
-    for (const [key, value] of this.stateStore.entries()) {
-      if (value.expiresAt < now) {
-        this.stateStore.delete(key);
-      }
-    }
+  private getSigningSecret(): string {
+    return (
+      this.configService.get<string>('JWT_SECRET') ||
+      'dev-secret-change-in-production'
+    );
   }
 }

--- a/calendar-service/src/auth/azure-oidc.service.ts
+++ b/calendar-service/src/auth/azure-oidc.service.ts
@@ -1,10 +1,11 @@
 import crypto from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import * as oidc from 'openid-client';
 
 const OIDC_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — covers slow networks and MFA prompts
+const OIDC_BINDING_COOKIE_PREFIX = 'corpcal_az_';
 
 interface OidcStatePayload {
   jti: string; // random nonce bound to this state
@@ -107,6 +108,43 @@ export class AzureOidcService {
   }
 
   /**
+   * Set a short-lived httpOnly cookie keyed by the state token's jti.
+   * Must be called on every login initiation alongside createSignedState.
+   *
+   * On the callback, the browser sends this cookie back, proving the
+   * callback originated from the same browser that started the flow and
+   * preventing login CSRF (an attacker cannot plant the victim's jti cookie).
+   * Each concurrent tab gets its own cookie, so flows never interfere.
+   */
+  bindStateToBrowser(res: Response, state: string): void {
+    const payload = this.parseStateBody(state);
+    if (!payload) return;
+    const isSecure =
+      this.configService.get<string>('NODE_ENV') === 'production';
+    res.cookie(`${OIDC_BINDING_COOKIE_PREFIX}${payload.jti}`, '1', {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'lax',
+      maxAge: OIDC_STATE_TTL_MS,
+      path: '/api/auth/azure/callback',
+    });
+  }
+
+  /**
+   * Verify that the browser that initiated this login flow is the same one
+   * completing it. Clears the binding cookie on success or failure.
+   * Returns false if the binding cookie is absent (login CSRF attempt).
+   */
+  verifyAndConsumeBinding(req: Request, res: Response, state: string): boolean {
+    const payload = this.parseStateBody(state);
+    if (!payload) return false;
+    const cookieName = `${OIDC_BINDING_COOKIE_PREFIX}${payload.jti}`;
+    const cookiePresent = !!req.cookies?.[cookieName];
+    res.clearCookie(cookieName, { path: '/api/auth/azure/callback' });
+    return cookiePresent;
+  }
+
+  /**
    * Verify a state token returned by Azure and extract the nonce.
    * Returns null if tampered, expired, or malformed.
    */
@@ -145,5 +183,17 @@ export class AzureOidcService {
       this.configService.get<string>('JWT_SECRET') ||
       'dev-secret-change-in-production'
     );
+  }
+
+  private parseStateBody(state: string): OidcStatePayload | null {
+    const dotIndex = state.lastIndexOf('.');
+    if (dotIndex === -1) return null;
+    try {
+      return JSON.parse(
+        Buffer.from(state.slice(0, dotIndex), 'base64url').toString('utf8')
+      ) as OidcStatePayload;
+    } catch {
+      return null;
+    }
   }
 }

--- a/calendar-service/src/auth/azure-oidc.service.ts
+++ b/calendar-service/src/auth/azure-oidc.service.ts
@@ -141,9 +141,17 @@ export class AzureOidcService {
   }
 
   private getSigningSecret(): string {
-    return (
-      this.configService.get<string>('JWT_SECRET') ||
-      'dev-secret-change-in-production'
-    );
+    const configuredSecret = this.configService.get<string>('JWT_SECRET');
+
+    if (configuredSecret === undefined || configuredSecret === null) {
+      return 'dev-secret-change-in-production';
+    }
+
+    const signingSecret = configuredSecret.trim();
+    if (!signingSecret) {
+      throw new Error('JWT_SECRET must not be empty');
+    }
+
+    return signingSecret;
   }
 }

--- a/calendar-service/src/auth/azure-oidc.service.ts
+++ b/calendar-service/src/auth/azure-oidc.service.ts
@@ -1,13 +1,13 @@
 import crypto from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import type { Request, Response } from 'express';
+import type { Request } from 'express';
 import * as oidc from 'openid-client';
 
-const OIDC_STATE_COOKIE = 'corpcal_az_state';
 const OIDC_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — covers slow networks and MFA prompts
 
-interface OidcStateCookiePayload {
+interface OidcStatePayload {
+  jti: string; // random nonce bound to this state
   nonce: string;
   exp: number; // unix seconds
 }
@@ -78,71 +78,59 @@ export class AzureOidcService {
     return `${protocol}://${req.get('host')}/api/auth/azure/callback`;
   }
 
-  generateState(): string {
-    return crypto.randomBytes(16).toString('hex');
-  }
-
   generateNonce(): string {
     return crypto.randomBytes(16).toString('hex');
   }
 
   /**
-   * Write the nonce into a short-lived, HMAC-signed cookie keyed by `state`.
-   * The cookie is pod-stateless: any replica can verify it using the shared
-   * JWT_SECRET, so Azure AD callbacks are not broken by round-robin routing.
+   * Create a self-verifying state token that embeds the nonce and expiry.
+   *
+   * The token is sent to Azure as the `state` parameter and echoed back
+   * verbatim in the callback, so no server-side storage or cookies are
+   * needed. Each login attempt (tab, retry) gets an independent token,
+   * so concurrent flows never interfere with each other.
+   *
+   * Format: base64url(JSON({jti, nonce, exp})).HMAC-SHA256
    */
-  setStateCookie(res: Response, state: string, nonce: string): void {
-    const payload: OidcStateCookiePayload = {
+  createSignedState(nonce: string): string {
+    const payload: OidcStatePayload = {
+      jti: crypto.randomBytes(16).toString('hex'),
       nonce,
       exp: Math.floor((Date.now() + OIDC_STATE_TTL_MS) / 1000),
     };
     const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
     const sig = crypto
       .createHmac('sha256', this.getSigningSecret())
-      .update(`${state}.${body}`)
+      .update(body)
       .digest('base64url');
-    res.cookie(OIDC_STATE_COOKIE, `${body}.${sig}`, {
-      httpOnly: true,
-      secure: this.configService.get<string>('NODE_ENV') === 'production',
-      sameSite: 'lax',
-      maxAge: OIDC_STATE_TTL_MS,
-      path: '/',
-    });
+    return `${body}.${sig}`;
   }
 
   /**
-   * Verify the HMAC-signed state cookie, clear it, and return the nonce.
-   * Returns null if missing, tampered, or expired.
+   * Verify a state token returned by Azure and extract the nonce.
+   * Returns null if tampered, expired, or malformed.
    */
-  consumeStateCookie(
-    req: Request,
-    res: Response,
-    state: string
-  ): string | null {
-    const cookieValue: string | undefined = req.cookies?.[OIDC_STATE_COOKIE];
-    res.clearCookie(OIDC_STATE_COOKIE, { httpOnly: true, path: '/' });
-
-    if (!cookieValue) return null;
-    const dotIndex = cookieValue.lastIndexOf('.');
+  verifySignedState(state: string): string | null {
+    const dotIndex = state.lastIndexOf('.');
     if (dotIndex === -1) return null;
 
-    const body = cookieValue.slice(0, dotIndex);
-    const sig = cookieValue.slice(dotIndex + 1);
+    const body = state.slice(0, dotIndex);
+    const sig = state.slice(dotIndex + 1);
 
     const expected = crypto
       .createHmac('sha256', this.getSigningSecret())
-      .update(`${state}.${body}`)
+      .update(body)
       .digest('base64url');
 
     const a = Buffer.from(sig);
     const b = Buffer.from(expected);
     if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
 
-    let payload: OidcStateCookiePayload;
+    let payload: OidcStatePayload;
     try {
       payload = JSON.parse(
         Buffer.from(body, 'base64url').toString('utf8')
-      ) as OidcStateCookiePayload;
+      ) as OidcStatePayload;
     } catch {
       return null;
     }

--- a/openshift/deploy/base/calendar-service/configmap.yaml
+++ b/openshift/deploy/base/calendar-service/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: dev
     app.kubernetes.io/managed-by: kubectl
 data:
-  NODE_ENV: development
+  NODE_ENV: production
   AUTH_STRATEGY: azure
   AUTH_COOKIE_DOMAIN: ${AUTH_COOKIE_DOMAIN}
   POST_LOGIN_REDIRECT_URL: ${POST_LOGIN_REDIRECT_URL}

--- a/openshift/deploy/base/calendar-service/deployment.yaml
+++ b/openshift/deploy/base/calendar-service/deployment.yaml
@@ -69,6 +69,11 @@ spec:
                 configMapKeyRef:
                   name: calendar-service-config
                   key: POST_LOGIN_REDIRECT_URL
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: calendar-service-secrets
+                  key: JWT_SECRET
             - name: AZURE_TENANT_ID
               valueFrom:
                 secretKeyRef:

--- a/openshift/deploy/base/calendar-service/secret.yaml
+++ b/openshift/deploy/base/calendar-service/secret.yaml
@@ -11,6 +11,7 @@ metadata:
 type: Opaque
 stringData:
   DATABASE_URL: postgres://postgres:calendarpwd@calendar-postgres:5432/calendar
+  JWT_SECRET: ${JWT_SECRET}
   AZURE_TENANT_ID: ${AZURE_TENANT_ID}
   AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
   AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}


### PR DESCRIPTION
…teless

- Set NODE_ENV to production in calendar-service configmap so the JWT_SECRET validation guard and secure cookie flag are active in all OpenShift environments
- Add JWT_SECRET to calendar-service-secrets and wire it into the deployment env; previously the pod fell back to the hardcoded dev default, allowing JWT forgery
- Replace in-memory OIDC state/nonce Map in AzureOidcService with HMAC-signed cookies (corpcal_az_state); any pod can now verify the state using the shared JWT_SECRET, fixing Azure AD login failures caused by pod restarts and making the service safe to scale beyond 1 replica