### PR TITLE
fix(calendar-ui): prevent stale empty rich text updates during hydration

### DIFF
--- a/calendar-ui/src/components/ui/rich-text-field.test.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EMPTY_RICH_TEXT_DOC,
+  tipTapDocJsonFromPlainText,
+} from '@corpcal/shared/utils';
+
+import { shouldIgnoreStaleEmptyRichTextUpdate } from './rich-text-field';
+
+describe('shouldIgnoreStaleEmptyRichTextUpdate', () => {
+  const savedValue = tipTapDocJsonFromPlainText('Saved summary');
+
+  it('ignores unfocused empty TipTap updates when the controlled value has content', () => {
+    expect(
+      shouldIgnoreStaleEmptyRichTextUpdate({
+        editorIsFocused: false,
+        nextValue: '{"type":"doc"}',
+        currentValue: savedValue,
+      })
+    ).toBe(true);
+  });
+
+  it('allows focused empty updates so users can intentionally clear the field', () => {
+    expect(
+      shouldIgnoreStaleEmptyRichTextUpdate({
+        editorIsFocused: true,
+        nextValue: EMPTY_RICH_TEXT_DOC,
+        currentValue: savedValue,
+      })
+    ).toBe(false);
+  });
+
+  it('allows non-empty editor updates', () => {
+    expect(
+      shouldIgnoreStaleEmptyRichTextUpdate({
+        editorIsFocused: false,
+        nextValue: tipTapDocJsonFromPlainText('Edited summary'),
+        currentValue: savedValue,
+      })
+    ).toBe(false);
+  });
+});

--- a/calendar-ui/src/components/ui/rich-text-field.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.tsx
@@ -10,6 +10,7 @@ import {
 import sanitizeHtml from 'sanitize-html';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { isActivityRichTextEffectivelyEmpty } from '@corpcal/shared/utils';
 import { Button } from '@/components/ui/button';
 import { RichTextLinkDialog } from '@/components/ui/rich-text-field-link-dialog';
 import { Separator } from '@/components/ui/separator';
@@ -46,6 +47,22 @@ const PASTE_ALLOWED_TAGS = [
 ];
 const PASTE_ALLOWED_ATTR = { a: ['href'] };
 
+export function shouldIgnoreStaleEmptyRichTextUpdate({
+  editorIsFocused,
+  nextValue,
+  currentValue,
+}: {
+  editorIsFocused: boolean;
+  nextValue: string;
+  currentValue: string;
+}): boolean {
+  return (
+    !editorIsFocused &&
+    isActivityRichTextEffectivelyEmpty(nextValue) &&
+    !isActivityRichTextEffectivelyEmpty(currentValue)
+  );
+}
+
 export function RichTextField({
   id,
   name,
@@ -60,6 +77,11 @@ export function RichTextField({
 }: RichTextFieldProps) {
   const editable = !readOnly && !disabled;
   const initialArgs = useRef(getSetContentArgs(value));
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const isSyncingFromPropRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
   const extensions = useMemo(
     () => getActivityRichTextEditorExtensions({ placeholder }),
     [placeholder]
@@ -95,7 +117,21 @@ export function RichTextField({
       },
     },
     onUpdate: ({ editor: ed }) => {
-      onChange(JSON.stringify(ed.getJSON()));
+      if (isSyncingFromPropRef.current) return;
+
+      const json = JSON.stringify(ed.getJSON());
+      const propValue = valueRef.current;
+      if (
+        shouldIgnoreStaleEmptyRichTextUpdate({
+          editorIsFocused: ed.isFocused,
+          nextValue: json,
+          currentValue: propValue,
+        })
+      ) {
+        return;
+      }
+
+      onChangeRef.current(json);
     },
   });
 
@@ -195,13 +231,27 @@ export function RichTextField({
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
     const args = getSetContentArgs(value);
+    const applyFromProp = () => {
+      isSyncingFromPropRef.current = true;
+      if (args.contentType === 'json') {
+        editor.commands.setContent(args.content, { emitUpdate: false });
+      } else {
+        editor.commands.setContent(args.content, {
+          contentType: 'markdown',
+          emitUpdate: false,
+        });
+      }
+      queueMicrotask(() => {
+        isSyncingFromPropRef.current = false;
+      });
+    };
     if (args.contentType === 'json') {
       if (JSON.stringify(args.content) === JSON.stringify(editor.getJSON())) {
         return;
       }
       queueMicrotask(() => {
         if (!editor || editor.isDestroyed) return;
-        editor.commands.setContent(args.content, { emitUpdate: false });
+        applyFromProp();
       });
       return;
     }
@@ -211,10 +261,7 @@ export function RichTextField({
     }
     queueMicrotask(() => {
       if (!editor || editor.isDestroyed) return;
-      editor.commands.setContent(args.content, {
-        contentType: 'markdown',
-        emitUpdate: false,
-      });
+      applyFromProp();
     });
   }, [editor, value]);
 

--- a/calendar-ui/src/hooks/useActivityEditFormHydration.test.tsx
+++ b/calendar-ui/src/hooks/useActivityEditFormHydration.test.tsx
@@ -68,7 +68,7 @@ describe('useActivityEditFormHydration', () => {
     expect(result.current.initialFormDataRef.current?.strategy).toBe('');
   });
 
-  it('hydrates synchronously when lookups are ready', () => {
+  it('marks hydrated after reset-driven controls have a task turn to settle', () => {
     const activity = createMockActivityResponse({
       id: 1,
       lastUpdatedDateTime: '2025-01-01T12:00:00.000Z',
@@ -79,6 +79,12 @@ describe('useActivityEditFormHydration', () => {
         defaultValues: getDefaultFormValues() as ActivityFormData,
       });
       return useActivityEditFormHydration(activity, mockLookups, form);
+    });
+
+    expect(result.current.isFormHydrated).toBe(false);
+
+    act(() => {
+      vi.runAllTimers();
     });
 
     expect(result.current.isFormHydrated).toBe(true);
@@ -107,6 +113,10 @@ describe('useActivityEditFormHydration', () => {
       return useActivityEditFormHydration(activity, mockLookups, form);
     });
 
+    act(() => {
+      vi.runAllTimers();
+    });
+
     expect(formRef!.formState.isDirty).toBe(false);
     expect(Object.keys(formRef!.formState.dirtyFields)).toHaveLength(0);
   });
@@ -126,6 +136,10 @@ describe('useActivityEditFormHydration', () => {
       });
       formRef = form;
       return useActivityEditFormHydration(activity, mockLookups, form);
+    });
+
+    act(() => {
+      vi.runAllTimers();
     });
 
     act(() => {
@@ -157,6 +171,10 @@ describe('useActivityEditFormHydration', () => {
     expect(result.current.hydrationGeneration).toBe(0);
 
     rerender({ lookups: mockLookups });
+
+    act(() => {
+      vi.runAllTimers();
+    });
 
     expect(result.current.isFormHydrated).toBe(true);
     expect(result.current.hydrationGeneration).toBe(1);

--- a/calendar-ui/src/hooks/useActivityEditFormHydration.ts
+++ b/calendar-ui/src/hooks/useActivityEditFormHydration.ts
@@ -27,10 +27,9 @@ import type { FormLookupData } from './useFormLookups';
  * Exposes {@link isFormHydrated} and a monotonic {@link hydrationGeneration}
  * for lock-intent logic.
  *
- * On **re-hydration** (activity sync key changes after the first successful
- * hydrate), {@link isFormHydrated} is set to `false` before `form.reset()` and
- * restored on the next macrotask so {@link useEditLockIntent} does not treat
- * in-flight reset churn as a user edit.
+ * On every hydrate (including the first), {@link isFormHydrated} is cleared before
+ * `form.reset()` and restored on the next macrotask so {@link useEditLockIntent}
+ * and TipTap controlled inputs can settle before change detection runs.
  */
 export function useActivityEditFormHydration(
   activity: ActivityResponse,
@@ -49,7 +48,6 @@ export function useActivityEditFormHydration(
 
   const [isFormHydrated, setIsFormHydrated] = useState(false);
   const [hydrationGeneration, setHydrationGeneration] = useState(0);
-  const hasHydratedRef = useRef(false);
 
   const activitySyncKey = `${activity.id}\0${activity.lastUpdatedDateTime}`;
   const lookupsReady = !lookups.isLoading && !lookups.hasError;
@@ -57,10 +55,7 @@ export function useActivityEditFormHydration(
   useEffect(() => {
     if (!lookupsReady) return;
 
-    const isRehydration = hasHydratedRef.current;
-    if (isRehydration) {
-      setIsFormHydrated(false);
-    }
+    setIsFormHydrated(false);
 
     const mapped = hydrateActivityFormData(
       activityRef.current,
@@ -69,23 +64,14 @@ export function useActivityEditFormHydration(
     form.reset(mapped);
     initialFormDataRef.current = mapped;
 
-    if (isRehydration) {
-      // Macrotask (not queueMicrotask): form.reset() and child controlled inputs
-      // need one paint/task turn to settle before useEditLockIntent compares baseline
-      // vs getValues(). Without this deferral, lock intent can treat reset churn as edits.
-      const timeoutId = window.setTimeout(() => {
-        setIsFormHydrated(true);
-        setHydrationGeneration((g) => g + 1);
-      }, 0);
+    const timeoutId = window.setTimeout(() => {
+      setIsFormHydrated(true);
+      setHydrationGeneration((g) => g + 1);
+    }, 0);
 
-      return () => {
-        window.clearTimeout(timeoutId);
-      };
-    }
-
-    hasHydratedRef.current = true;
-    setIsFormHydrated(true);
-    setHydrationGeneration((g) => g + 1);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
   }, [activitySyncKey, lookupsReady, form]);
 
   return {


### PR DESCRIPTION
## Summary

Fixes a hydration issue in the activity form caused by TipTap `onUpdate`.

What this fixes: During activity form hydration, TipTap could emit a stale empty onUpdate after form.reset(), making the summary field fail validation, and other TipTap fields look dirty.

The fix ignores those unfocused empty updates when the controlled value still has content, skips onChange during prop sync, and defers isFormHydrated on every hydrate so reset-driven inputs can settle first.