### PR TITLE
fix/CORPCAL-999-unexpected-form-dirty-state

### DIFF
--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityEventSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityEventSection.tsx
@@ -9,6 +9,7 @@ import type {
   VenueStatusLookupItem,
 } from '@corpcal/shared/api/types';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
+import { normalizeEventPlannerFormEntries } from '@corpcal/shared/utils';
 import { fetchCities, fetchVenuePresets } from '@/api/lookupsApi';
 import {
   FormSelectSafe,
@@ -784,14 +785,20 @@ export const ActivityEventSection: FC<ActivityEventSectionProps> = ({
             if (next.length > 0 && !next.some((p) => p.isLead)) {
               next[0] = { ...next[0], isLead: true };
             }
-            setActivityFormFieldValue(form, field.name, next);
+            setActivityFormFieldValue(
+              form,
+              field.name,
+              normalizeEventPlannerFormEntries(next)
+            );
           };
 
           const setLead = (index: number) => {
-            const next = (field.value ?? []).map((p, i) => ({
-              ...p,
-              isLead: i === index,
-            }));
+            const next = normalizeEventPlannerFormEntries(
+              (field.value ?? []).map((p, i) => ({
+                ...p,
+                isLead: i === index,
+              }))
+            );
             setActivityFormFieldValue(form, field.name, next);
           };
 

--- a/calendar-ui/src/components/ui/rich-text-field.test.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@corpcal/shared/utils';
 
 import {
+  coalesceEditorRichTextUpdate,
   RichTextField,
   shouldIgnoreStaleEmptyRichTextUpdate,
 } from './rich-text-field';
@@ -44,6 +45,22 @@ async function waitForRichTextEditor() {
     await Promise.resolve();
   });
 }
+
+describe('coalesceEditorRichTextUpdate', () => {
+  it('maps effectively empty TipTap JSON to EMPTY_RICH_TEXT_DOC', () => {
+    expect(coalesceEditorRichTextUpdate('{"type":"doc"}')).toBe(
+      EMPTY_RICH_TEXT_DOC
+    );
+    expect(coalesceEditorRichTextUpdate(EMPTY_RICH_TEXT_DOC)).toBe(
+      EMPTY_RICH_TEXT_DOC
+    );
+  });
+
+  it('returns non-empty TipTap JSON unchanged', () => {
+    const json = tipTapDocJsonFromPlainText('Hello');
+    expect(coalesceEditorRichTextUpdate(json)).toBe(json);
+  });
+});
 
 describe('shouldIgnoreStaleEmptyRichTextUpdate', () => {
   const savedValue = tipTapDocJsonFromPlainText('Saved summary');

--- a/calendar-ui/src/components/ui/rich-text-field.test.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.test.tsx
@@ -1,11 +1,49 @@
-import { describe, expect, it } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
 
 import {
   EMPTY_RICH_TEXT_DOC,
   tipTapDocJsonFromPlainText,
 } from '@corpcal/shared/utils';
 
-import { shouldIgnoreStaleEmptyRichTextUpdate } from './rich-text-field';
+import {
+  RichTextField,
+  shouldIgnoreStaleEmptyRichTextUpdate,
+} from './rich-text-field';
+
+function renderRichTextField(
+  props: Partial<ComponentProps<typeof RichTextField>> & {
+    value: string;
+  }
+) {
+  const onChange = props.onChange ?? vi.fn();
+  const onBlur = props.onBlur ?? vi.fn();
+
+  const result = render(
+    <MemoryRouter>
+      <RichTextField
+        name="summary"
+        onChange={onChange}
+        onBlur={onBlur}
+        {...props}
+      />
+    </MemoryRouter>
+  );
+
+  return { ...result, onChange, onBlur };
+}
+
+async function waitForRichTextEditor() {
+  await waitFor(() => {
+    expect(document.querySelector('.ProseMirror')).toBeInTheDocument();
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
 
 describe('shouldIgnoreStaleEmptyRichTextUpdate', () => {
   const savedValue = tipTapDocJsonFromPlainText('Saved summary');
@@ -38,5 +76,32 @@ describe('shouldIgnoreStaleEmptyRichTextUpdate', () => {
         currentValue: savedValue,
       })
     ).toBe(false);
+  });
+});
+
+describe('RichTextField', () => {
+  it('suppresses onChange when TipTap emits a semantically equivalent empty doc', async () => {
+    const { onChange } = renderRichTextField({ value: '{"type":"doc"}' });
+
+    await waitForRichTextEditor();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('suppresses onChange when the controlled value is already canonical empty', async () => {
+    const { onChange } = renderRichTextField({ value: EMPTY_RICH_TEXT_DOC });
+
+    await waitForRichTextEditor();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('suppresses unfocused empty TipTap updates when the controlled value has content', async () => {
+    const savedValue = tipTapDocJsonFromPlainText('Saved summary');
+    const { onChange } = renderRichTextField({ value: savedValue });
+
+    await waitForRichTextEditor();
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/calendar-ui/src/components/ui/rich-text-field.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.tsx
@@ -10,7 +10,10 @@ import {
 import sanitizeHtml from 'sanitize-html';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { isActivityRichTextEffectivelyEmpty } from '@corpcal/shared/utils';
+import {
+  EMPTY_RICH_TEXT_DOC,
+  isActivityRichTextEffectivelyEmpty,
+} from '@corpcal/shared/utils';
 import { Button } from '@/components/ui/button';
 import { RichTextLinkDialog } from '@/components/ui/rich-text-field-link-dialog';
 import { Separator } from '@/components/ui/separator';
@@ -64,6 +67,11 @@ export function shouldIgnoreStaleEmptyRichTextUpdate({
   );
 }
 
+/** TipTap `getJSON()` output is already valid JSON; only empty variants need coalescing. */
+export function coalesceEditorRichTextUpdate(json: string): string {
+  return isActivityRichTextEffectivelyEmpty(json) ? EMPTY_RICH_TEXT_DOC : json;
+}
+
 export function RichTextField({
   id,
   name,
@@ -87,6 +95,12 @@ export function RichTextField({
     () => getActivityRichTextEditorExtensions({ placeholder }),
     [placeholder]
   );
+  const coalescedValue = useMemo(
+    () => coalesceRichTextFormStorageValue(value),
+    [value]
+  );
+  const coalescedValueRef = useRef(coalescedValue);
+  coalescedValueRef.current = coalescedValue;
 
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linkUrl, setLinkUrl] = useState('');
@@ -122,10 +136,13 @@ export function RichTextField({
 
       const json = JSON.stringify(ed.getJSON());
       const propValue = valueRef.current;
-      const nextValue = coalesceRichTextFormStorageValue(json);
-      const currentValue = coalesceRichTextFormStorageValue(propValue);
+      if (json === propValue) return;
+
+      const nextValue = coalesceEditorRichTextUpdate(json);
+      const currentValue = coalescedValueRef.current;
       if (
         nextValue === currentValue ||
+        coalesceRichTextFormStorageValue(json) === currentValue ||
         shouldIgnoreStaleEmptyRichTextUpdate({
           editorIsFocused: ed.isFocused,
           nextValue: json,

--- a/calendar-ui/src/components/ui/rich-text-field.tsx
+++ b/calendar-ui/src/components/ui/rich-text-field.tsx
@@ -18,6 +18,7 @@ import {
   getActivityRichTextEditorExtensions,
   getSetContentArgs,
 } from '@/lib/activity-rich-text-extensions';
+import { coalesceRichTextFormStorageValue } from '@/lib/normalize-activity-rich-text-form';
 import { cn } from '@/lib/utils';
 
 export type RichTextFieldProps = {
@@ -121,7 +122,10 @@ export function RichTextField({
 
       const json = JSON.stringify(ed.getJSON());
       const propValue = valueRef.current;
+      const nextValue = coalesceRichTextFormStorageValue(json);
+      const currentValue = coalesceRichTextFormStorageValue(propValue);
       if (
+        nextValue === currentValue ||
         shouldIgnoreStaleEmptyRichTextUpdate({
           editorIsFocused: ed.isFocused,
           nextValue: json,
@@ -131,7 +135,7 @@ export function RichTextField({
         return;
       }
 
-      onChangeRef.current(json);
+      onChangeRef.current(nextValue);
     },
   });
 

--- a/calendar-ui/src/lib/normalize-activity-rich-text-form.test.ts
+++ b/calendar-ui/src/lib/normalize-activity-rich-text-form.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { EMPTY_RICH_TEXT_DOC, tryParseTipTapDoc } from '@corpcal/shared/utils';
 
 import {
+  coalesceRichTextFormStorageValue,
   normalizeActivityRichTextFormFields,
   normalizeActivityRichTextFormValue,
 } from './normalize-activity-rich-text-form';
@@ -45,5 +46,17 @@ describe('normalizeActivityRichTextFormFields', () => {
     expect(data.summary).toBe(EMPTY_RICH_TEXT_DOC);
     expect(data.significance).toBe(EMPTY_RICH_TEXT_DOC);
     expect(data.executiveSummary).toBe(EMPTY_RICH_TEXT_DOC);
+  });
+});
+
+describe('coalesceRichTextFormStorageValue', () => {
+  it('maps equivalent empty variants to EMPTY_RICH_TEXT_DOC', () => {
+    expect(coalesceRichTextFormStorageValue('{"type":"doc"}')).toBe(
+      EMPTY_RICH_TEXT_DOC
+    );
+    expect(coalesceRichTextFormStorageValue(EMPTY_RICH_TEXT_DOC)).toBe(
+      EMPTY_RICH_TEXT_DOC
+    );
+    expect(coalesceRichTextFormStorageValue('')).toBe(EMPTY_RICH_TEXT_DOC);
   });
 });

--- a/calendar-ui/src/lib/normalize-activity-rich-text-form.ts
+++ b/calendar-ui/src/lib/normalize-activity-rich-text-form.ts
@@ -43,6 +43,13 @@ export function normalizeActivityRichTextFormValue(
   }
 }
 
+/** Stable empty/non-empty JSON string for RHF storage and TipTap onChange. */
+export function coalesceRichTextFormStorageValue(
+  value: string | undefined | null
+): string {
+  return normalizeActivityRichTextFormValue(value) ?? EMPTY_RICH_TEXT_DOC;
+}
+
 /** Normalizes summary, significance, and executive summary for edit-form hydration. */
 export function normalizeActivityRichTextFormFields(
   data: ActivityFormData

--- a/packages/shared/src/utils/activity-form-canonicalize.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.ts
@@ -1,5 +1,6 @@
 import type { ActivityResponse } from '../schemas/activity-response.schema';
 import type { ActivityFormData } from '../schemas/activity.schema';
+import { normalizeEventPlannerFormEntries } from './activity-form-event-planner-normalize';
 import { normalizeVenueAddressForForm } from './activity-form-mapper';
 import {
   EMPTY_RICH_TEXT_DOC,
@@ -104,7 +105,7 @@ export function canonicalizeActivityFormData(
     venueAddress: normalizeVenueAddressForForm(
       data.venueAddress as ActivityResponse['venueAddress']
     ),
-    eventPlanners: canonObjectArray(data.eventPlanners),
+    eventPlanners: normalizeEventPlannerFormEntries(data.eventPlanners),
     representatives: canonObjectArray(data.representatives),
     commsContacts: canonObjectArray(data.commsContacts),
     reportSettings: canonObjectArray(data.reportSettings),

--- a/packages/shared/src/utils/activity-form-event-planner-normalize.spec.ts
+++ b/packages/shared/src/utils/activity-form-event-planner-normalize.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalizeActivityFormData } from './activity-form-canonicalize';
+import {
+  normalizeEventPlannerFormEntries,
+  normalizeEventPlannerFormEntry,
+} from './activity-form-event-planner-normalize';
+import { isDeepEqual } from './isDeepEqual';
+
+describe('normalizeEventPlannerFormEntry', () => {
+  it('keeps id-based planners without redundant name keys', () => {
+    expect(
+      normalizeEventPlannerFormEntry({
+        eventPlannerId: 5,
+        eventPlannerName: 'Lookup Name',
+        isLead: true,
+      })
+    ).toEqual({ eventPlannerId: 5, isLead: true });
+  });
+
+  it('keeps freeform planners by name', () => {
+    expect(
+      normalizeEventPlannerFormEntry({
+        eventPlannerName: ' External Lead ',
+        isLead: true,
+      })
+    ).toEqual({ eventPlannerName: 'External Lead', isLead: true });
+  });
+});
+
+describe('normalizeEventPlannerFormEntries', () => {
+  it('matches combobox round-trip shape for lookup planners', () => {
+    const hydrated = normalizeEventPlannerFormEntries([
+      {
+        eventPlannerId: 5,
+        eventPlannerName: undefined,
+        isLead: true,
+      },
+    ]);
+    const comboboxRoundTrip = normalizeEventPlannerFormEntries([
+      { eventPlannerId: 5, isLead: true },
+    ]);
+    expect(isDeepEqual(hydrated, comboboxRoundTrip)).toBe(true);
+  });
+});
+
+describe('canonicalizeActivityFormData eventPlanners', () => {
+  it('normalizes redundant planner keys during canonicalize', () => {
+    const canon = canonicalizeActivityFormData({
+      title: 'T',
+      summary: 'S',
+      dateStatusId: 1,
+      timeStatusId: 1,
+      isIssue: false,
+      isAllDay: false,
+      isConfidential: false,
+      visibility: 'global',
+      leadTeamId: 1,
+      categoryIds: [1],
+      eventPlanners: [
+        {
+          eventPlannerId: 5,
+          eventPlannerName: 'Lookup Name',
+          isLead: true,
+        },
+      ],
+    });
+
+    expect(canon.eventPlanners).toEqual([{ eventPlannerId: 5, isLead: true }]);
+  });
+});

--- a/packages/shared/src/utils/activity-form-event-planner-normalize.ts
+++ b/packages/shared/src/utils/activity-form-event-planner-normalize.ts
@@ -1,0 +1,51 @@
+import type { ActivityFormData } from '../schemas/activity.schema';
+
+export type EventPlannerFormEntry = NonNullable<
+  ActivityFormData['eventPlanners']
+>[number];
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * One event planner row in the shape custom controls persist: id XOR name, explicit isLead.
+ * Strips redundant keys (e.g. eventPlannerName when eventPlannerId is set) so hydrate,
+ * review diff, and FreeformCombobox round-trips compare equal.
+ */
+export function normalizeEventPlannerFormEntry(
+  entry: Record<string, unknown>
+): EventPlannerFormEntry | null {
+  const isLead = entry.isLead === true;
+  const id =
+    typeof entry.eventPlannerId === 'number' && entry.eventPlannerId > 0
+      ? entry.eventPlannerId
+      : undefined;
+
+  if (id != null) {
+    return { eventPlannerId: id, isLead };
+  }
+
+  const name =
+    typeof entry.eventPlannerName === 'string'
+      ? entry.eventPlannerName.trim()
+      : '';
+  if (name.length > 0) {
+    return { eventPlannerName: name, isLead };
+  }
+
+  return null;
+}
+
+export function normalizeEventPlannerFormEntries(
+  entries: unknown
+): EventPlannerFormEntry[] {
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+  const out: EventPlannerFormEntry[] = [];
+  for (const item of entries) {
+    if (!isPlainRecord(item)) continue;
+    const normalized = normalizeEventPlannerFormEntry(item);
+    if (normalized) out.push(normalized);
+  }
+  return out;
+}

--- a/packages/shared/src/utils/activity-form-mapper.ts
+++ b/packages/shared/src/utils/activity-form-mapper.ts
@@ -1,5 +1,6 @@
 import type { ActivityResponse } from '../schemas/activity-response.schema';
 import type { ActivityFormData } from '../schemas/activity.schema';
+import { normalizeEventPlannerFormEntries } from './activity-form-event-planner-normalize';
 
 function trimVenueNullable(v: string | null | undefined): string | null {
   if (v == null) return null;
@@ -153,7 +154,9 @@ export function mapResponseToFormData(
     newsReleaseOriginId: response.newsReleaseOriginId ?? undefined,
     leadTeamId: response.leadTeamId ?? 0,
     leadMinistryId: response.leadMinistryId ?? undefined,
-    eventPlanners: eventPlanners?.length ? eventPlanners : undefined,
+    eventPlanners: normalizeEventPlannerFormEntries(
+      eventPlanners?.length ? eventPlanners : undefined
+    ),
     newsReleaseDistributionId: response.newsReleaseDistributionId ?? undefined,
     premierRequestedId: response.premierRequestedId ?? undefined,
     categoryIds: categoryIds?.length ? categoryIds : [],

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './saved-filter-payload-empty';
 export * from './isDeepEqual';
 export * from './schema-helpers';
 export * from './activity-form-mapper';
+export * from './activity-form-event-planner-normalize';
 export * from './activity-form-canonicalize';
 export * from './activity-review-diff';
 export * from './apply-update-activity-request';


### PR DESCRIPTION
## Summary

1. Empty TipTap fields showing "Changed" TipTap can emit {"type":"doc"} (14 chars) while the hydrated baseline uses EMPTY_RICH_TEXT_DOC ({"type":"doc","content":[]}). Both are semantically empty, but RHF treats them as different strings and marks the field dirty. The previous stale-empty guard only helped when the prop had content, not when both sides were empty.

2. Event planners always showing "Changed" when populated API hydration could produce { eventPlannerId: 5, eventPlannerName: undefined, isLead: true }, while the FreeformCombobox round-trip writes { eventPlannerId: 5, isLead: true }. Extra keys caused dirty state and review-diff mismatches.

Changes
coalesceRichTextFormStorageValue — normalizes all empty rich-text variants to EMPTY_RICH_TEXT_DOC before compare/onChange in RichTextField.
normalizeEventPlannerFormEntries — canonical id-based vs name-based planner shape in shared utils, used at map, canonicalize, and combobox write paths.
Tests added for both normalization paths (26 tests passing across shared + calendar-ui).
Please verify using the second-navigation scenario where these issues appeared before.

- coalesce rich text empty variants to EMPTY_RICH_TEXT_DOC before onChange
- skip TipTap onChange when canonical storage value is unchanged
- add RichTextField tests for suppressed hydration onChange noise
- normalize event planner entries to id XOR name with explicit isLead
- wire planner normalization through mapper, canonicalize, and event section