### PR TITLE
style/CORPCAL-245 activity list polish

### DIFF
--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -30,6 +30,8 @@ import {
 
 import { DEFAULT_ACTIVITY_FILTER_STATE, PERMISSIONS } from '@corpcal/shared';
 import { canViewActivityFieldScope, SYSTEM_ROLES } from '@corpcal/shared/auth';
+import { sanitizeLegendSwatchHexColor } from '@corpcal/shared/schemas';
+import { contrastingBlackOrWhiteForegroundHex } from '@corpcal/shared/utils';
 import { ActivityFlagPopover } from '@/components/activity/activities/ActivityFlagPopover';
 import { ErrorState } from '@/components/shared';
 import {
@@ -76,6 +78,7 @@ import {
 } from '@/hooks/useLiveActivitySyncContext';
 import {
   getLookAheadSectionLabelFromRows,
+  getLookAheadSectionLegendColorFromRows,
   useLookAheadSectionRows,
 } from '@/hooks/useLookAheadSectionRows';
 import {
@@ -311,14 +314,15 @@ function OverviewCell({
             (cat): BadgeGroupItem => ({
               key: cat,
               label: cat,
-              variant: 'primary',
-              className: 'h-auto min-h-5 whitespace-normal text-white',
+              variant: 'outline',
+              className:
+                'h-auto min-h-5 whitespace-normal border-slate-200 text-slate-600',
             })
           )}
           maxLines={1}
           lineHeight={28}
-          badgeVariant="primary"
-          badgeClassName="h-auto min-h-5 whitespace-normal text-white"
+          badgeVariant="outline"
+          badgeClassName="h-auto min-h-5 whitespace-normal text-slate-600"
           containerClassName="gap-1"
         />
       )}
@@ -359,12 +363,26 @@ function SummaryCell({ row }: { row: ActivityTableRow }) {
       : null;
 
   const summaryBadgeGroupItems = useMemo((): BadgeGroupItem[] => {
+    const sectionLegendColor = sanitizeLegendSwatchHexColor(
+      section
+        ? getLookAheadSectionLegendColorFromRows(lookAheadSectionRows, section)
+        : null
+    );
     const lookAheadItem: BadgeGroupItem | null = lookAheadLabel
       ? {
           key: 'look-ahead',
           label: lookAheadLabel,
           variant: 'primary',
-          className: 'h-auto min-h-5 text-xs text-white',
+          className: sectionLegendColor
+            ? 'h-auto min-h-5 border-transparent text-xs'
+            : 'h-auto min-h-5 text-xs text-white',
+          style: sectionLegendColor
+            ? {
+                backgroundColor: sectionLegendColor,
+                color: contrastingBlackOrWhiteForegroundHex(sectionLegendColor),
+                borderColor: 'transparent',
+              }
+            : undefined,
         }
       : null;
     const tagItems: BadgeGroupItem[] = row.tags.map((tag) => ({
@@ -374,7 +392,7 @@ function SummaryCell({ row }: { row: ActivityTableRow }) {
       className: 'h-auto min-h-5 text-xs whitespace-normal text-slate-600',
     }));
     return lookAheadItem ? [lookAheadItem, ...tagItems] : tagItems;
-  }, [lookAheadLabel, row.tags]);
+  }, [lookAheadLabel, lookAheadSectionRows, row.tags, section]);
 
   const isCollapsedWithTruncation = needsTruncation && !expanded;
 
@@ -543,13 +561,14 @@ function SchedulingCell({ row }: { row: ActivityTableRow }) {
 function LeadsCell({ row }: { row: ActivityTableRow }) {
   const lines: Array<{ label: string; value: string }> = [];
 
-  if (row.leadOrg) lines.push({ label: 'Lead org', value: row.leadOrg });
   const leadMinistryDisplay =
     row.leadMinistryAbbreviation ?? row.leadMinistry ?? null;
+  if (row.leadOrg && row.leadOrg !== leadMinistryDisplay)
+    lines.push({ label: 'Lead org', value: row.leadOrg });
   if (leadMinistryDisplay)
     lines.push({ label: 'Lead ministry', value: leadMinistryDisplay });
   if (row.commsLeadName)
-    lines.push({ label: 'Comms lead', value: row.commsLeadName });
+    lines.push({ label: 'Comms contact', value: row.commsLeadName });
   if (row.eventPlanners?.length)
     lines.push({
       label: 'Event planners',
@@ -568,7 +587,7 @@ function LeadsCell({ row }: { row: ActivityTableRow }) {
         <div key={label}>
           <span className="text-slate-500">{label}: </span>
           <span className="font-medium">{value}</span>
-          {label === 'Comms lead' && additionalComms > 0 && (
+          {label === 'Comms contact' && additionalComms > 0 && (
             <Badge
               variant="outline"
               className="ml-1 h-auto min-h-5 text-xs text-slate-600"

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -289,17 +289,21 @@ function OverviewCell({
             {displayIdText}
           </CopyableText>
         </span>
-        {row.isConfidential && (
-          <span className="text-corpcal-text-alert font-bold uppercase">
-            CONFIDENTIAL
-          </span>
-        )}
-        {row.isIssue && (
-          <span className="text-corpcal-text-alert font-bold uppercase">
-            ISSUE
-          </span>
-        )}
       </div>
+      {(row.isConfidential || row.isIssue) && (
+        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0 text-sm font-semibold">
+          {row.isConfidential && (
+            <span className="text-corpcal-text-alert font-bold uppercase">
+              CONFIDENTIAL
+            </span>
+          )}
+          {row.isIssue && (
+            <span className="text-corpcal-text-alert font-bold uppercase">
+              ISSUE
+            </span>
+          )}
+        </div>
+      )}
       <div
         className="mb-1 line-clamp-4 text-[16px] font-semibold wrap-anywhere text-slate-900"
         title={row.title}

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -300,7 +300,10 @@ function OverviewCell({
           </span>
         )}
       </div>
-      <div className="mb-1 text-[16px] font-semibold text-slate-900">
+      <div
+        className="mb-1 line-clamp-4 text-[16px] font-semibold wrap-anywhere text-slate-900"
+        title={row.title}
+      >
         {row.title}
       </div>
       {pitchLabel && (
@@ -330,6 +333,14 @@ function OverviewCell({
   );
 }
 
+const SUMMARY_MAX_LINES = 5;
+const SUMMARY_LINE_HEIGHT_PX = 20;
+
+function summaryContentNeedsTruncation(el: HTMLDivElement): boolean {
+  const maxHeight = SUMMARY_LINE_HEIGHT_PX * SUMMARY_MAX_LINES;
+  return el.scrollHeight > maxHeight + 1 || el.scrollWidth > el.clientWidth + 1;
+}
+
 function SummaryCell({ row }: { row: ActivityTableRow }) {
   const [expanded, setExpanded] = useState(false);
   const [needsTruncation, setNeedsTruncation] = useState(false);
@@ -337,12 +348,9 @@ function SummaryCell({ row }: { row: ActivityTableRow }) {
   const showMoreLessRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (contentRef.current) {
-      const lineHeight = 20;
-      const maxLines = 5;
-      setNeedsTruncation(
-        contentRef.current.scrollHeight > lineHeight * maxLines
-      );
+    const el = contentRef.current;
+    if (el) {
+      setNeedsTruncation(summaryContentNeedsTruncation(el));
     }
   }, [row.summary]);
 
@@ -421,13 +429,10 @@ function SummaryCell({ row }: { row: ActivityTableRow }) {
       >
         <div
           ref={contentRef}
-          className="text-[14px] leading-[1.4]"
-          style={{
-            display: '-webkit-box',
-            WebkitLineClamp: expanded ? 'unset' : 5,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
+          className={cn(
+            'text-[14px] leading-[1.4] wrap-anywhere',
+            !expanded && 'line-clamp-5'
+          )}
         >
           <ActivityRichTextContent value={row.summary} stopLinkPropagation />
         </div>

--- a/calendar-ui/src/components/ui/activity-rich-text-content.tsx
+++ b/calendar-ui/src/components/ui/activity-rich-text-content.tsx
@@ -25,7 +25,7 @@ export function ActivityRichTextContent({
       className={cn(
         // Match RichTextField: outside list markers + padding (list-inside breaks li > p layout).
         // Vertical margin only on top-level lists — nested ul/ol under li would otherwise gap more than siblings.
-        'activity-rich-text-content [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 [&_li]:my-0 [&_li>ol]:my-0 [&_li>p]:mb-0 [&_li>ul]:my-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-1 last:[&_p]:mb-0 [&_ul]:list-disc [&_ul]:pl-5 [&>ol]:my-1 [&>ul]:my-1',
+        'activity-rich-text-content [&_a]:text-primary wrap-anywhere [&_a]:wrap-anywhere [&_a]:underline [&_a]:underline-offset-2 [&_li]:my-0 [&_li>ol]:my-0 [&_li>p]:mb-0 [&_li>ul]:my-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-1 last:[&_p]:mb-0 [&_ul]:list-disc [&_ul]:pl-5 [&>ol]:my-1 [&>ul]:my-1',
         className
       )}
       dangerouslySetInnerHTML={{ __html: html }}

--- a/calendar-ui/src/components/ui/badge-group.tsx
+++ b/calendar-ui/src/components/ui/badge-group.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
 
 import { useElementWidth } from '@/hooks/useElementWidth';
 import { cn } from '@/lib/utils';
@@ -16,6 +23,7 @@ export interface BadgeGroupItem {
   label: string;
   variant?: BadgeProps['variant'];
   className?: string;
+  style?: CSSProperties;
 }
 
 export interface BadgeGroupProps {
@@ -186,6 +194,7 @@ export function BadgeGroup({
           data-badge-group-measure="true"
           variant={item.variant ?? badgeVariant}
           className={cn(badgeClassName, item.className)}
+          style={item.style}
         >
           {item.label}
         </Badge>

--- a/calendar-ui/src/hooks/useLookAheadSectionRows.ts
+++ b/calendar-ui/src/hooks/useLookAheadSectionRows.ts
@@ -77,3 +77,16 @@ export function getLookAheadSectionLabelFromRows(
   const match = rows.find((r) => r.lookAheadKey === value);
   return match?.uiLabel ?? value;
 }
+
+/**
+ * Look up the configured legend swatch color for a stored `activity.lookAheadSection`
+ * value using the resolved rows.
+ */
+export function getLookAheadSectionLegendColorFromRows(
+  rows: ReadonlyArray<LookAheadSectionRow>,
+  value: string | null | undefined
+): string | null {
+  if (!value) return null;
+  const match = rows.find((r) => r.lookAheadKey === value);
+  return match?.legendColor ?? null;
+}


### PR DESCRIPTION
## Summary

- switch category badges to outline styling in OverviewCell
- color look-ahead section badges from configured legend swatches
- add getLookAheadSectionLegendColorFromRows helper
- support per-badge style on BadgeGroup items
- hide lead org when it duplicates lead ministry display
- rename comms lead label to comms contact