### PR TITLE
fix(layout): Move Release & translation fields into dedicated Release…

### DIFF
--- a/calendar-ui/src/components/activity/ActivityFormBody.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormBody.tsx
@@ -26,6 +26,7 @@ import {
   ActivityCommsSection,
   ActivityEventSection,
   ActivityOverviewSection,
+  ActivityReleaseSection,
   ActivityReportsSection,
   ActivityScheduleSection,
   ActivitySharingSection,
@@ -157,9 +158,6 @@ export function ActivityFormBody({
               commsMaterialOptions={lookups.commsMaterials}
               commsLeadOptions={commsLeadOptions}
               translationLanguageOptions={lookups.translationLanguages}
-              newsReleaseDistributionOptions={lookups.newsReleaseDistributions}
-              newsReleaseOriginOptions={lookups.newsReleaseOrigins}
-              translationRequiredStatuses={lookups.translationRequiredStatuses}
             />
           </div>
 
@@ -169,6 +167,13 @@ export function ActivityFormBody({
             <ActivityScheduleSection
               dateStatuses={lookups.dateStatuses}
               timeStatuses={lookups.timeStatuses}
+            />
+
+            <ActivityReleaseSection
+              newsReleaseDistributionOptions={lookups.newsReleaseDistributions}
+              newsReleaseOriginOptions={lookups.newsReleaseOrigins}
+              translationRequiredStatuses={lookups.translationRequiredStatuses}
+              translationLanguageOptions={lookups.translationLanguages}
             />
 
             <ActivityEventSection

--- a/calendar-ui/src/components/activity/ActivityFormBody.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormBody.tsx
@@ -157,7 +157,6 @@ export function ActivityFormBody({
             <ActivityCommsSection
               commsMaterialOptions={lookups.commsMaterials}
               commsLeadOptions={commsLeadOptions}
-              translationLanguageOptions={lookups.translationLanguages}
             />
           </div>
 

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityCommsSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityCommsSection.tsx
@@ -42,11 +42,6 @@ type ActivityCommsSectionProps = {
     displayName?: string;
   }>;
   commsLeadOptions: OptionItem[];
-  translationLanguageOptions: Array<{
-    id: number;
-    name: string;
-    displayName?: string;
-  }>;
 };
 
 function optionItemsEqual(a: OptionItem, b: OptionItem): boolean {
@@ -74,7 +69,6 @@ function buildCommsContactsFromSelection(
 export const ActivityCommsSection: React.FC<ActivityCommsSectionProps> = ({
   commsMaterialOptions,
   commsLeadOptions,
-  translationLanguageOptions,
 }) => {
   const { readOnly } = useActivityEdit();
   const form = useFormContext<ActivityFormData>();
@@ -85,12 +79,6 @@ export const ActivityCommsSection: React.FC<ActivityCommsSectionProps> = ({
     value: String(m.id),
     label: m.displayName ?? m.name,
   }));
-  const translationLanguageComboboxOptions = translationLanguageOptions.map(
-    (l) => ({
-      value: String(l.id),
-      label: l.displayName ?? l.name,
-    })
-  );
 
   return (
     <ActivityFormSection title={ACTIVITY_FORM_SECTION_LABELS.comms}>
@@ -307,10 +295,6 @@ export const ActivityCommsSection: React.FC<ActivityCommsSectionProps> = ({
           );
         }}
       />
-
-      {/* Release fields moved to their own section `ActivityReleaseSection` */}
-
-      {/* Translations fields moved to ActivityReleaseSection */}
     </ActivityFormSection>
   );
 };

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityCommsSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityCommsSection.tsx
@@ -1,11 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 
-import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
-import {
-  FormSelectSafe,
-  FormSelectTrigger,
-} from '@/components/app/form-select';
 import {
   Combobox,
   ComboboxChip,
@@ -31,21 +26,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  optionalIdSelectDisplayValue,
-  optionalSelectIdValue,
-} from '@/lib/activity-form-coerce-value';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
 import { setActivityFormFieldValue } from '@/lib/activity-form-set-field';
 import type { OptionItem } from '@/schemas/types';
 
 import { useActivityEdit } from '../activity-edit-context';
-import { ActivityFieldScopePermissionTooltip } from '../activity-field-scope-permission-tooltip';
-import { useActivityFieldScopeControl } from '../use-activity-field-scope-control';
-import { ActivityFormHeading } from './ActivityFormHeading';
 import { ActivityFormSection } from './ActivityFormSection';
 
 type ActivityCommsSectionProps = {
@@ -60,9 +47,6 @@ type ActivityCommsSectionProps = {
     name: string;
     displayName?: string;
   }>;
-  newsReleaseDistributionOptions: OptionItem[];
-  newsReleaseOriginOptions: OptionItem[];
-  translationRequiredStatuses: TranslationRequiredStatusLookupItem[];
 };
 
 function optionItemsEqual(a: OptionItem, b: OptionItem): boolean {
@@ -91,16 +75,11 @@ export const ActivityCommsSection: React.FC<ActivityCommsSectionProps> = ({
   commsMaterialOptions,
   commsLeadOptions,
   translationLanguageOptions,
-  newsReleaseDistributionOptions,
-  newsReleaseOriginOptions,
-  translationRequiredStatuses,
 }) => {
   const { readOnly } = useActivityEdit();
-  const translationsScope = useActivityFieldScopeControl('translations');
   const form = useFormContext<ActivityFormData>();
   const commsContactsAnchorRef = useComboboxAnchor();
   const commsMaterialsAnchorRef = useComboboxAnchor();
-  const translationsAnchorRef = useComboboxAnchor();
 
   const commsMaterialComboboxOptions = commsMaterialOptions.map((m) => ({
     value: String(m.id),
@@ -329,193 +308,9 @@ export const ActivityCommsSection: React.FC<ActivityCommsSectionProps> = ({
         }}
       />
 
-      <ActivityFormHeading>Release</ActivityFormHeading>
+      {/* Release fields moved to their own section `ActivityReleaseSection` */}
 
-      <FormField
-        control={form.control}
-        name="newsReleaseOriginId"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-            <FormSelectSafe
-              readOnly={readOnly}
-              optionValues={newsReleaseOriginOptions.map((o) => o.value)}
-              value={optionalIdSelectDisplayValue(field.value)}
-              onValueChange={(value) =>
-                setActivityFormFieldValue(
-                  form,
-                  field.name,
-                  optionalSelectIdValue(value)
-                )
-              }
-            >
-              <FormControl data-field={field.name}>
-                <FormSelectTrigger readOnly={readOnly}>
-                  <SelectValue placeholder="Select news release origin" />
-                </FormSelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {newsReleaseOriginOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </FormSelectSafe>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={form.control}
-        name="newsReleaseDistributionId"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-            <FormSelectSafe
-              readOnly={readOnly}
-              optionValues={newsReleaseDistributionOptions.map((o) => o.value)}
-              value={optionalIdSelectDisplayValue(field.value)}
-              onValueChange={(value) =>
-                setActivityFormFieldValue(
-                  form,
-                  field.name,
-                  optionalSelectIdValue(value)
-                )
-              }
-            >
-              <FormControl data-field={field.name}>
-                <FormSelectTrigger readOnly={readOnly}>
-                  <SelectValue placeholder="Select news release distribution" />
-                </FormSelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {newsReleaseDistributionOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </FormSelectSafe>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={form.control}
-        name="translationsRequiredStatusId"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-            <FormSelectSafe
-              readOnly={translationsScope.readOnly}
-              disabled={translationsScope.fieldScopeDisabled}
-              optionValues={translationRequiredStatuses.map((s) =>
-                String(s.id)
-              )}
-              value={optionalIdSelectDisplayValue(field.value)}
-              onValueChange={(value) =>
-                setActivityFormFieldValue(
-                  form,
-                  field.name,
-                  optionalSelectIdValue(value)
-                )
-              }
-            >
-              <ActivityFieldScopePermissionTooltip scope="translations">
-                <FormControl data-field={field.name}>
-                  <FormSelectTrigger
-                    readOnly={
-                      translationsScope.readOnly &&
-                      !translationsScope.fieldScopeDisabled
-                    }
-                  >
-                    <SelectValue placeholder="Select status" />
-                  </FormSelectTrigger>
-                </FormControl>
-              </ActivityFieldScopePermissionTooltip>
-              <SelectContent>
-                {translationRequiredStatuses.map((status) => (
-                  <SelectItem key={status.id} value={String(status.id)}>
-                    {status.displayName ?? status.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </FormSelectSafe>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={form.control}
-        name="translationLanguageIds"
-        render={({ field }) => {
-          const selectedOptions = translationLanguageComboboxOptions.filter(
-            (o) => (field.value ?? []).includes(Number(o.value))
-          );
-          return (
-            <FormItem>
-              <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-              <ActivityFieldScopePermissionTooltip scope="translations">
-                <FormControl data-field={field.name}>
-                  <Combobox
-                    items={translationLanguageComboboxOptions}
-                    multiple
-                    value={selectedOptions}
-                    onValueChange={(selected) =>
-                      setActivityFormFieldValue(
-                        form,
-                        field.name,
-                        selected.map((o) => Number(o.value))
-                      )
-                    }
-                    itemToStringValue={(o) => o.label}
-                    readOnly={
-                      translationsScope.readOnly &&
-                      !translationsScope.fieldScopeDisabled
-                    }
-                    disabled={translationsScope.fieldScopeDisabled}
-                  >
-                    <ComboboxChips
-                      ref={translationsAnchorRef}
-                      className="w-full"
-                    >
-                      <ComboboxValue>
-                        {(values: OptionItem[]) => (
-                          <>
-                            {values.map((option) => (
-                              <ComboboxChip key={option.value}>
-                                {option.label}
-                              </ComboboxChip>
-                            ))}
-                            <ComboboxChipsInput placeholder="Select translation languages" />
-                          </>
-                        )}
-                      </ComboboxValue>
-                    </ComboboxChips>
-                    <ComboboxContent anchor={translationsAnchorRef}>
-                      <ComboboxEmpty>
-                        No translation languages found.
-                      </ComboboxEmpty>
-                      <ComboboxList>
-                        {(option: OptionItem) => (
-                          <ComboboxItem key={option.value} value={option}>
-                            {option.label}
-                          </ComboboxItem>
-                        )}
-                      </ComboboxList>
-                    </ComboboxContent>
-                  </Combobox>
-                </FormControl>
-              </ActivityFieldScopePermissionTooltip>
-              <FormMessage />
-            </FormItem>
-          );
-        }}
-      />
+      {/* Translations fields moved to ActivityReleaseSection */}
     </ActivityFormSection>
   );
 };

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import type { ActivityFormData } from '@corpcal/shared/schemas';
+import { getDefaultFormValues } from '@/lib/activity-form-defaults';
+
+import { ActivityEditProvider } from '../activity-edit-context';
+import { ActivityReleaseSection } from './ActivityReleaseSection';
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => undefined;
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+});
+
+const mockLookups = {
+  isLoading: false,
+  hasError: false,
+  categories: [],
+  organizations: [],
+  ministries: [],
+  users: [],
+  eventPlanners: [],
+  tags: [],
+  pitchStatuses: [],
+  pitchRequiredStatuses: [],
+  activityStatuses: [],
+  commsMaterials: [],
+  translationLanguages: [
+    { id: 1, name: 'French', displayName: 'French' },
+    { id: 2, name: 'Spanish', displayName: 'Spanish' },
+  ],
+  translationRequiredStatuses: [
+    { id: 1, name: 'Not required', displayName: 'Not required' },
+    { id: 2, name: 'Required', displayName: 'Required' },
+  ],
+  governmentRepresentatives: [],
+  newsReleaseDistributions: [
+    { id: 1, name: 'Internal', displayName: 'Internal', value: '1' },
+  ],
+  premierRequested: [],
+  newsReleaseOrigins: [
+    { id: 1, name: 'Origin A', displayName: 'Origin A', value: '1' },
+  ],
+  sharedWithTeams: [],
+  quickShareGroups: [],
+  dateStatuses: [],
+  timeStatuses: [],
+  venueStatuses: [],
+} as any;
+
+function ActivityReleaseSectionHarness({
+  readOnly,
+  canEditFieldScope,
+}: {
+  readOnly: boolean;
+  canEditFieldScope?: (s: string) => boolean;
+}) {
+  const form = useForm<ActivityFormData>({
+    defaultValues: getDefaultFormValues() as ActivityFormData,
+  });
+
+  return (
+    <FormProvider {...form}>
+      <ActivityEditProvider
+        value={{
+          readOnly,
+          canViewFieldScope: () => true,
+          canEditFieldScope: canEditFieldScope ?? (() => true),
+        }}
+      >
+        <ActivityReleaseSection
+          newsReleaseDistributionOptions={mockLookups.newsReleaseDistributions}
+          newsReleaseOriginOptions={mockLookups.newsReleaseOrigins}
+          translationRequiredStatuses={mockLookups.translationRequiredStatuses}
+          translationLanguageOptions={mockLookups.translationLanguages}
+        />
+      </ActivityEditProvider>
+    </FormProvider>
+  );
+}
+
+describe('ActivityReleaseSection permissions', () => {
+  it('renders news release selects as readOnly when activity is view-only', async () => {
+    render(<ActivityReleaseSectionHarness readOnly={true} />);
+
+    const placeholder = await screen.findByText(/Select news release origin/i);
+    const origin = placeholder.closest('button[role="combobox"]');
+    expect(origin).toHaveAttribute('aria-readonly', 'true');
+  });
+
+  it('disables translation languages when field scope forbids edit', async () => {
+    render(
+      <ActivityReleaseSectionHarness
+        readOnly={false}
+        canEditFieldScope={(s: string) => s !== 'translations'}
+      />
+    );
+
+    const input = await screen.findByPlaceholderText(
+      /Select translation languages/i
+    );
+    expect(input).toBeDisabled();
+  });
+});

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
@@ -34,23 +34,31 @@ const mockLookups = {
     { id: 2, name: 'Spanish', displayName: 'Spanish' },
   ],
   translationRequiredStatuses: [
-    { id: 1, name: 'Not required', displayName: 'Not required' },
-    { id: 2, name: 'Required', displayName: 'Required' },
+    {
+      id: 1,
+      name: 'Not required',
+      displayName: 'Not required',
+      label: 'Not required',
+      value: 1,
+    },
+    {
+      id: 2,
+      name: 'Required',
+      displayName: 'Required',
+      label: 'Required',
+      value: 2,
+    },
   ],
   governmentRepresentatives: [],
-  newsReleaseDistributions: [
-    { id: 1, name: 'Internal', displayName: 'Internal', value: '1' },
-  ],
+  newsReleaseDistributions: [{ value: '1', label: 'Internal' }],
   premierRequested: [],
-  newsReleaseOrigins: [
-    { id: 1, name: 'Origin A', displayName: 'Origin A', value: '1' },
-  ],
+  newsReleaseOrigins: [{ value: '1', label: 'Origin A' }],
   sharedWithTeams: [],
   quickShareGroups: [],
   dateStatuses: [],
   timeStatuses: [],
   venueStatuses: [],
-} as any;
+};
 
 function ActivityReleaseSectionHarness({
   readOnly,

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -112,33 +112,31 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
         render={({ field }) => (
           <FormItem>
             <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-            <FormControl data-field={field.name}>
-              <FormSelectSafe
-                readOnly={readOnly}
-                optionValues={newsReleaseDistributionOptions.map(
-                  (o) => o.value
-                )}
-                value={optionalIdSelectDisplayValue(field.value)}
-                onValueChange={(value) =>
-                  setActivityFormFieldValue(
-                    form,
-                    field.name,
-                    optionalSelectIdValue(value)
-                  )
-                }
-              >
+            <FormSelectSafe
+              readOnly={readOnly}
+              optionValues={newsReleaseDistributionOptions.map((o) => o.value)}
+              value={optionalIdSelectDisplayValue(field.value)}
+              onValueChange={(value) =>
+                setActivityFormFieldValue(
+                  form,
+                  field.name,
+                  optionalSelectIdValue(value)
+                )
+              }
+            >
+              <FormControl data-field={field.name}>
                 <FormSelectTrigger readOnly={readOnly}>
                   <SelectValue placeholder="Select news release distribution" />
                 </FormSelectTrigger>
-                <SelectContent>
-                  {newsReleaseDistributionOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </FormSelectSafe>
-            </FormControl>
+              </FormControl>
+              <SelectContent>
+                {newsReleaseDistributionOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </FormSelectSafe>
             <FormMessage />
           </FormItem>
         )}

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -35,6 +35,7 @@ import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels
 import { setActivityFormFieldValue } from '@/lib/activity-form-set-field';
 import type { OptionItem } from '@/schemas/types';
 
+import { useActivityEdit } from '../activity-edit-context';
 import { ActivityFieldScopePermissionTooltip } from '../activity-field-scope-permission-tooltip';
 import { useActivityFieldScopeControl } from '../use-activity-field-scope-control';
 import { ActivityFormSection } from './ActivityFormSection';
@@ -57,6 +58,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
   translationLanguageOptions,
 }) => {
   const form = useFormContext<ActivityFormData>();
+  const { readOnly } = useActivityEdit();
   const translationsScope = useActivityFieldScopeControl('translations');
   const translationsAnchorRef = useComboboxAnchor();
 
@@ -76,7 +78,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
             <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
             <FormControl data-field={field.name}>
               <FormSelectSafe
-                readOnly={false}
+                readOnly={readOnly}
                 optionValues={newsReleaseOriginOptions.map((o) => o.value)}
                 value={optionalIdSelectDisplayValue(field.value)}
                 onValueChange={(value) =>
@@ -87,7 +89,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
                   )
                 }
               >
-                <FormSelectTrigger>
+                <FormSelectTrigger readOnly={readOnly}>
                   <SelectValue placeholder="Select news release origin" />
                 </FormSelectTrigger>
                 <SelectContent>
@@ -112,7 +114,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
             <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
             <FormControl data-field={field.name}>
               <FormSelectSafe
-                readOnly={false}
+                readOnly={readOnly}
                 optionValues={newsReleaseDistributionOptions.map(
                   (o) => o.value
                 )}
@@ -125,7 +127,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
                   )
                 }
               >
-                <FormSelectTrigger>
+                <FormSelectTrigger readOnly={readOnly}>
                   <SelectValue placeholder="Select news release distribution" />
                 </FormSelectTrigger>
                 <SelectContent>
@@ -259,4 +261,4 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
   );
 };
 
-export default ActivityReleaseSection;
+// Use named export only

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -76,31 +76,31 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
         render={({ field }) => (
           <FormItem>
             <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-            <FormControl data-field={field.name}>
-              <FormSelectSafe
-                readOnly={readOnly}
-                optionValues={newsReleaseOriginOptions.map((o) => o.value)}
-                value={optionalIdSelectDisplayValue(field.value)}
-                onValueChange={(value) =>
-                  setActivityFormFieldValue(
-                    form,
-                    field.name,
-                    optionalSelectIdValue(value)
-                  )
-                }
-              >
+            <FormSelectSafe
+              readOnly={readOnly}
+              optionValues={newsReleaseOriginOptions.map((o) => o.value)}
+              value={optionalIdSelectDisplayValue(field.value)}
+              onValueChange={(value) =>
+                setActivityFormFieldValue(
+                  form,
+                  field.name,
+                  optionalSelectIdValue(value)
+                )
+              }
+            >
+              <FormControl data-field={field.name}>
                 <FormSelectTrigger readOnly={readOnly}>
                   <SelectValue placeholder="Select news release origin" />
                 </FormSelectTrigger>
-                <SelectContent>
-                  {newsReleaseOriginOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </FormSelectSafe>
-            </FormControl>
+              </FormControl>
+              <SelectContent>
+                {newsReleaseOriginOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </FormSelectSafe>
             <FormMessage />
           </FormItem>
         )}

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -1,0 +1,262 @@
+import { useFormContext } from 'react-hook-form';
+
+import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
+import type { ActivityFormData } from '@corpcal/shared/schemas';
+import {
+  FormSelectSafe,
+  FormSelectTrigger,
+} from '@/components/app/form-select';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '@/components/ui/combobox';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import {
+  optionalIdSelectDisplayValue,
+  optionalSelectIdValue,
+} from '@/lib/activity-form-coerce-value';
+import { getActivityFieldLabel } from '@/lib/activity-form-labels';
+import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
+import { setActivityFormFieldValue } from '@/lib/activity-form-set-field';
+import type { OptionItem } from '@/schemas/types';
+
+import { ActivityFieldScopePermissionTooltip } from '../activity-field-scope-permission-tooltip';
+import { useActivityFieldScopeControl } from '../use-activity-field-scope-control';
+import { ActivityFormSection } from './ActivityFormSection';
+
+type ActivityReleaseSectionProps = {
+  newsReleaseDistributionOptions: OptionItem[];
+  newsReleaseOriginOptions: OptionItem[];
+  translationRequiredStatuses: TranslationRequiredStatusLookupItem[];
+  translationLanguageOptions: Array<{
+    id: number;
+    name: string;
+    displayName?: string;
+  }>;
+};
+
+export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
+  newsReleaseDistributionOptions,
+  newsReleaseOriginOptions,
+  translationRequiredStatuses,
+  translationLanguageOptions,
+}) => {
+  const form = useFormContext<ActivityFormData>();
+  const translationsScope = useActivityFieldScopeControl('translations');
+  const translationsAnchorRef = useComboboxAnchor();
+
+  const translationLanguageComboboxOptions: OptionItem[] =
+    translationLanguageOptions.map((l) => ({
+      value: String(l.id),
+      label: l.displayName ?? l.name,
+    }));
+
+  return (
+    <ActivityFormSection title={ACTIVITY_FORM_SECTION_LABELS.newsRelease}>
+      <FormField
+        control={form.control}
+        name="newsReleaseOriginId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
+            <FormControl data-field={field.name}>
+              <FormSelectSafe
+                readOnly={false}
+                optionValues={newsReleaseOriginOptions.map((o) => o.value)}
+                value={optionalIdSelectDisplayValue(field.value)}
+                onValueChange={(value) =>
+                  setActivityFormFieldValue(
+                    form,
+                    field.name,
+                    optionalSelectIdValue(value)
+                  )
+                }
+              >
+                <FormSelectTrigger>
+                  <SelectValue placeholder="Select news release origin" />
+                </FormSelectTrigger>
+                <SelectContent>
+                  {newsReleaseOriginOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </FormSelectSafe>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="newsReleaseDistributionId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
+            <FormControl data-field={field.name}>
+              <FormSelectSafe
+                readOnly={false}
+                optionValues={newsReleaseDistributionOptions.map(
+                  (o) => o.value
+                )}
+                value={optionalIdSelectDisplayValue(field.value)}
+                onValueChange={(value) =>
+                  setActivityFormFieldValue(
+                    form,
+                    field.name,
+                    optionalSelectIdValue(value)
+                  )
+                }
+              >
+                <FormSelectTrigger>
+                  <SelectValue placeholder="Select news release distribution" />
+                </FormSelectTrigger>
+                <SelectContent>
+                  {newsReleaseDistributionOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </FormSelectSafe>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="translationsRequiredStatusId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
+            <FormSelectSafe
+              readOnly={translationsScope.readOnly}
+              disabled={translationsScope.fieldScopeDisabled}
+              optionValues={translationRequiredStatuses.map((s) =>
+                String(s.id)
+              )}
+              value={optionalIdSelectDisplayValue(field.value)}
+              onValueChange={(value) =>
+                setActivityFormFieldValue(
+                  form,
+                  field.name,
+                  optionalSelectIdValue(value)
+                )
+              }
+            >
+              <ActivityFieldScopePermissionTooltip scope="translations">
+                <FormControl data-field={field.name}>
+                  <FormSelectTrigger
+                    readOnly={
+                      translationsScope.readOnly &&
+                      !translationsScope.fieldScopeDisabled
+                    }
+                  >
+                    <SelectValue placeholder="Select status" />
+                  </FormSelectTrigger>
+                </FormControl>
+              </ActivityFieldScopePermissionTooltip>
+              <SelectContent>
+                {translationRequiredStatuses.map((status) => (
+                  <SelectItem key={status.id} value={String(status.id)}>
+                    {status.displayName ?? status.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </FormSelectSafe>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="translationLanguageIds"
+        render={({ field }) => {
+          const selectedOptions = translationLanguageComboboxOptions.filter(
+            (o) => (field.value ?? []).includes(Number(o.value))
+          );
+          return (
+            <FormItem>
+              <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
+              <ActivityFieldScopePermissionTooltip scope="translations">
+                <FormControl data-field={field.name}>
+                  <Combobox
+                    items={translationLanguageComboboxOptions}
+                    multiple
+                    value={selectedOptions}
+                    onValueChange={(selected) =>
+                      setActivityFormFieldValue(
+                        form,
+                        field.name,
+                        selected.map((o) => Number(o.value))
+                      )
+                    }
+                    itemToStringValue={(o) => o.label}
+                    readOnly={
+                      translationsScope.readOnly &&
+                      !translationsScope.fieldScopeDisabled
+                    }
+                    disabled={translationsScope.fieldScopeDisabled}
+                  >
+                    <ComboboxChips
+                      ref={translationsAnchorRef}
+                      className="w-full"
+                    >
+                      <ComboboxValue>
+                        {(values: OptionItem[]) => (
+                          <>
+                            {values.map((option) => (
+                              <ComboboxChip key={option.value}>
+                                {option.label}
+                              </ComboboxChip>
+                            ))}
+                            <ComboboxChipsInput placeholder="Select translation languages" />
+                          </>
+                        )}
+                      </ComboboxValue>
+                    </ComboboxChips>
+                    <ComboboxContent anchor={translationsAnchorRef}>
+                      <ComboboxEmpty>
+                        No translation languages found.
+                      </ComboboxEmpty>
+                      <ComboboxList>
+                        {(option: OptionItem) => (
+                          <ComboboxItem key={option.value} value={option}>
+                            {option.label}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
+                </FormControl>
+              </ActivityFieldScopePermissionTooltip>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
+      />
+    </ActivityFormSection>
+  );
+};
+
+export default ActivityReleaseSection;

--- a/calendar-ui/src/components/activity/ActivityFormSections/index.ts
+++ b/calendar-ui/src/components/activity/ActivityFormSections/index.ts
@@ -1,6 +1,7 @@
 export { ActivityOverviewSection } from './ActivityOverviewSection';
 export { ActivityScheduleSection } from './ActivityScheduleSection';
 export { ActivityCommsSection } from './ActivityCommsSection';
+export { ActivityReleaseSection } from './ActivityReleaseSection';
 export { ActivityEventSection } from './ActivityEventSection';
 export { ActivityReportsSection } from './ActivityReportsSection';
 export { ActivitySharingSection } from './ActivitySharingSection';

--- a/calendar-ui/src/lib/activity-form-section-labels.ts
+++ b/calendar-ui/src/lib/activity-form-section-labels.ts
@@ -20,7 +20,7 @@ export const ACTIVITY_FORM_SECTION_LABELS: Record<
 > = {
   overview: 'Overview',
   comms: 'Comms',
-  newsRelease: 'News release',
+  newsRelease: 'Release',
   reports: 'Reports',
   schedule: 'Schedule',
   event: 'Event',


### PR DESCRIPTION
… section

Extract newsReleaseOriginId, newsReleaseDistributionId, translationsRequiredStatusId, and translationLanguageIds from the Comms section into a new ActivityReleaseSection. Rename section label newsRelease from 'News release' to 'Release'. Render ActivityReleaseSection above ActivityEventSection in the shared form body and pass required lookups. Clean up ActivityCommsSection props/variables (removed release & translations responsibilities). Export the new section and update imports.
Ran full build and test suite — build/tests pass.
Files changed (key):

ActivityReleaseSection.tsx
ActivityCommsSection.tsx
ActivityFormBody.tsx
index.ts
activity-form-section-labels.ts