### PR TITLE
Fix/CORPCAL 999 add chromium to docker image

### DIFF
--- a/calendar-service/.env.example
+++ b/calendar-service/.env.example
@@ -23,3 +23,7 @@ RATE_LIMIT_MAX=100
 #   test:  https://corpcal-test.example.gov.bc.ca
 #   prod:  https://corpcal.example.gov.bc.ca
 PUBLIC_APP_BASE_URL=http://localhost:3000
+
+# Optional: path to Chrome/Chromium for report PDF export (puppeteer-core).
+# macOS default is detected when unset; Docker sets /usr/bin/chromium-browser.
+# PUPPETEER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome

--- a/calendar-service/Dockerfile
+++ b/calendar-service/Dockerfile
@@ -10,7 +10,8 @@ COPY packages/ ./packages/
 COPY calendar-service/ ./calendar-service/
 
 # Ensure npm skips optional dependencies (platform-specific binaries)
-ENV NPM_CONFIG_OPTIONAL=false
+ENV NPM_CONFIG_OPTIONAL=false \
+    PUPPETEER_SKIP_DOWNLOAD=true
 RUN npm ci --ignore-scripts
 
 # Build packages first, then service
@@ -21,7 +22,22 @@ RUN npm run build --workspace=packages/database && \
 
 FROM node:24-alpine
 WORKDIR /app
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    HOME=/tmp \
+    PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# System Chromium for report PDF export (puppeteer-core; fonts are inlined in HTML)
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates \
+  && if test -x /usr/bin/chromium-browser; then :; \
+     elif test -x /usr/bin/chromium; then ln -sf /usr/bin/chromium /usr/bin/chromium-browser; \
+     else echo "No Chromium binary under /usr/bin/chromium*" >&2; exit 1; fi \
+  && test -x "${PUPPETEER_EXECUTABLE_PATH}"
 
 # Copy workspace package files for dependency resolution
 COPY package*.json ./

--- a/calendar-service/package.json
+++ b/calendar-service/package.json
@@ -47,7 +47,7 @@
     "nestjs-zod": "^5.0.0",
     "pdf-lib": "^1.17.1",
     "postgres": "^3.4.3",
-    "puppeteer": "^24.40.0",
+    "puppeteer-core": "^24.40.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "reflect-metadata": "^0.2.2",

--- a/calendar-service/package.json
+++ b/calendar-service/package.json
@@ -47,7 +47,7 @@
     "nestjs-zod": "^5.0.0",
     "pdf-lib": "^1.17.1",
     "postgres": "^3.4.3",
-    "puppeteer-core": "^24.40.0",
+    "puppeteer-core": "24.43.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "reflect-metadata": "^0.2.2",

--- a/calendar-service/src/reports/pdf-generator.service.ts
+++ b/calendar-service/src/reports/pdf-generator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import puppeteer, { type Browser, type PDFOptions } from 'puppeteer';
+import type { Browser, PDFOptions } from 'puppeteer-core';
 
 import {
   REPORT_PDF_PAGE_FOOTER_MARGIN_BOTTOM_CSS,
@@ -11,6 +11,8 @@ import {
   REPORT_PRINT_LANDSCAPE_PDF_LAYOUT_TO_LETTER_SCALE,
   REPORT_PRINT_LAYOUT_WIDTH_PX,
 } from '@corpcal/shared/reports/reportPrintHtml';
+
+import { puppeteer, puppeteerLaunchOptions } from './report-pdf-puppeteer';
 
 export type GenerateReportPdfOptions = {
   /** Puppeteer `footerTemplate` HTML; enables `displayHeaderFooter` and bottom margin. */
@@ -86,10 +88,7 @@ export class PdfGeneratorService implements OnModuleDestroy {
 
   private async getBrowser(): Promise<Browser> {
     if (!this.browserLaunch) {
-      this.browserLaunch = puppeteer.launch({
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      });
+      this.browserLaunch = puppeteer.launch(puppeteerLaunchOptions());
     }
     try {
       return await this.browserLaunch;

--- a/calendar-service/src/reports/report-pdf-puppeteer.spec.ts
+++ b/calendar-service/src/reports/report-pdf-puppeteer.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CHROMIUM_USER_DATA_DIR,
@@ -7,9 +7,31 @@ import {
   resolveChromiumExecutablePath,
 } from './report-pdf-puppeteer';
 
+const mockExistsSync = vi.hoisted(() =>
+  vi.fn<typeof import('node:fs').existsSync>()
+);
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
+      mockExistsSync(path),
+  };
+});
+
+const LINUX_CHROMIUM_PATH = '/usr/bin/chromium-browser';
+const MACOS_CHROME_PATH =
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
 describe('resolveChromiumExecutablePath', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it('returns trimmed PUPPETEER_EXECUTABLE_PATH when set', () => {
@@ -17,27 +39,52 @@ describe('resolveChromiumExecutablePath', () => {
     expect(resolveChromiumExecutablePath()).toBe('/usr/bin/chromium');
   });
 
-  it('does not use env when unset', () => {
-    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '');
-    const path = resolveChromiumExecutablePath();
-    if (path) {
-      expect(path).not.toBe('');
+  it.each(['', '   '])(
+    'ignores empty or whitespace-only PUPPETEER_EXECUTABLE_PATH (%j)',
+    (envValue) => {
+      vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', envValue);
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+      mockExistsSync.mockImplementation((path) => path === LINUX_CHROMIUM_PATH);
+      expect(resolveChromiumExecutablePath()).toBe(LINUX_CHROMIUM_PATH);
     }
+  );
+
+  it('returns macOS Chrome when env is empty and Chrome is installed', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    mockExistsSync.mockImplementation((path) => path === MACOS_CHROME_PATH);
+    expect(resolveChromiumExecutablePath()).toBe(MACOS_CHROME_PATH);
   });
 });
 
 describe('puppeteerLaunchOptions', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
+  beforeEach(() => {
+    mockExistsSync.mockReset();
   });
 
-  it('throws when no executable can be resolved', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('throws when resolved executable does not exist on disk', () => {
     vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '/nonexistent/chromium-binary');
+    mockExistsSync.mockReturnValue(false);
     expect(() => puppeteerLaunchOptions()).toThrow(/not found at/);
+  });
+
+  it('throws when no Chromium executable can be resolved', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    mockExistsSync.mockReturnValue(false);
+    expect(() => puppeteerLaunchOptions()).toThrow(
+      /No Chromium\/Chrome executable found/
+    );
   });
 
   it('includes container-safe Chromium args when executable exists', () => {
     vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', process.execPath);
+    mockExistsSync.mockReturnValue(true);
     const options = puppeteerLaunchOptions();
     expect(options.executablePath).toBe(process.execPath);
     expect(options.args).toEqual(

--- a/calendar-service/src/reports/report-pdf-puppeteer.spec.ts
+++ b/calendar-service/src/reports/report-pdf-puppeteer.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CHROMIUM_USER_DATA_DIR,
+  PUPPETEER_LAUNCH_ARGS,
+  puppeteerLaunchOptions,
+  resolveChromiumExecutablePath,
+} from './report-pdf-puppeteer';
+
+describe('resolveChromiumExecutablePath', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns trimmed PUPPETEER_EXECUTABLE_PATH when set', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '  /usr/bin/chromium  ');
+    expect(resolveChromiumExecutablePath()).toBe('/usr/bin/chromium');
+  });
+
+  it('does not use env when unset', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '');
+    const path = resolveChromiumExecutablePath();
+    if (path) {
+      expect(path).not.toBe('');
+    }
+  });
+});
+
+describe('puppeteerLaunchOptions', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when no executable can be resolved', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '/nonexistent/chromium-binary');
+    expect(() => puppeteerLaunchOptions()).toThrow(/not found at/);
+  });
+
+  it('includes container-safe Chromium args when executable exists', () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', process.execPath);
+    const options = puppeteerLaunchOptions();
+    expect(options.executablePath).toBe(process.execPath);
+    expect(options.args).toEqual(
+      expect.arrayContaining([...PUPPETEER_LAUNCH_ARGS])
+    );
+    expect(options.args).toContain(`--user-data-dir=${CHROMIUM_USER_DATA_DIR}`);
+    expect(options.args).toContain('--crash-dumps-dir=/tmp');
+  });
+});

--- a/calendar-service/src/reports/report-pdf-puppeteer.ts
+++ b/calendar-service/src/reports/report-pdf-puppeteer.ts
@@ -1,0 +1,65 @@
+import { existsSync } from 'node:fs';
+import puppeteer, { type LaunchOptions } from 'puppeteer-core';
+
+/** Writable under OpenShift arbitrary UID; Chromium profile and crash dumps. */
+export const CHROMIUM_USER_DATA_DIR = '/tmp/chromium';
+
+export const PUPPETEER_LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+  `--user-data-dir=${CHROMIUM_USER_DATA_DIR}`,
+  '--crash-dumps-dir=/tmp',
+] as const;
+
+const LINUX_CHROMIUM_CANDIDATES = [
+  '/usr/bin/chromium-browser',
+  '/usr/bin/chromium',
+] as const;
+
+const MACOS_CHROME_PATH =
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+/**
+ * Resolves a Chromium/Chrome binary for puppeteer-core.
+ * Docker sets `PUPPETEER_EXECUTABLE_PATH`; local dev can use env or common install paths.
+ */
+export function resolveChromiumExecutablePath(): string | undefined {
+  const fromEnv = process.env.PUPPETEER_EXECUTABLE_PATH?.trim();
+  if (fromEnv) return fromEnv;
+
+  if (process.platform === 'darwin' && existsSync(MACOS_CHROME_PATH)) {
+    return MACOS_CHROME_PATH;
+  }
+
+  if (process.platform === 'linux') {
+    for (const candidate of LINUX_CHROMIUM_CANDIDATES) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function puppeteerLaunchOptions(): LaunchOptions {
+  const executablePath = resolveChromiumExecutablePath();
+  if (!executablePath) {
+    throw new Error(
+      'No Chromium/Chrome executable found for PDF export. Set PUPPETEER_EXECUTABLE_PATH or install Chromium/Chrome.'
+    );
+  }
+
+  if (!existsSync(executablePath)) {
+    throw new Error(
+      `Chromium/Chrome executable not found at "${executablePath}". Check PUPPETEER_EXECUTABLE_PATH.`
+    );
+  }
+
+  return {
+    headless: true,
+    executablePath,
+    args: [...PUPPETEER_LAUNCH_ARGS],
+  };
+}
+
+export { puppeteer };

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "nestjs-zod": "^5.0.0",
         "pdf-lib": "^1.17.1",
         "postgres": "^3.4.3",
-        "puppeteer": "^24.40.0",
+        "puppeteer-core": "^24.40.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "reflect-metadata": "^0.2.2",
@@ -436,6 +436,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -597,6 +598,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -8398,6 +8400,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9130,6 +9133,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -10096,6 +10100,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10118,6 +10123,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -12168,6 +12174,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -12184,6 +12191,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12302,6 +12310,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -13028,6 +13037,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -13579,6 +13589,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkifyjs": {
@@ -15039,6 +15050,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -15051,6 +15063,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -15804,27 +15817,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "24.43.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
-      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.13.2",
-        "chromium-bidi": "14.0.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1608973",
-        "puppeteer-core": "24.43.1",
-        "typed-query-selector": "^2.12.2"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "nestjs-zod": "^5.0.0",
         "pdf-lib": "^1.17.1",
         "postgres": "^3.4.3",
-        "puppeteer-core": "^24.40.0",
+        "puppeteer-core": "24.43.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "reflect-metadata": "^0.2.2",


### PR DESCRIPTION
# PR: fix/CORPCAL-999-image-add-chromium

## Summary

Report PDF export now uses `puppeteer-core` with a system Chromium binary instead of the full `puppeteer` package (which downloads its own Chromium). The calendar-service Docker image installs Alpine Chromium and sets launch options suited to containers and OpenShift-style arbitrary UIDs.

## Important

- **Dev setup:** Run `npm i` at the repo root (dependency swap and lockfile update).
- **Local PDF export:** macOS Chrome is auto-detected when installed at the default path; otherwise set `PUPPETEER_EXECUTABLE_PATH` (see `calendar-service/.env.example`).
- **Deploy:** Rebuild and redeploy the calendar-service image so system Chromium is present in the runtime container.

## Changes

1. **Report PDF (calendar-service):** Centralize Puppeteer launch configuration for report PDFs.
   - Replace `puppeteer` with `puppeteer-core` in `package.json` and `pdf-generator.service.ts`.
   - Add `report-pdf-puppeteer.ts` with executable path resolution and container-safe launch args.
   - Include `--no-sandbox`, `--disable-setuid-sandbox`, `--disable-dev-shm-usage`, and writable `/tmp` profile paths.
2. **Docker (calendar-service):** Install system Chromium for production PDF generation.
   - Add Alpine `chromium` and runtime libraries via `apk`.
   - Set `PUPPETEER_EXECUTABLE_PATH`, `PUPPETEER_SKIP_DOWNLOAD`, and `HOME=/tmp`.
   - Symlink `/usr/bin/chromium` when `chromium-browser` is missing.
3. **Config/docs:** Document optional local Chromium path.
   - Add commented `PUPPETEER_EXECUTABLE_PATH` example to `.env.example`.
4. **Tests:** Cover Chromium resolution and launch options.
   - Add `report-pdf-puppeteer.spec.ts` for env path, missing binary, and launch args.

## Testing

- `npm test -- --run src/reports/report-pdf-puppeteer.spec.ts` in `calendar-service` (4 tests passed).
- Pre-commit `lint-staged` (ESLint, Prettier, related Vitest) passed on commit.
- Manual: rebuild calendar-service image and export a report PDF in a deployed/test environment.
- Export of reports works locally.