### PR TITLE
refactor/CORPCAL-253-intersetional-date-filter

### DIFF
--- a/calendar-service/API.md
+++ b/calendar-service/API.md
@@ -93,11 +93,11 @@ Array filters accept comma-separated values in the query string (e.g. `tagIds=1,
 | Parameter                      | Type                           | Description                                                                                                                     |
 | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | `title`                        | string                         | Exact title match                                                                                                               |
-| `startDateFrom`                | ISO date                       | With `startDateTo`, lower bound for scheduled-span overlap (see `scheduledDateRangeOverlaps`)                                   |
-| `startDateTo`                  | ISO date                       | With `startDateFrom`, upper bound for scheduled-span overlap (see `scheduledDateRangeOverlaps`)                                 |
+| `startDateFrom`                | ISO date                       | Lower bound of the scheduled-span overlap window (optional; may be used alone)                                                  |
+| `startDateTo`                  | ISO date                       | Upper bound of the scheduled-span overlap window (optional; may be used alone)                                                  |
 | `endDateFrom`                  | ISO date                       | Activity `endDate` on or after                                                                                                  |
 | `endDateTo`                    | ISO date                       | Activity `endDate` on or before                                                                                                 |
-| `scheduledDateRangeOverlaps`   | boolean (`true`)               | When set with `startDateFrom`/`startDateTo`, activity `startDate` and `endDate` must be non-empty and overlap the window        |
+| `scheduledDateRangeOverlaps`   | boolean (`true`)               | Requires both activity dates and span overlap; UI/reports set this with date bounds (see below)                                 |
 | `activityStatusIds`            | int[]                          | Filter by status IDs (OR). When omitted, deleted activities are excluded; completed are excluded unless `includeCompleted=true` |
 | `leadMinistryIds`              | int[]                          | Lead ministry IDs (OR)                                                                                                          |
 | `leadOrgIds`                   | int[]                          | Lead organization IDs (OR)                                                                                                      |
@@ -125,6 +125,10 @@ Array filters accept comma-separated values in the query string (e.g. `tagIds=1,
 | `includeDeleted`               | boolean (`true`)               | Include deleted-status activities (Admin/System Admin only)                                                                     |
 | `page`                         | integer                        | Page number (default `1`)                                                                                                       |
 | `limit`                        | integer                        | Page size (default `20`, max `100`; not applied to unpaginated list responses today)                                            |
+
+**Scheduled date window (`startDateFrom` / `startDateTo`):** bounds use **span overlap**, not containment. An activity matches when its scheduled range intersects the window: `activity.end >= startDateFrom` (when set) and `activity.start <= startDateTo` (when set). Either bound may be omitted for an open-ended window. `startDate` must be set; activities with no start date never match.
+
+When `scheduledDateRangeOverlaps=true` (Activity List, Reports, and Look Ahead always send this with date bounds), `endDate` must also be set. Without the flag, a missing `endDate` is treated as a single-day span (`COALESCE(endDate, startDate)`).
 
 **Example:** `GET /activities?startDateFrom=2026-01-01&activityStatusIds=1,3&tagIds=5`
 

--- a/calendar-service/API.md
+++ b/calendar-service/API.md
@@ -93,11 +93,11 @@ Array filters accept comma-separated values in the query string (e.g. `tagIds=1,
 | Parameter                      | Type                           | Description                                                                                                                     |
 | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | `title`                        | string                         | Exact title match                                                                                                               |
-| `startDateFrom`                | ISO date                       | Activity `startDate` on or after (see `scheduledBothDatesInRange`)                                                              |
-| `startDateTo`                  | ISO date                       | Activity `startDate` on or before (see `scheduledBothDatesInRange`)                                                             |
+| `startDateFrom`                | ISO date                       | With `startDateTo`, lower bound for scheduled-span overlap (see `scheduledDateRangeOverlaps`)                                   |
+| `startDateTo`                  | ISO date                       | With `startDateFrom`, upper bound for scheduled-span overlap (see `scheduledDateRangeOverlaps`)                                 |
 | `endDateFrom`                  | ISO date                       | Activity `endDate` on or after                                                                                                  |
 | `endDateTo`                    | ISO date                       | Activity `endDate` on or before                                                                                                 |
-| `scheduledBothDatesInRange`    | boolean (`true`)               | When set with `startDateFrom`/`startDateTo`, both `startDate` and `endDate` must be non-empty and fall within the window        |
+| `scheduledDateRangeOverlaps`   | boolean (`true`)               | When set with `startDateFrom`/`startDateTo`, activity `startDate` and `endDate` must be non-empty and overlap the window        |
 | `activityStatusIds`            | int[]                          | Filter by status IDs (OR). When omitted, deleted activities are excluded; completed are excluded unless `includeCompleted=true` |
 | `leadMinistryIds`              | int[]                          | Lead ministry IDs (OR)                                                                                                          |
 | `leadOrgIds`                   | int[]                          | Lead organization IDs (OR)                                                                                                      |

--- a/calendar-service/src/activities/services/activity-find-all-filters.spec.ts
+++ b/calendar-service/src/activities/services/activity-find-all-filters.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import {
+  activityDateSpanOverlapsRange,
+  activityScheduledRangeOverlaps,
+  type DateRangeValue,
+} from '@corpcal/shared';
 import type { FilterActivitiesQueryParams } from '@corpcal/shared/schemas';
 
 import {
@@ -10,6 +15,7 @@ import {
 import {
   buildActivityFindAllConditions,
   buildActivityVisibilityCondition,
+  buildScheduledWindowOverlapConditions,
   hasActivityFindAllFilterFields,
 } from './activity-find-all-filters';
 
@@ -17,6 +23,66 @@ const DELETED_STATUS_ID = 99;
 const COMPLETED_STATUS_ID = 5;
 /** Bypass visibility so filter-only tests stay focused on non-visibility conditions. */
 const BYPASS_DATA_SCOPE: DataScope = { teamIds: [], bypass: true };
+
+type ScheduledWindowFilters = Pick<
+  FilterActivitiesQueryParams,
+  'startDateFrom' | 'startDateTo' | 'scheduledDateRangeOverlaps'
+>;
+
+/** Mirrors `buildScheduledWindowOverlapConditions` semantics for parity tests. */
+function activityMatchesScheduledWindowOverlap(
+  startDate: string | null,
+  endDate: string | null,
+  filters: ScheduledWindowFilters
+): boolean {
+  const hasLower =
+    filters.startDateFrom != null && filters.startDateFrom !== '';
+  const hasUpper = filters.startDateTo != null && filters.startDateTo !== '';
+  if (!hasLower && !hasUpper) {
+    if (filters.scheduledDateRangeOverlaps === true) {
+      return (
+        startDate != null &&
+        startDate !== '' &&
+        endDate != null &&
+        endDate !== ''
+      );
+    }
+    return true;
+  }
+
+  if (startDate == null || startDate === '') return false;
+
+  const requireFullSpan = filters.scheduledDateRangeOverlaps === true;
+  if (requireFullSpan && (endDate == null || endDate === '')) return false;
+
+  const effectiveEnd = requireFullSpan ? endDate! : (endDate ?? startDate);
+
+  if (hasLower && effectiveEnd < filters.startDateFrom!) return false;
+  if (hasUpper && startDate > filters.startDateTo!) return false;
+  return true;
+}
+
+function scheduledWindowToDateRange(
+  filters: ScheduledWindowFilters
+): DateRangeValue {
+  return {
+    startDate: filters.startDateFrom ?? '',
+    endDate: filters.startDateTo ?? '',
+    noStartDate: filters.startDateFrom == null || filters.startDateFrom === '',
+    noEndDate: filters.startDateTo == null || filters.startDateTo === '',
+  };
+}
+
+function sharedScheduledOverlapPredicate(
+  startDate: string | null,
+  endDate: string | null,
+  filters: ScheduledWindowFilters
+): boolean {
+  const range = scheduledWindowToDateRange(filters);
+  return filters.scheduledDateRangeOverlaps === true
+    ? activityScheduledRangeOverlaps(startDate, endDate, range)
+    : activityDateSpanOverlapsRange(startDate, endDate, range);
+}
 
 function createMockDb() {
   const select = vi.fn(() => ({
@@ -366,6 +432,168 @@ describe('buildActivityFindAllConditions', () => {
       dataScope: { teamIds: [1], bypass: true },
     });
     expect(conditions).toHaveLength(2);
+  });
+});
+
+describe('buildScheduledWindowOverlapConditions', () => {
+  const window: ScheduledWindowFilters = {
+    startDateFrom: '2026-05-01',
+    startDateTo: '2026-05-31',
+  };
+
+  const withFlag: ScheduledWindowFilters = {
+    ...window,
+    scheduledDateRangeOverlaps: true,
+  };
+
+  const activities = {
+    fullyInside: { start: '2026-05-10', end: '2026-05-20' },
+    fullyContainsWindow: { start: '2026-04-01', end: '2026-06-30' },
+    endsBeforeWindow: { start: '2026-04-01', end: '2026-04-30' },
+    startsAfterWindow: { start: '2026-06-01', end: '2026-06-30' },
+    overlapsStart: { start: '2026-04-15', end: '2026-05-10' },
+    overlapsEnd: { start: '2026-05-20', end: '2026-06-15' },
+    singleDayInWindow: { start: '2026-05-15', end: null },
+    missingStart: { start: null, end: '2026-05-15' },
+  } as const;
+
+  it('returns no conditions when neither bound is set without the flag', () => {
+    expect(buildScheduledWindowOverlapConditions(baseFilters())).toEqual([]);
+  });
+
+  it('returns non-null date guards when the flag is set but neither bound is set', () => {
+    expect(
+      buildScheduledWindowOverlapConditions(
+        baseFilters({ scheduledDateRangeOverlaps: true })
+      )
+    ).toHaveLength(2);
+  });
+
+  it('builds open lower-bound overlap (startDateFrom only)', () => {
+    const filters = baseFilters({ startDateFrom: '2026-05-01' });
+    expect(buildScheduledWindowOverlapConditions(filters)).toHaveLength(2);
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.endsBeforeWindow.start,
+        activities.endsBeforeWindow.end,
+        filters
+      )
+    ).toBe(false);
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.overlapsEnd.start,
+        activities.overlapsEnd.end,
+        filters
+      )
+    ).toBe(true);
+  });
+
+  it('builds open upper-bound overlap (startDateTo only)', () => {
+    const filters = baseFilters({ startDateTo: '2026-05-31' });
+    expect(buildScheduledWindowOverlapConditions(filters)).toHaveLength(2);
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.startsAfterWindow.start,
+        activities.startsAfterWindow.end,
+        filters
+      )
+    ).toBe(false);
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.overlapsStart.start,
+        activities.overlapsStart.end,
+        filters
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    ['fully inside', activities.fullyInside, true],
+    ['fully contains window', activities.fullyContainsWindow, true],
+    ['ends before window', activities.endsBeforeWindow, false],
+    ['starts after window', activities.startsAfterWindow, false],
+    ['overlaps start edge', activities.overlapsStart, true],
+    ['overlaps end edge', activities.overlapsEnd, true],
+    ['missing start', activities.missingStart, false],
+  ] as const)(
+    'with scheduledDateRangeOverlaps: %s => %s',
+    (_label, activity, expected) => {
+      expect(
+        activityMatchesScheduledWindowOverlap(
+          activity.start,
+          activity.end,
+          withFlag
+        )
+      ).toBe(expected);
+      expect(
+        sharedScheduledOverlapPredicate(activity.start, activity.end, withFlag)
+      ).toBe(expected);
+    }
+  );
+
+  it('requires both activity dates when scheduledDateRangeOverlaps is true', () => {
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.singleDayInWindow.start,
+        activities.singleDayInWindow.end,
+        withFlag
+      )
+    ).toBe(false);
+    expect(
+      sharedScheduledOverlapPredicate(
+        activities.singleDayInWindow.start,
+        activities.singleDayInWindow.end,
+        withFlag
+      )
+    ).toBe(false);
+    expect(
+      buildScheduledWindowOverlapConditions(baseFilters(withFlag))
+    ).toHaveLength(4);
+  });
+
+  it('treats missing end as single-day overlap without the flag', () => {
+    const filters = baseFilters(window);
+    expect(
+      activityMatchesScheduledWindowOverlap(
+        activities.singleDayInWindow.start,
+        activities.singleDayInWindow.end,
+        filters
+      )
+    ).toBe(true);
+    expect(
+      sharedScheduledOverlapPredicate(
+        activities.singleDayInWindow.start,
+        activities.singleDayInWindow.end,
+        filters
+      )
+    ).toBe(true);
+    expect(buildScheduledWindowOverlapConditions(filters)).toHaveLength(3);
+  });
+
+  it('matches shared overlap predicates for calendar-date fixtures', () => {
+    const cases = [
+      activities.fullyInside,
+      activities.fullyContainsWindow,
+      activities.endsBeforeWindow,
+      activities.startsAfterWindow,
+      activities.overlapsStart,
+      activities.overlapsEnd,
+      activities.singleDayInWindow,
+      activities.missingStart,
+    ];
+    for (const activity of cases) {
+      for (const filters of [window, withFlag]) {
+        expect(
+          activityMatchesScheduledWindowOverlap(
+            activity.start,
+            activity.end,
+            filters
+          )
+        ).toBe(
+          sharedScheduledOverlapPredicate(activity.start, activity.end, filters)
+        );
+      }
+    }
   });
 });
 

--- a/calendar-service/src/activities/services/activity-find-all-filters.spec.ts
+++ b/calendar-service/src/activities/services/activity-find-all-filters.spec.ts
@@ -54,7 +54,7 @@ describe('hasActivityFindAllFilterFields', () => {
   it.each([
     ['title', { title: 'Briefing' }],
     ['startDateFrom', { startDateFrom: '2026-01-01' }],
-    ['scheduledBothDatesInRange', { scheduledBothDatesInRange: true }],
+    ['scheduledDateRangeOverlaps', { scheduledDateRangeOverlaps: true }],
     ['activityStatusIds', { activityStatusIds: [1, 2] }],
     ['tagIds', { tagIds: [10] }],
     ['categoryNames', { categoryNames: ['Event'] }],
@@ -180,11 +180,11 @@ describe('buildActivityFindAllConditions', () => {
     expect(from).toHaveBeenCalled();
   });
 
-  it('requires both start and end in range when scheduledBothDatesInRange is true', () => {
+  it('requires full span overlap when scheduledDateRangeOverlaps is true', () => {
     const { db } = createMockDb();
     const conditions = buildActivityFindAllConditions({
       filters: baseFilters({
-        scheduledBothDatesInRange: true,
+        scheduledDateRangeOverlaps: true,
         startDateFrom: '2026-05-01',
         startDateTo: '2026-05-31',
       }),
@@ -194,11 +194,11 @@ describe('buildActivityFindAllConditions', () => {
       db,
       dataScope: BYPASS_DATA_SCOPE,
     });
-    // 2 non-null date guards + 2 lower bounds + 2 upper bounds + 2 archive exclusions
-    expect(conditions).toHaveLength(8);
+    // 1 start guard + 1 end guard + 1 overlap lower + 1 overlap upper + 2 archive exclusions
+    expect(conditions).toHaveLength(6);
   });
 
-  it('uses single-sided start date bounds when scheduledBothDatesInRange is false', () => {
+  it('uses span overlap when date bounds are set without the flag', () => {
     const { db } = createMockDb();
     const conditions = buildActivityFindAllConditions({
       filters: baseFilters({
@@ -211,8 +211,8 @@ describe('buildActivityFindAllConditions', () => {
       db,
       dataScope: BYPASS_DATA_SCOPE,
     });
-    // 2 archive exclusions + 2 start-date bounds
-    expect(conditions).toHaveLength(4);
+    // 2 archive exclusions + 1 start guard + 1 coalesce lower + 1 upper overlap
+    expect(conditions).toHaveLength(5);
   });
 
   it('adds pitch date null guard when pitchDateNotScheduled is true', () => {

--- a/calendar-service/src/activities/services/activity-find-all-filters.ts
+++ b/calendar-service/src/activities/services/activity-find-all-filters.ts
@@ -121,8 +121,51 @@ export function buildActivityVisibilityCondition(
 }
 
 /**
+ * Overlap conditions for `startDateFrom` / `startDateTo` windows:
+ * `activity.end >= windowStart` AND `activity.start <= windowEnd`.
+ * When `scheduledDateRangeOverlaps` is true, both activity dates must be set.
+ * Otherwise missing `endDate` is treated as single-day (`COALESCE(end, start)`).
+ */
+export function buildScheduledWindowOverlapConditions(
+  filters: FilterActivitiesQueryParams
+): SQL[] {
+  const hasLower =
+    filters.startDateFrom != null && filters.startDateFrom !== '';
+  const hasUpper = filters.startDateTo != null && filters.startDateTo !== '';
+  if (!hasLower && !hasUpper) return [];
+
+  const requireFullSpan = filters.scheduledDateRangeOverlaps === true;
+  const result: SQL[] = [];
+
+  result.push(isNotNull(activities.startDate));
+
+  if (requireFullSpan) {
+    result.push(isNotNull(activities.endDate));
+  }
+
+  if (hasLower) {
+    if (requireFullSpan) {
+      result.push(gte(activities.endDate, filters.startDateFrom!));
+    } else {
+      result.push(
+        gte(
+          sql`COALESCE(${activities.endDate}, ${activities.startDate})`,
+          filters.startDateFrom!
+        )
+      );
+    }
+  }
+
+  if (hasUpper) {
+    result.push(lte(activities.startDate, filters.startDateTo!));
+  }
+
+  return result;
+}
+
+/**
  * Builds SQL WHERE conditions for {@link ActivitiesService.findAll}.
- * Array params use OR semantics; scheduled date range requires both start and end in bounds.
+ * Array params use OR semantics; scheduled date windows use span overlap.
  *
  * This SQL builder is the Reports/list API implementation. Its behavioral
  * specification (dimension semantics, AND across / OR within) is documented and
@@ -210,25 +253,9 @@ export function buildActivityFindAllConditions(
     );
   }
 
-  if (filters.scheduledBothDatesInRange === true) {
-    conditions.push(isNotNull(activities.startDate));
-    conditions.push(isNotNull(activities.endDate));
-    if (filters.startDateFrom) {
-      conditions.push(gte(activities.startDate, filters.startDateFrom));
-      conditions.push(gte(activities.endDate, filters.startDateFrom));
-    }
-    if (filters.startDateTo) {
-      conditions.push(lte(activities.startDate, filters.startDateTo));
-      conditions.push(lte(activities.endDate, filters.startDateTo));
-    }
-  } else {
-    if (filters.startDateFrom) {
-      conditions.push(gte(activities.startDate, filters.startDateFrom));
-    }
-    if (filters.startDateTo) {
-      conditions.push(lte(activities.startDate, filters.startDateTo));
-    }
-  }
+  const scheduledWindowConditions =
+    buildScheduledWindowOverlapConditions(filters);
+  conditions.push(...scheduledWindowConditions);
 
   if (filters.endDateFrom) {
     conditions.push(gte(activities.endDate, filters.endDateFrom));
@@ -494,7 +521,7 @@ export function hasActivityFindAllFilterFields(
     query.startDateTo !== undefined ||
     query.endDateFrom !== undefined ||
     query.endDateTo !== undefined ||
-    query.scheduledBothDatesInRange === true ||
+    query.scheduledDateRangeOverlaps === true ||
     (query.activityStatusIds != null && query.activityStatusIds.length > 0) ||
     (query.leadMinistryIds != null && query.leadMinistryIds.length > 0) ||
     (query.leadOrgIds != null && query.leadOrgIds.length > 0) ||

--- a/calendar-service/src/activities/services/activity-find-all-filters.ts
+++ b/calendar-service/src/activities/services/activity-find-all-filters.ts
@@ -132,9 +132,12 @@ export function buildScheduledWindowOverlapConditions(
   const hasLower =
     filters.startDateFrom != null && filters.startDateFrom !== '';
   const hasUpper = filters.startDateTo != null && filters.startDateTo !== '';
-  if (!hasLower && !hasUpper) return [];
-
   const requireFullSpan = filters.scheduledDateRangeOverlaps === true;
+  if (!hasLower && !hasUpper) {
+    return requireFullSpan
+      ? [isNotNull(activities.startDate), isNotNull(activities.endDate)]
+      : [];
+  }
   const result: SQL[] = [];
 
   result.push(isNotNull(activities.startDate));

--- a/calendar-service/src/look-ahead/look-ahead.service.ts
+++ b/calendar-service/src/look-ahead/look-ahead.service.ts
@@ -80,6 +80,9 @@ export class LookAheadService {
       if (options?.endDate) {
         filters.startDateTo = options.endDate;
       }
+      if (options?.startDate ?? options?.endDate) {
+        filters.scheduledDateRangeOverlaps = true;
+      }
 
       const activities = await this.activitiesService.findAll(filters, ctx, {
         profile: HYDRATION_PROFILES.list,

--- a/calendar-service/src/reports/reports.service.ts
+++ b/calendar-service/src/reports/reports.service.ts
@@ -94,17 +94,28 @@ function pickDefinedActivityFilters(
   );
 }
 
-/** When the report section already pins the activity start-date window, query dates must not override it. */
+/** When the report section already pins the activity date window, query dates must not override it. */
 function withoutActivityStartDateWindow(
   filters: Partial<FilterActivitiesQueryParams>
 ): Partial<FilterActivitiesQueryParams> {
-  const {
-    startDateFrom: _f,
-    startDateTo: _t,
-    scheduledBothDatesInRange: _b,
-    ...rest
-  } = filters;
+  const { startDateFrom: _f, startDateTo: _t, ...rest } = filters;
   return rest;
+}
+
+function applyScheduledDateWindowToFilters(
+  filters: FilterActivitiesQueryParams,
+  start: string | undefined,
+  end: string | undefined
+): void {
+  if (start) {
+    filters.startDateFrom = start;
+  }
+  if (end) {
+    filters.startDateTo = end;
+  }
+  if (start ?? end) {
+    filters.scheduledDateRangeOverlaps = true;
+  }
 }
 
 /** User query filters ready to merge onto section-scoped activity queries. */
@@ -554,8 +565,11 @@ export class ReportsService {
         startDateTo: query.startDateTo,
       });
       const filters = reportDataQueryToActivityFindAllFilters(query);
-      filters.startDateFrom = dateWindow.start;
-      filters.startDateTo = dateWindow.end;
+      applyScheduledDateWindowToFilters(
+        filters,
+        dateWindow.start,
+        dateWindow.end
+      );
       let activities = await this.findActivitiesForReport(
         filters,
         ctx,
@@ -622,9 +636,13 @@ export class ReportsService {
       const filters: FilterActivitiesQueryParams = {
         page: 1,
         limit: 100,
-        startDateFrom: queryWindow.queryStartDateFrom,
-        startDateTo: queryWindow.queryStartDateTo,
       };
+
+      applyScheduledDateWindowToFilters(
+        filters,
+        queryWindow.queryStartDateFrom,
+        queryWindow.queryStartDateTo
+      );
 
       Object.assign(
         filters,
@@ -681,9 +699,13 @@ export class ReportsService {
         const filters: FilterActivitiesQueryParams = {
           page: 1,
           limit: 100,
-          startDateFrom: dateWindow.start,
-          startDateTo: dateWindow.end,
         };
+
+        applyScheduledDateWindowToFilters(
+          filters,
+          dateWindow.start,
+          dateWindow.end
+        );
 
         Object.assign(
           filters,

--- a/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
+++ b/calendar-ui/docs/ACTIVITY_LIST_SEARCH.md
@@ -26,6 +26,7 @@ Unified query shape: all ID-list filters use `…Ids` array params in HTTP (comm
 Both surfaces interpret `ActivityFilterState` through one shared specification in `packages/shared/src/filters/`:
 
 - `activityMatchesFilterState` (in `activity-filter-match.ts`) is the canonical predicate (AND across dimensions, OR within a multi-select). The Activity List client filter delegates to it; the server SQL builder (`calendar-service/.../activity-find-all-filters.ts`) is the API owner and is kept in sync with it.
+- Scheduled date filters use **span overlap** (not containment): an activity is included when its start/end range overlaps the filter window. Reports place spanning activities under the **first in-range day** (print/preview) or **first overlapping month** (30/60/90).
 - `activityMatchesSearchKeyword` / `getActivitySearchableTexts` (in `activity-searchable-text.ts`) define the single keyword field set used by both the list and Reports search.
 - `hasActivityFilterCriteria` (in `activity-filter-active.ts`) detects applied criteria for "Clear filters" / summary affordances — purely value-based, so applied **Pitch** / **Look Ahead** criteria count even when their controls are hidden by field scope.
 

--- a/calendar-ui/src/lib/activity-query-utils.spec.ts
+++ b/calendar-ui/src/lib/activity-query-utils.spec.ts
@@ -293,7 +293,7 @@ describe('filterActivityRowsByFilters', () => {
     expect(result.map((r) => r.id)).toEqual([1, 2]);
   });
 
-  it('filters by date range (activity start and end must fall within range)', () => {
+  it('filters by date range (activity span must overlap range)', () => {
     const rows = [
       makeRow({
         id: 1,
@@ -303,12 +303,17 @@ describe('filterActivityRowsByFilters', () => {
       makeRow({
         id: 2,
         startDate: '2024-12-01',
-        endDate: '2024-12-31',
+        endDate: '2025-01-10',
       }),
       makeRow({
         id: 3,
         startDate: '2025-02-01',
         endDate: '2025-02-28',
+      }),
+      makeRow({
+        id: 4,
+        startDate: '2024-12-15',
+        endDate: '2025-02-15',
       }),
     ];
     const result = filterActivityRowsByFilters(rows, {
@@ -322,7 +327,7 @@ describe('filterActivityRowsByFilters', () => {
       categoryNames: [],
       activityStatusIds: [],
     });
-    expect(result.map((r) => r.id)).toEqual([1]);
+    expect(result.map((r) => r.id)).toEqual([1, 2, 4]);
   });
 
   it('filters by look-ahead status', () => {

--- a/packages/shared/src/filters/README.md
+++ b/packages/shared/src/filters/README.md
@@ -6,20 +6,21 @@ is interpreted across the Reports (server SQL) path and the Activity List
 
 ## Modules
 
-| File                                  | Responsibility                                                                                     |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `../activity-filter-state.ts`         | `ActivityFilterState` type, defaults, coercion, key allow-list.                                    |
-| `activityFilterStateToQueryParams.ts` | Maps filter state to HTTP query params for the Reports/list API.                                   |
-| `activity-filter-match-input.ts`      | `ActivityFilterMatchInput` — normalized per-activity fields; `activityResponseToFilterMatchInput`. |
-| `activity-filter-date.ts`             | Date helpers (`isDateInRange`, `isDateRangeActive`, `activityScheduledRangeMatches`).              |
-| `activity-filter-match.ts`            | `activityMatchesFilterState` — the canonical predicate.                                            |
-| `activity-searchable-text.ts`         | `getActivitySearchableTexts` / `activityMatchesSearchKeyword` — the single keyword field set.      |
-| `activity-filter-active.ts`           | `hasActivityFilterCriteria` — value-based "any filter applied" check.                              |
+| File                                  | Responsibility                                                                                       |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `../activity-filter-state.ts`         | `ActivityFilterState` type, defaults, coercion, key allow-list.                                      |
+| `activityFilterStateToQueryParams.ts` | Maps filter state to HTTP query params for the Reports/list API.                                     |
+| `activity-filter-match-input.ts`      | `ActivityFilterMatchInput` — normalized per-activity fields; `activityResponseToFilterMatchInput`.   |
+| `activity-filter-date.ts`             | Date helpers (`isDateInRange`, `isDateRangeActive`, overlap helpers, report display day/month keys). |
+| `activity-filter-match.ts`            | `activityMatchesFilterState` — the canonical predicate.                                              |
+| `activity-searchable-text.ts`         | `getActivitySearchableTexts` / `activityMatchesSearchKeyword` — the single keyword field set.        |
+| `activity-filter-active.ts`           | `hasActivityFilterCriteria` — value-based "any filter applied" check.                                |
 
 ## Predicate semantics
 
 - **AND across dimensions**: every dimension with a value in state must pass.
 - **OR within a multi-select**: any selected value matches.
+- **Scheduled date range**: activity span must **overlap** the filter window (both activity dates required).
 - A dimension with no value in state is skipped.
 - Field-scope visibility (e.g. pitch) does **not** gate predicates: criteria
   apply whenever present in state. The same goes for `hasActivityFilterCriteria`.

--- a/packages/shared/src/filters/README.md
+++ b/packages/shared/src/filters/README.md
@@ -20,7 +20,7 @@ is interpreted across the Reports (server SQL) path and the Activity List
 
 - **AND across dimensions**: every dimension with a value in state must pass.
 - **OR within a multi-select**: any selected value matches.
-- **Scheduled date range**: activity span must **overlap** the filter window (both activity dates required).
+- **Scheduled date range**: activity span must **overlap** the filter window. The Activity List and Reports set `scheduledDateRangeOverlaps=true`, so both activity `startDate` and `endDate` are required. Without that API flag, SQL overlap still applies but a missing `endDate` is treated as single-day.
 - A dimension with no value in state is skipped.
 - Field-scope visibility (e.g. pitch) does **not** gate predicates: criteria
   apply whenever present in state. The same goes for `hasActivityFilterCriteria`.

--- a/packages/shared/src/filters/activity-filter-date.spec.ts
+++ b/packages/shared/src/filters/activity-filter-date.spec.ts
@@ -136,6 +136,19 @@ describe('activityReportDisplayDayKey', () => {
       activityReportDisplayDayKey('2025-06-01', '2025-06-30', null)
     ).toBeNull();
   });
+
+  it('normalizes UTC instants to Pacific calendar dates', () => {
+    expect(
+      activityReportDisplayDayKey(
+        '2026-04-27T06:59:00.000Z',
+        '2026-04-27T06:59:00.000Z',
+        {
+          start: toCalendarDateString('2026-04-26'),
+          end: toCalendarDateString('2026-04-28'),
+        }
+      )
+    ).toBe('2026-04-26');
+  });
 });
 
 describe('activityReportDisplayMonthKey', () => {

--- a/packages/shared/src/filters/activity-filter-date.spec.ts
+++ b/packages/shared/src/filters/activity-filter-date.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DateRangeValue } from '../activity-filter-state';
+import { toCalendarDateString } from '../datetime/types';
+import {
+  activityDateSpanOverlapsRange,
+  activityReportDisplayDayKey,
+  activityReportDisplayMonthKey,
+  activityScheduledRangeOverlaps,
+} from './activity-filter-date';
+
+function range(overrides: Partial<DateRangeValue> = {}): DateRangeValue {
+  return {
+    startDate: '2025-06-16',
+    endDate: '2025-06-24',
+    noStartDate: false,
+    noEndDate: false,
+    ...overrides,
+  };
+}
+
+describe('activityDateSpanOverlapsRange', () => {
+  it('includes a span that fully contains the window', () => {
+    expect(
+      activityDateSpanOverlapsRange('2025-06-01', '2025-06-30', range())
+    ).toBe(true);
+  });
+
+  it('includes a span fully inside the window', () => {
+    expect(
+      activityDateSpanOverlapsRange('2025-06-18', '2025-06-20', range())
+    ).toBe(true);
+  });
+
+  it('excludes a span that ends before the window', () => {
+    expect(
+      activityDateSpanOverlapsRange('2025-06-01', '2025-06-15', range())
+    ).toBe(false);
+  });
+
+  it('excludes a span that starts after the window', () => {
+    expect(
+      activityDateSpanOverlapsRange('2025-06-25', '2025-06-30', range())
+    ).toBe(false);
+  });
+
+  it('treats a missing activity end as single-day', () => {
+    expect(activityDateSpanOverlapsRange('2025-06-20', null, range())).toBe(
+      true
+    );
+    expect(activityDateSpanOverlapsRange('2025-06-01', null, range())).toBe(
+      false
+    );
+  });
+
+  it('excludes when activity start is missing', () => {
+    expect(activityDateSpanOverlapsRange(null, '2025-06-20', range())).toBe(
+      false
+    );
+  });
+
+  it('honors open lower bound', () => {
+    expect(
+      activityDateSpanOverlapsRange(
+        '2025-01-15',
+        '2025-02-05',
+        range({
+          startDate: '',
+          endDate: '2025-01-31',
+          noStartDate: true,
+          noEndDate: false,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('honors open upper bound', () => {
+    expect(
+      activityDateSpanOverlapsRange(
+        '2025-06-20',
+        '2025-07-10',
+        range({
+          startDate: '2025-06-16',
+          endDate: '',
+          noStartDate: false,
+          noEndDate: true,
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('activityScheduledRangeOverlaps', () => {
+  it('requires both activity dates to be set', () => {
+    expect(activityScheduledRangeOverlaps(null, '2025-06-20', range())).toBe(
+      false
+    );
+    expect(activityScheduledRangeOverlaps('2025-06-20', null, range())).toBe(
+      false
+    );
+  });
+
+  it('matches overlap when both dates are set', () => {
+    expect(
+      activityScheduledRangeOverlaps('2025-06-01', '2025-06-30', range())
+    ).toBe(true);
+  });
+});
+
+describe('activityReportDisplayDayKey', () => {
+  const reportRange = {
+    start: toCalendarDateString('2025-06-16'),
+    end: toCalendarDateString('2025-06-24'),
+  };
+
+  it('returns the first in-range day for a spanning activity', () => {
+    expect(
+      activityReportDisplayDayKey('2025-06-01', '2025-06-30', reportRange)
+    ).toBe('2025-06-16');
+  });
+
+  it('returns activity start when it is already inside the window', () => {
+    expect(
+      activityReportDisplayDayKey('2025-06-18', '2025-06-20', reportRange)
+    ).toBe('2025-06-18');
+  });
+
+  it('returns null when there is no overlap', () => {
+    expect(
+      activityReportDisplayDayKey('2025-05-01', '2025-05-31', reportRange)
+    ).toBeNull();
+  });
+
+  it('returns null when report range is missing', () => {
+    expect(
+      activityReportDisplayDayKey('2025-06-01', '2025-06-30', null)
+    ).toBeNull();
+  });
+});
+
+describe('activityReportDisplayMonthKey', () => {
+  it('returns the month of the first overlapping day', () => {
+    expect(
+      activityReportDisplayMonthKey('2025-05-24', '2025-07-15', {
+        start: toCalendarDateString('2025-06-01'),
+        end: toCalendarDateString('2025-06-30'),
+      })
+    ).toBe('2025-06');
+  });
+});

--- a/packages/shared/src/filters/activity-filter-date.ts
+++ b/packages/shared/src/filters/activity-filter-date.ts
@@ -1,4 +1,5 @@
 import type { DateRangeValue } from '../activity-filter-state';
+import { pacificDayKey } from '../datetime/calendar';
 import type { CalendarDateString } from '../datetime/types';
 
 /** Inclusive calendar-date bounds (`YYYY-MM-DD`). */
@@ -7,18 +8,14 @@ export interface CalendarDateBounds {
   end: CalendarDateString;
 }
 
-function calendarDatePrefix(value: string | null | undefined): string {
-  return value?.slice(0, 10) ?? '';
-}
-
 function normalizedActivitySpan(
   startDate: string | null,
   endDate: string | null
 ): { start: string; end: string } | null {
-  const start = calendarDatePrefix(startDate);
-  if (start === '') return null;
-  const endRaw = calendarDatePrefix(endDate);
-  const end = endRaw === '' ? start : endRaw;
+  const start = pacificDayKey(startDate);
+  if (start == null) return null;
+  const endRaw = pacificDayKey(endDate);
+  const end = endRaw ?? start;
   return { start, end };
 }
 
@@ -83,9 +80,9 @@ export function activityScheduledRangeOverlaps(
   endDate: string | null,
   range: DateRangeValue
 ): boolean {
-  const start = calendarDatePrefix(startDate);
-  const end = calendarDatePrefix(endDate);
-  if (start === '' || end === '') return false;
+  const start = pacificDayKey(startDate);
+  const end = pacificDayKey(endDate);
+  if (start == null || end == null) return false;
   return activityDateSpanOverlapsRange(startDate, endDate, range);
 }
 

--- a/packages/shared/src/filters/activity-filter-date.ts
+++ b/packages/shared/src/filters/activity-filter-date.ts
@@ -1,4 +1,26 @@
 import type { DateRangeValue } from '../activity-filter-state';
+import type { CalendarDateString } from '../datetime/types';
+
+/** Inclusive calendar-date bounds (`YYYY-MM-DD`). */
+export interface CalendarDateBounds {
+  start: CalendarDateString;
+  end: CalendarDateString;
+}
+
+function calendarDatePrefix(value: string | null | undefined): string {
+  return value?.slice(0, 10) ?? '';
+}
+
+function normalizedActivitySpan(
+  startDate: string | null,
+  endDate: string | null
+): { start: string; end: string } | null {
+  const start = calendarDatePrefix(startDate);
+  if (start === '') return null;
+  const endRaw = calendarDatePrefix(endDate);
+  const end = endRaw === '' ? start : endRaw;
+  return { start, end };
+}
 
 /**
  * True when a single ISO date string falls within the given bounds.
@@ -29,32 +51,72 @@ export function isDateRangeActive(range: DateRangeValue): boolean {
 }
 
 /**
- * True when both the activity start and end dates fall within `range`.
- * Mirrors the SQL `scheduledBothDatesInRange` semantics: an activity with a
- * missing start or end date never matches an active scheduled-date filter.
+ * True when the activity scheduled span overlaps `range`.
+ * Requires a non-empty activity start; treats a missing end as single-day.
+ * Open filter bounds (`noStartDate` / `noEndDate`) omit that side of the window.
  */
-export function activityScheduledRangeMatches(
+export function activityDateSpanOverlapsRange(
   startDate: string | null,
   endDate: string | null,
   range: DateRangeValue
 ): boolean {
-  const start = startDate ?? '';
-  const end = endDate ?? '';
+  const span = normalizedActivitySpan(startDate, endDate);
+  if (span == null) return false;
+
+  const windowStart =
+    !range.noStartDate && range.startDate !== '' ? range.startDate : null;
+  const windowEnd =
+    !range.noEndDate && range.endDate !== '' ? range.endDate : null;
+
+  if (windowStart != null && span.end < windowStart) return false;
+  if (windowEnd != null && span.start > windowEnd) return false;
+  return true;
+}
+
+/**
+ * True when the activity scheduled span overlaps `range` and both activity
+ * start and end are set (non-empty). Used when the API flag
+ * `scheduledDateRangeOverlaps` requires a full schedulable span.
+ */
+export function activityScheduledRangeOverlaps(
+  startDate: string | null,
+  endDate: string | null,
+  range: DateRangeValue
+): boolean {
+  const start = calendarDatePrefix(startDate);
+  const end = calendarDatePrefix(endDate);
   if (start === '' || end === '') return false;
-  return (
-    isDateInRange(
-      start,
-      range.startDate,
-      range.endDate,
-      range.noStartDate,
-      range.noEndDate
-    ) &&
-    isDateInRange(
-      end,
-      range.startDate,
-      range.endDate,
-      range.noStartDate,
-      range.noEndDate
-    )
-  );
+  return activityDateSpanOverlapsRange(startDate, endDate, range);
+}
+
+/**
+ * First calendar day of overlap between an activity span and a report window.
+ * Returns `null` when there is no overlap or the report range is incomplete.
+ */
+export function activityReportDisplayDayKey(
+  startDate: string | null,
+  endDate: string | null,
+  reportRange: CalendarDateBounds | null | undefined
+): CalendarDateString | null {
+  const span = normalizedActivitySpan(startDate, endDate);
+  if (span == null || reportRange?.start == null || reportRange?.end == null) {
+    return null;
+  }
+  if (span.end < reportRange.start || span.start > reportRange.end) {
+    return null;
+  }
+  const key = span.start < reportRange.start ? reportRange.start : span.start;
+  return key as CalendarDateString;
+}
+
+/**
+ * Month bucket key (`YYYY-MM`) for the first overlapping day within a month section.
+ */
+export function activityReportDisplayMonthKey(
+  startDate: string | null,
+  endDate: string | null,
+  monthRange: CalendarDateBounds
+): string | null {
+  const dayKey = activityReportDisplayDayKey(startDate, endDate, monthRange);
+  return dayKey?.slice(0, 7) ?? null;
 }

--- a/packages/shared/src/filters/activity-filter-match.spec.ts
+++ b/packages/shared/src/filters/activity-filter-match.spec.ts
@@ -142,8 +142,8 @@ describe('activityMatchesFilterState', () => {
     expect(matchIds(DEFAULT_ACTIVITY_FILTER_STATE)).toEqual([1, 2, 3, 4]);
   });
 
-  describe('scheduled date range (both dates must fall in window)', () => {
-    it('excludes activities with a date outside the window or a missing bound', () => {
+  describe('scheduled date range (span must overlap window)', () => {
+    it('excludes disjoint activities and those with a missing bound', () => {
       expect(
         matchIds(
           state({
@@ -155,7 +155,7 @@ describe('activityMatchesFilterState', () => {
             },
           })
         )
-      ).toEqual([1, 4]); // 2 end outside; 3 missing start
+      ).toEqual([1, 2, 4]); // 3 missing start; 2 spans into Feb but overlaps Jan
     });
 
     it('honors noStartDate (open lower bound)', () => {
@@ -170,7 +170,7 @@ describe('activityMatchesFilterState', () => {
             },
           })
         )
-      ).toEqual([1, 4]); // 2 end in Feb; 3 missing start
+      ).toEqual([1, 2, 4]); // 3 missing start
     });
   });
 

--- a/packages/shared/src/filters/activity-filter-match.ts
+++ b/packages/shared/src/filters/activity-filter-match.ts
@@ -1,6 +1,6 @@
 import type { ActivityFilterState } from '../activity-filter-state';
 import {
-  activityScheduledRangeMatches,
+  activityScheduledRangeOverlaps,
   isDateInRange,
   isDateRangeActive,
 } from './activity-filter-date';
@@ -38,10 +38,10 @@ export function activityMatchesFilterState(
   input: ActivityFilterMatchInput,
   options?: ActivityFilterMatchOptions
 ): boolean {
-  // Scheduled date range: both start and end must fall within bounds.
+  // Scheduled date range: activity span must overlap the filter window.
   if (isDateRangeActive(filterState.dateRange)) {
     if (
-      !activityScheduledRangeMatches(
+      !activityScheduledRangeOverlaps(
         input.startDate,
         input.endDate,
         filterState.dateRange

--- a/packages/shared/src/filters/activity-filter-parity.spec.ts
+++ b/packages/shared/src/filters/activity-filter-parity.spec.ts
@@ -145,7 +145,7 @@ describe('activityFilterStateToQueryParams + activityMatchesFilterState parity',
     ).toBe(false);
   });
 
-  it('scheduled date range maps to bounds and requires both dates in window', () => {
+  it('scheduled date range maps to bounds and uses span overlap', () => {
     const filterState: ActivityFilterState = {
       ...DEFAULT_ACTIVITY_FILTER_STATE,
       dateRange: {
@@ -166,7 +166,7 @@ describe('activityFilterStateToQueryParams + activityMatchesFilterState parity',
     );
     expect(params.startDateFrom).toBe('2025-01-01');
     expect(params.startDateTo).toBe('2025-01-31');
-    expect(params.scheduledBothDatesInRange).toBe(true);
+    expect(params.scheduledDateRangeOverlaps).toBe(true);
 
     expect(
       activityMatchesFilterState(
@@ -178,6 +178,12 @@ describe('activityFilterStateToQueryParams + activityMatchesFilterState parity',
       activityMatchesFilterState(
         filterState,
         makeMatchInput({ startDate: '2025-01-10', endDate: '2025-02-10' })
+      )
+    ).toBe(true);
+    expect(
+      activityMatchesFilterState(
+        filterState,
+        makeMatchInput({ startDate: '2025-02-01', endDate: '2025-02-10' })
       )
     ).toBe(false);
     expect(

--- a/packages/shared/src/filters/activityFilterStateToQueryParams.spec.ts
+++ b/packages/shared/src/filters/activityFilterStateToQueryParams.spec.ts
@@ -53,7 +53,7 @@ describe('activityFilterStateToQueryParams', () => {
     expect(result.search).toBeUndefined();
   });
 
-  it('maps scheduled date range with both-dates flag', () => {
+  it('maps scheduled date range with overlap flag', () => {
     const result = activityFilterStateToQueryParams(
       {
         filterState: {
@@ -73,7 +73,7 @@ describe('activityFilterStateToQueryParams', () => {
     );
     expect(result.startDateFrom).toBe('2025-01-01');
     expect(result.startDateTo).toBe('2025-01-31');
-    expect(result.scheduledBothDatesInRange).toBe(true);
+    expect(result.scheduledDateRangeOverlaps).toBe(true);
   });
 
   it('maps multi-select arrays', () => {

--- a/packages/shared/src/filters/activityFilterStateToQueryParams.ts
+++ b/packages/shared/src/filters/activityFilterStateToQueryParams.ts
@@ -65,7 +65,7 @@ export function activityFilterStateToQueryParams(
     if (!fs.dateRange.noEndDate && fs.dateRange.endDate !== '') {
       params.startDateTo = fs.dateRange.endDate;
     }
-    params.scheduledBothDatesInRange = true;
+    params.scheduledDateRangeOverlaps = true;
   }
 
   const statusIds = nonEmptyArray(fs.activityStatusIds);

--- a/packages/shared/src/reports/print/buildPrintGroupedDayBlocks.spec.ts
+++ b/packages/shared/src/reports/print/buildPrintGroupedDayBlocks.spec.ts
@@ -30,6 +30,26 @@ describe('buildCalendarDayKeys', () => {
 });
 
 describe('buildPrintGroupedDayBlocks', () => {
+  it('places a spanning activity under the first in-range day for per-day chrome', () => {
+    const spanningActivity = {
+      ...BASE_ACTIVITY,
+      startDate: '2026-04-20',
+      endDate: '2026-04-30',
+    };
+    const blocks = buildPrintGroupedDayBlocks({
+      activitiesByKey: new Map([['2026-04-27', [spanningActivity]]]),
+      resolvedDateRange: { start: APR_27, end: APR_29 },
+      showPerDayPrintChrome: true,
+      emptyDayDisplayMode: 'grouped',
+      variant: 'lookAhead',
+      activityBaseUrl: 'https://example.test',
+    });
+
+    const dayWithActivity = blocks.find((block) => block.rows.length > 0);
+    expect(dayWithActivity?.dayKey).toBe('2026-04-27');
+    expect(dayWithActivity?.rows).toHaveLength(1);
+  });
+
   it('includes every day in range for per-day chrome with grouped empty runs', () => {
     const blocks = buildPrintGroupedDayBlocks({
       activitiesByKey: new Map([['2026-04-28', [BASE_ACTIVITY]]]),

--- a/packages/shared/src/reports/print/collectPrintReportSections.spec.ts
+++ b/packages/shared/src/reports/print/collectPrintReportSections.spec.ts
@@ -61,4 +61,37 @@ describe('collectPrintReportSections', () => {
     expect(events.activitiesByKey.get('2025-06-16')).toHaveLength(1);
     expect(events.activitiesByKey.has('2025-06-01')).toBe(false);
   });
+
+  it('omits activities when resolvedDateRange is missing', () => {
+    const data: ReportDataResponse = {
+      report: {
+        id: 1,
+        name: 'look-ahead',
+        displayName: 'Look Ahead',
+        sortOrder: 1,
+        isActive: true,
+        visibility: 'team',
+        config: { fields: ['startDate', 'title'], sections: [] },
+        description: null,
+      },
+      sections: [
+        {
+          id: 'events',
+          name: 'Events',
+          order: 1,
+          activities: [
+            createMockActivityListItem({
+              id: 1,
+              startDate: '2025-06-18',
+              endDate: '2025-06-20',
+              title: 'Unbucketed',
+            }),
+          ],
+        },
+      ],
+    };
+
+    const sections = collectPrintReportSections(data);
+    expect(sections[0].activitiesByKey.size).toBe(0);
+  });
 });

--- a/packages/shared/src/reports/print/collectPrintReportSections.spec.ts
+++ b/packages/shared/src/reports/print/collectPrintReportSections.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ReportDataResponse } from '../../api/report-data';
+import { toCalendarDateString } from '../../datetime/types';
+import { createMockActivityListItem } from '../../test-utils';
+import { collectPrintReportSections } from './collectPrintReportSections';
+
+describe('collectPrintReportSections', () => {
+  it('buckets spanning activities under the first in-range report day', () => {
+    const data: ReportDataResponse = {
+      report: {
+        id: 1,
+        name: 'look-ahead',
+        displayName: 'Look Ahead',
+        sortOrder: 1,
+        isActive: true,
+        visibility: 'team',
+        config: {
+          fields: ['startDate', 'title'],
+          sections: [
+            {
+              id: 'events',
+              name: 'Events',
+              order: 1,
+              filter: { lookAheadSection: 'events' },
+              printPerDayColumnHeaderRepeat: true,
+            },
+          ],
+        },
+        description: null,
+      },
+      sections: [
+        {
+          id: 'events',
+          name: 'Events',
+          order: 1,
+          activities: [
+            createMockActivityListItem({
+              id: 1,
+              startDate: '2025-06-01',
+              endDate: '2025-06-30',
+              title: 'Spanning event',
+            }),
+          ],
+        },
+      ],
+      meta: {
+        resolvedDateRange: {
+          start: toCalendarDateString('2025-06-16'),
+          end: toCalendarDateString('2025-06-24'),
+        },
+        activityCount: 1,
+        wasClamped: false,
+        inferredBound: null,
+        largeResultWarning: false,
+      },
+    };
+
+    const sections = collectPrintReportSections(data);
+    const events = sections[0];
+    expect(events.activitiesByKey.get('2025-06-16')).toHaveLength(1);
+    expect(events.activitiesByKey.has('2025-06-01')).toBe(false);
+  });
+});

--- a/packages/shared/src/reports/print/collectPrintReportSections.ts
+++ b/packages/shared/src/reports/print/collectPrintReportSections.ts
@@ -1,7 +1,8 @@
 import type { ReportDataResponse } from '../../api/report-data';
 import type { ReportActivityRow } from '../../api/types';
+import { activityReportDisplayDayKey } from '../../filters/activity-filter-date';
 import { resolveLookAheadSectionRows } from '../look-ahead';
-import { dateKeyLocal } from './react/dateFormatters';
+import type { ReportDateRange } from '../normalizeReportActivityDateRange';
 import { compareActivitiesForPrint } from './react/rowViewModel';
 
 /** Default when section config omits `printPerDayColumnHeaderRepeat`. */
@@ -18,12 +19,20 @@ export interface PrintReportSortedSection {
 }
 
 function indexActivitiesByDay(
-  activities: ReportActivityRow[]
+  activities: ReportActivityRow[],
+  resolvedDateRange: ReportDateRange | null | undefined
 ): Map<string, ReportActivityRow[]> {
   const sorted = [...activities].sort(compareActivitiesForPrint);
   const byKey = new Map<string, ReportActivityRow[]>();
   for (const activity of sorted) {
-    const key = dateKeyLocal(activity.startDate);
+    const key =
+      activityReportDisplayDayKey(
+        activity.startDate,
+        activity.endDate,
+        resolvedDateRange ?? undefined
+      ) ??
+      activity.startDate?.slice(0, 10) ??
+      null;
     if (!key) continue;
     const bucket = byKey.get(key);
     if (bucket) {
@@ -38,6 +47,7 @@ function indexActivitiesByDay(
 export function collectPrintReportSections(
   data: ReportDataResponse
 ): PrintReportSortedSection[] {
+  const resolvedDateRange = data.meta?.resolvedDateRange;
   const legendColorById = new Map<string, string | null>();
   const printHeadingById = new Map<string, string>();
   const showPerDayChromeById = new Map<string, boolean>();
@@ -67,7 +77,10 @@ export function collectPrintReportSections(
         showPerDayChromeById.get(section.id) ??
         DEFAULT_SHOW_PER_DAY_PRINT_CHROME,
       omitReleaseColumn: omitReleaseColumnById.get(section.id) ?? false,
-      activitiesByKey: indexActivitiesByDay(section.activities),
+      activitiesByKey: indexActivitiesByDay(
+        section.activities,
+        resolvedDateRange
+      ),
     }));
 }
 

--- a/packages/shared/src/reports/print/collectPrintReportSections.ts
+++ b/packages/shared/src/reports/print/collectPrintReportSections.ts
@@ -25,14 +25,11 @@ function indexActivitiesByDay(
   const sorted = [...activities].sort(compareActivitiesForPrint);
   const byKey = new Map<string, ReportActivityRow[]>();
   for (const activity of sorted) {
-    const key =
-      activityReportDisplayDayKey(
-        activity.startDate,
-        activity.endDate,
-        resolvedDateRange ?? undefined
-      ) ??
-      activity.startDate?.slice(0, 10) ??
-      null;
+    const key = activityReportDisplayDayKey(
+      activity.startDate,
+      activity.endDate,
+      resolvedDateRange ?? undefined
+    );
     if (!key) continue;
     const bucket = byKey.get(key);
     if (bucket) {

--- a/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.spec.ts
+++ b/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.spec.ts
@@ -8,13 +8,15 @@ import { groupActivitiesByMonthSection } from './groupActivitiesByMonthSection';
 function createActivity(
   id: number,
   startDate: string,
-  startTime?: string
+  startTime?: string,
+  endDate?: string
 ): ActivityListItem {
   return createMockActivityListItem({
     id,
     displayId: `ACT-${id}`,
     title: `Activity ${id}`,
     startDate,
+    endDate: endDate ?? startDate,
     startTime: startTime ?? null,
   });
 }
@@ -35,5 +37,30 @@ describe('groupActivitiesByMonthSection', () => {
     const may = grouped.get('2026-05') ?? [];
 
     expect(may.map((activity) => activity.id)).toEqual([2, 1, 3]);
+  });
+
+  it('assigns spanning activities to the first overlapping month in the query range', () => {
+    const monthSections = buildCalendarMonthSections({
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    });
+    const activities = [
+      createMockActivityListItem({
+        id: 1,
+        displayId: 'ACT-1',
+        title: 'Activity 1',
+        startDate: '2026-05-24',
+        endDate: '2026-07-15',
+        startTime: '09:00',
+      }),
+      createActivity(2, '2026-06-10', '10:00', '2026-06-12'),
+    ];
+
+    const grouped = groupActivitiesByMonthSection(activities, monthSections);
+
+    expect(grouped.get('2026-06')?.map((activity) => activity.id)).toEqual([
+      1, 2,
+    ]);
+    expect(grouped.get('2026-05') ?? []).toHaveLength(0);
   });
 });

--- a/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.ts
+++ b/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.ts
@@ -1,5 +1,5 @@
 import type { ReportActivityRow } from '../../api/types';
-import { pacificDayKey } from '../../datetime';
+import { activityReportDisplayDayKey } from '../../filters/activity-filter-date';
 import { createCompareActivitiesForPrint } from '../print/react/rowViewModel';
 import type { CalendarMonthSection } from './buildCalendarMonthSections';
 
@@ -7,10 +7,24 @@ const compareActivitiesForMonthSection = createCompareActivitiesForPrint({
   sortByDayKey: true,
 });
 
+function queryRangeFromMonthSections(monthSections: CalendarMonthSection[]): {
+  start: CalendarMonthSection['dateRange']['start'];
+  end: CalendarMonthSection['dateRange']['end'];
+} | null {
+  if (monthSections.length === 0) return null;
+  let start = monthSections[0].dateRange.start;
+  let end = monthSections[0].dateRange.end;
+  for (const section of monthSections.slice(1)) {
+    if (section.dateRange.start < start) start = section.dateRange.start;
+    if (section.dateRange.end > end) end = section.dateRange.end;
+  }
+  return { start, end };
+}
+
 /**
- * Buckets activities into calendar month sections by Pacific start date.
- * Activities outside a section's clipped date range or without a start date
- * are omitted.
+ * Buckets activities into calendar month sections by the first overlapping day
+ * within the report query range (legacy parity: spanning events land in the
+ * first month the report contains, not the activity start month when earlier).
  */
 export function groupActivitiesByMonthSection(
   activities: ReportActivityRow[],
@@ -19,17 +33,17 @@ export function groupActivitiesByMonthSection(
   const buckets = new Map(
     monthSections.map((section) => [section.id, [] as ReportActivityRow[]])
   );
-  const rangeById = new Map(
-    monthSections.map((section) => [section.id, section.dateRange])
-  );
+  const queryRange = queryRangeFromMonthSections(monthSections);
+  if (queryRange == null) return buckets;
 
   for (const activity of activities) {
-    const dayKey = pacificDayKey(activity.startDate);
+    const dayKey = activityReportDisplayDayKey(
+      activity.startDate,
+      activity.endDate,
+      queryRange
+    );
     if (!dayKey) continue;
     const monthId = dayKey.slice(0, 7);
-    const range = rangeById.get(monthId);
-    if (!range) continue;
-    if (dayKey < range.start || dayKey > range.end) continue;
     buckets.get(monthId)?.push(activity);
   }
 

--- a/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.ts
+++ b/packages/shared/src/reports/thirty-sixty-ninety/groupActivitiesByMonthSection.ts
@@ -1,5 +1,5 @@
 import type { ReportActivityRow } from '../../api/types';
-import { activityReportDisplayDayKey } from '../../filters/activity-filter-date';
+import { activityReportDisplayMonthKey } from '../../filters/activity-filter-date';
 import { createCompareActivitiesForPrint } from '../print/react/rowViewModel';
 import type { CalendarMonthSection } from './buildCalendarMonthSections';
 
@@ -37,13 +37,12 @@ export function groupActivitiesByMonthSection(
   if (queryRange == null) return buckets;
 
   for (const activity of activities) {
-    const dayKey = activityReportDisplayDayKey(
+    const monthId = activityReportDisplayMonthKey(
       activity.startDate,
       activity.endDate,
       queryRange
     );
-    if (!dayKey) continue;
-    const monthId = dayKey.slice(0, 7);
+    if (!monthId) continue;
     buckets.get(monthId)?.push(activity);
   }
 

--- a/packages/shared/src/schemas/query-params.schema.spec.ts
+++ b/packages/shared/src/schemas/query-params.schema.spec.ts
@@ -97,13 +97,13 @@ describe('filterActivitiesQuerySchema', () => {
       pitchDateNotScheduled: 'true',
       pitchDateFrom: '2025-01-01',
       pitchDateTo: '2025-01-31',
-      scheduledBothDatesInRange: 'true',
+      scheduledDateRangeOverlaps: 'true',
     });
     expect(result.dateConfirmedFilter).toBe('confirmed');
     expect(result.timeConfirmedFilter).toBe('not_confirmed');
     expect(result.pitchDateNotScheduled).toBe(true);
     expect(result.pitchDateFrom).toBe('2025-01-01');
-    expect(result.scheduledBothDatesInRange).toBe(true);
+    expect(result.scheduledDateRangeOverlaps).toBe(true);
   });
 
   it('parses includeCompleted and includeDeleted', () => {

--- a/packages/shared/src/schemas/query-params.schema.ts
+++ b/packages/shared/src/schemas/query-params.schema.ts
@@ -61,10 +61,11 @@ export const filterActivitiesQuerySchema = z.object({
   endDateFrom: z.string().date().optional(),
   endDateTo: z.string().date().optional(),
   /**
-   * When true with startDateFrom/startDateTo, both activity start and end dates
-   * must fall within the scheduled window (matches activity list client filter).
+   * When true with startDateFrom/startDateTo, activity start and end must be
+   * non-empty and the scheduled span must overlap the window (matches activity
+   * list client filter).
    */
-  scheduledBothDatesInRange: z
+  scheduledDateRangeOverlaps: z
     .string()
     .optional()
     .transform((val): boolean | undefined =>


### PR DESCRIPTION
# PR: refactor/CORPCAL-253-intersetional-date-filter

## Summary

Replaces the old "containment" scheduled-date filtering behaviour (both start and end must fall inside the filter window) with span overlap matching. Activities now appear when their scheduled range intersects the filter window, which fixes multi-day and cross-month activities being dropped from Activity List, Look Ahead, and Reports.

This follows from **legacy date filter behaviour** and supports existing user expectation.

## Important

- `npm run build:packages` (shared filter/query-param changes)

## Changes

1. **Shared filter semantics:** switch scheduled date matching from containment to span overlap.
   - Rename `scheduledBothDatesInRange` to `scheduledDateRangeOverlaps`.
   - Replace `activityScheduledRangeMatches` with `activityDateSpanOverlapsRange` and `activityScheduledRangeOverlaps`.
   - Treat missing `endDate` as single-day unless the overlap flag requires both dates.
   - Normalize activity spans with `pacificDayKey` before comparisons.

2. **Report display bucketing:** place spanning activities by first overlapping day in the window.
   - Add `activityReportDisplayDayKey` and `activityReportDisplayMonthKey`.
   - Update print report day grouping and 30/60/90 month section grouping to use overlap-based keys.
   - Skip print bucketing when overlap cannot be resolved (no meta range).

3. **API / service wiring:** apply overlap flag wherever date windows are pinned.
   - Extract `buildScheduledWindowOverlapConditions` in activity find-all SQL builder.
   - Set `scheduledDateRangeOverlaps` in reports, look-ahead, and filter-state-to-query-params.
   - Add `applyScheduledDateWindowToFilters` helper in reports service.

4. **Schema and docs:** align query param and documentation with new semantics.
   - Update `query-params.schema` for `scheduledDateRangeOverlaps`.
   - Document overlap rules in `calendar-service/API.md`, `packages/shared/src/filters/README.md`, and `ACTIVITY_LIST_SEARCH.md`.

5. **Tests:** expand parity and regression coverage.
   - Add semantic tests comparing SQL overlap conditions to shared predicates.
   - Add specs for display day/month keys, print section collection, and month grouping.
   - Update existing filter, parity, and query-param tests for renamed flag and overlap behavior.

## Testing

- [x] `npm test -- activity-filter` in `packages/shared` (50 passed)
- [x] `npm test -- activity-find-all-filters` in `calendar-service` (49 passed)
- [x] Print/grouping specs in `packages/shared` (12 passed across 3 files)
- [ ] Manual: Activity List date filter includes activities whose span crosses the selected window
- [ ] Manual: Custom/print reports show spanning activities under the first overlapping day/month
- [ ] Manual: Look Ahead date window returns overlapping activities only
