### PR TITLE
Feat/corpcal 254 activity form polish

### DIFF
--- a/calendar-ui/docs/UI_CUSTOMIZE_LOG.md
+++ b/calendar-ui/docs/UI_CUSTOMIZE_LOG.md
@@ -101,12 +101,10 @@ Append-only notes for fork-level UI changes that diverge from stock Shadcn/Radix
 
 **Files:**
 
-| File                                                        | Change                                                                                                                                                                                                                                      |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [src/components/ui/form.tsx](../src/components/ui/form.tsx) | `useFormField` exposes `showError`: error is shown only when `isTouched`, `isDirty`, or `submitCount > 0`. `FormControl` and `FormMessage` use `showError` instead of raw `error` for `aria-invalid`, `aria-describedby`, and message text. |
+| File                                                        | Change                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [src/components/ui/form.tsx](../src/components/ui/form.tsx) | `useFormField` exposes `showError`: error is shown only when `isTouched`, `isDirty`, or `submitCount > 0`. `FormControl`, `FormMessage`, and `FormLabel` use `showError` instead of raw `error` for `aria-invalid`, `aria-describedby`, message text, and destructive label styling. |
 
-**Scope:** Applies to all forms using `FormControl` / `FormMessage` from this module (not opt-in via `FormDisplayOptionsProvider`).
-
-**Note:** `FormLabel` still uses raw `error` for destructive label styling; labels may turn red before the inline message appears.
+**Scope:** Applies to all forms using `FormControl` / `FormMessage` / `FormLabel` from this module (not opt-in via `FormDisplayOptionsProvider`).
 
 **Rationale:** Keeps validation running on change for submit gating without showing errors on untouched empty fields on first paint. Left in `useFormField` so message, control, and a11y attributes stay consistent in one place.

--- a/calendar-ui/docs/UI_CUSTOMIZE_LOG.md
+++ b/calendar-ui/docs/UI_CUSTOMIZE_LOG.md
@@ -90,3 +90,23 @@ Append-only notes for fork-level UI changes that diverge from stock Shadcn/Radix
 **Component:** [form.tsx](../src/components/ui/form.tsx) exports `RequiredFieldIndicator` (asterisk using `text-[var(--color-required-field-indicator)]`).
 
 **Activity sections using it:** [ActivityOverviewSection.tsx](../src/components/activity/ActivityFormSections/ActivityOverviewSection.tsx) (category, title, lead team, summary), [ActivityScheduleSection.tsx](../src/components/activity/ActivityFormSections/ActivityScheduleSection.tsx) (Date / Time row labels), [ActivityCommsSection.tsx](../src/components/activity/ActivityFormSections/ActivityCommsSection.tsx) (comms lead). Visibility intentionally has no required asterisk (API defaults `global`).
+
+---
+
+## Deferred inline field errors (activity / onChange forms)
+
+**Date:** 2026-06-10
+
+**Goal:** With `mode: 'onChange'` and programmatic `setValue(..., { shouldValidate: true })`, react-hook-form can hold validation errors on mount while the sticky submit bar still uses live Zod/RHF state. Inline `FormMessage` / `aria-invalid` should not appear until the user has interacted with a field or attempted submit.
+
+**Files:**
+
+| File                                                        | Change                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [src/components/ui/form.tsx](../src/components/ui/form.tsx) | `useFormField` exposes `showError`: error is shown only when `isTouched`, `isDirty`, or `submitCount > 0`. `FormControl` and `FormMessage` use `showError` instead of raw `error` for `aria-invalid`, `aria-describedby`, and message text. |
+
+**Scope:** Applies to all forms using `FormControl` / `FormMessage` from this module (not opt-in via `FormDisplayOptionsProvider`).
+
+**Note:** `FormLabel` still uses raw `error` for destructive label styling; labels may turn red before the inline message appears.
+
+**Rationale:** Keeps validation running on change for submit gating without showing errors on untouched empty fields on first paint. Left in `useFormField` so message, control, and a11y attributes stay consistent in one place.

--- a/calendar-ui/src/components/activity/ActivityFormMissingFieldsHint.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormMissingFieldsHint.tsx
@@ -1,0 +1,117 @@
+import { Info } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+const HOVER_CLOSE_DELAY_MS = 150;
+
+const infoTriggerClassName =
+  'text-stone-500 hover:text-stone-700 focus-visible:ring-ring/50 relative z-10 -ml-1.5 inline-flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent p-0 outline-none focus-visible:ring-[3px]';
+
+function usePrefersHover(): boolean {
+  const [value, setValue] = useState(() =>
+    typeof window !== 'undefined'
+      ? window.matchMedia('(hover: hover)').matches
+      : false
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(hover: hover)');
+    const onChange = () => setValue(mq.matches);
+    onChange();
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+  return value;
+}
+
+type ActivityFormMissingFieldsHintProps = {
+  helperText: string;
+  fields: readonly string[];
+  align?: 'start' | 'center' | 'end';
+};
+
+export function ActivityFormMissingFieldsHint({
+  helperText,
+  fields,
+  align = 'end',
+}: ActivityFormMissingFieldsHintProps) {
+  const [open, setOpen] = useState(false);
+  const prefersHover = usePrefersHover();
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelScheduledClose = () => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const handleHoverOpen = () => {
+    if (!prefersHover) return;
+    cancelScheduledClose();
+    setOpen(true);
+  };
+
+  const handleHoverScheduleClose = () => {
+    if (!prefersHover) return;
+    cancelScheduledClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      setOpen(false);
+      closeTimerRef.current = null;
+    }, HOVER_CLOSE_DELAY_MS);
+  };
+
+  useEffect(
+    () => () => {
+      cancelScheduledClose();
+    },
+    []
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <span
+        className="inline-flex max-w-full min-w-0 items-center gap-x-0 leading-normal"
+        onMouseEnter={handleHoverOpen}
+        onMouseLeave={handleHoverScheduleClose}
+      >
+        <span className="text-muted-foreground min-w-0 px-1 text-sm wrap-break-word">
+          {helperText}
+        </span>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={infoTriggerClassName}
+            aria-label={`${helperText}. Show required field details.`}
+            aria-expanded={open}
+            onMouseEnter={handleHoverOpen}
+            onMouseLeave={handleHoverScheduleClose}
+          >
+            <Info className="size-3.5 shrink-0" aria-hidden />
+          </button>
+        </PopoverTrigger>
+      </span>
+      <PopoverContent
+        className="w-80"
+        align={align}
+        onMouseEnter={handleHoverOpen}
+        onMouseLeave={handleHoverScheduleClose}
+      >
+        <div>
+          <h4 className="mb-4 text-sm font-medium">
+            Required fields remaining:
+          </h4>
+          <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
+            {fields.map((field) => (
+              <li key={field}>{field}</li>
+            ))}
+          </ul>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/calendar-ui/src/components/activity/ActivityFormMissingFieldsHint.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormMissingFieldsHint.tsx
@@ -1,5 +1,5 @@
 import { Info } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 
 import {
   Popover,
@@ -42,6 +42,11 @@ export function ActivityFormMissingFieldsHint({
   const [open, setOpen] = useState(false);
   const prefersHover = usePrefersHover();
   const closeTimerRef = useRef<number | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const preventMouseFocus = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
 
   const cancelScheduledClose = () => {
     if (closeTimerRef.current != null) {
@@ -61,6 +66,7 @@ export function ActivityFormMissingFieldsHint({
     cancelScheduledClose();
     closeTimerRef.current = window.setTimeout(() => {
       setOpen(false);
+      triggerRef.current?.blur();
       closeTimerRef.current = null;
     }, HOVER_CLOSE_DELAY_MS);
   };
@@ -84,10 +90,12 @@ export function ActivityFormMissingFieldsHint({
         </span>
         <PopoverTrigger asChild>
           <button
+            ref={triggerRef}
             type="button"
             className={infoTriggerClassName}
             aria-label={`${helperText}. Show required field details.`}
             aria-expanded={open}
+            onMouseDown={preventMouseFocus}
             onMouseEnter={handleHoverOpen}
             onMouseLeave={handleHoverScheduleClose}
           >
@@ -100,9 +108,10 @@ export function ActivityFormMissingFieldsHint({
         align={align}
         onMouseEnter={handleHoverOpen}
         onMouseLeave={handleHoverScheduleClose}
+        onCloseAutoFocus={(event) => event.preventDefault()}
       >
         <div>
-          <h4 className="mb-4 text-sm font-medium">
+          <h4 className="mb-3 text-sm font-medium">
             Required fields remaining:
           </h4>
           <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -1,9 +1,9 @@
-import { Flag, History, Star } from 'lucide-react';
+import { History, Star } from 'lucide-react';
 import { useState, type ReactElement } from 'react';
 
 import type { ActivityFlagResponse } from '@corpcal/shared/api/types';
+import { ActivityFlagIcon } from '@/components/activity/activities/ActivityFlagIcon';
 import { AssignActivityModal } from '@/components/activity/activities/AssignActivityModal';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge, getActivityStatusBadgeVariant } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { CopyableText } from '@/components/ui/copyable-text';
@@ -85,6 +85,7 @@ export function ActivityPageHeader({
   const currentFlag = hasSingleFlag ? sortedFlags[0] : null;
 
   const iconButtonClassName = 'shrink-0 shadow-none';
+  const headerActionIconClassName = 'text-muted-foreground size-4';
   const timestampClassName = 'text-muted-foreground text-xs sm:text-sm';
   const showActionButtons =
     canFlag || isFlagged || onFavouriteToggle || onHistoryClick;
@@ -168,36 +169,12 @@ export function ActivityPageHeader({
               }
               onClick={() => setAssignModalOpen(true)}
               disabled={isFlagPending}
-              className={`relative ${iconButtonClassName}`}
+              className={iconButtonClassName}
             >
-              {isFlagged && currentFlag ? (
-                <>
-                  <Avatar size="sm" className="size-full">
-                    <AvatarFallback className="text-[10px] font-medium">
-                      {currentFlag.assigneeName
-                        .split(' ')
-                        .slice(0, 2)
-                        .map((n) => n[0])
-                        .join('')
-                        .toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <Flag
-                    className="absolute -right-0.5 -bottom-0.5 size-2.5"
-                    style={{
-                      fill:
-                        currentFlag.assigneeFlagColour ??
-                        'var(--flag-button-icon)',
-                      color:
-                        currentFlag.assigneeFlagColour ??
-                        'var(--flag-button-icon)',
-                    }}
-                    aria-hidden
-                  />
-                </>
-              ) : (
-                <Flag className="h-4 w-4" />
-              )}
+              <ActivityFlagIcon
+                assigneeName={isFlagged ? currentFlag?.assigneeName : null}
+                assigneeFlagColour={currentFlag?.assigneeFlagColour}
+              />
             </Button>
           )}
           {!canFlag && isFlagged && currentFlag && onFlagUnassign && (
@@ -211,27 +188,11 @@ export function ActivityPageHeader({
                 onFlagUnassign(currentFlag.teamId, currentFlag.assigneeName)
               }
               disabled={isFlagPending}
-              className={`relative ${iconButtonClassName}`}
+              className={iconButtonClassName}
             >
-              <Avatar size="sm" className="size-full">
-                <AvatarFallback className="text-[10px] font-medium">
-                  {currentFlag.assigneeName
-                    .split(' ')
-                    .slice(0, 2)
-                    .map((n) => n[0])
-                    .join('')
-                    .toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-              <Flag
-                className="absolute -right-0.5 -bottom-0.5 size-2.5"
-                style={{
-                  fill:
-                    currentFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
-                  color:
-                    currentFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
-                }}
-                aria-hidden
+              <ActivityFlagIcon
+                assigneeName={currentFlag.assigneeName}
+                assigneeFlagColour={currentFlag.assigneeFlagColour}
               />
             </Button>
           )}
@@ -246,7 +207,7 @@ export function ActivityPageHeader({
               className={iconButtonClassName}
             >
               <Star
-                className="h-4 w-4"
+                className={headerActionIconClassName}
                 fill={isFavourite ? 'currentColor' : 'none'}
               />
             </Button>
@@ -260,7 +221,7 @@ export function ActivityPageHeader({
               onClick={onHistoryClick}
               className={iconButtonClassName}
             >
-              <History className="h-4 w-4" />
+              <History className={headerActionIconClassName} />
             </Button>
           )}
         </div>

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -20,7 +20,7 @@ type ActivityPageHeaderProps = {
   displayId: string;
   title: string;
   categories: string[];
-  leadOrg?: string | null;
+  leadMinistry?: string | null;
   activityStatus?: unknown;
   lastUpdatedDateTime?: string | null;
   createdDateTime?: string | null;
@@ -49,7 +49,7 @@ export function ActivityPageHeader({
   displayId,
   title,
   categories,
-  leadOrg,
+  leadMinistry,
   activityStatus,
   lastUpdatedDateTime,
   createdDateTime,
@@ -84,38 +84,59 @@ export function ActivityPageHeader({
   const hasSingleFlag = sortedFlags.length === 1;
   const currentFlag = hasSingleFlag ? sortedFlags[0] : null;
 
+  const iconButtonClassName = 'shrink-0 shadow-none';
+  const timestampClassName = 'text-muted-foreground text-xs sm:text-sm';
+  const showActionButtons =
+    canFlag || isFlagged || onFavouriteToggle || onHistoryClick;
+
   return (
-    <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-      <div className="min-w-0 flex-1">
+    <div className="mb-6 grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2 sm:gap-x-12 sm:gap-y-1">
+      <div className="col-start-1 row-start-1 w-fit justify-self-start">
         <CopyableText
           text={displayId}
           copyLabel="Copy display ID"
-          className="text-md text-muted-foreground hover:text-foreground mb-1.5 -ml-2 px-2 py-1"
+          className="text-md text-muted-foreground hover:text-foreground -ml-2 px-2 py-1"
         >
           {displayId}
         </CopyableText>
+      </div>
+
+      {statusDisplay !== '' ? (
+        <div className="col-start-2 row-start-1 self-start justify-self-end">
+          <Badge
+            size="md"
+            variant={getActivityStatusBadgeVariant(statusDisplay)}
+          >
+            {statusDisplay}
+          </Badge>
+        </div>
+      ) : null}
+
+      <div className="col-span-2 row-start-2 min-w-0 sm:col-span-1 sm:col-start-1">
         <h1 className="text-lg font-bold">{title}</h1>
         {categories.length > 0 && (
           <div className="mt-2 flex flex-wrap gap-2">
             {categories.map((cat, idx) => (
-              <Badge key={idx} variant="default" className="bg-primary">
+              <Badge
+                key={idx}
+                variant="default"
+                className="bg-primary hover:bg-primary"
+              >
                 {cat}
               </Badge>
             ))}
           </div>
         )}
-        {leadOrg && (
-          <div className="text-muted-foreground mt-3 text-sm">{leadOrg}</div>
-        )}
       </div>
 
-      <div className="flex shrink-0 flex-col items-end gap-2 text-right">
-        {statusDisplay !== '' ? (
-          <Badge variant={getActivityStatusBadgeVariant(statusDisplay)}>
-            {statusDisplay}
-          </Badge>
+      <div className="col-span-2 row-start-3 self-end sm:col-span-1 sm:col-start-1">
+        {leadMinistry ? (
+          <div className="text-muted-foreground text-sm">{leadMinistry}</div>
         ) : null}
-        <div className="text-muted-foreground text-xs sm:text-sm">
+      </div>
+
+      <div className="col-start-1 row-start-4 self-center sm:col-start-2 sm:row-start-2 sm:self-auto sm:text-right">
+        <div className={timestampClassName}>
           {updatedLabel ? <div>Updated {updatedLabel}</div> : null}
           <div>
             Created{' '}
@@ -126,127 +147,124 @@ export function ActivityPageHeader({
               : ''}
           </div>
         </div>
-        {(canFlag || isFlagged || onFavouriteToggle || onHistoryClick) && (
-          <div className="flex items-center gap-2">
-            {canFlag && onFlagAssign && onFlagUnassign && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                title={
-                  isFlagged
-                    ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
-                    : 'Assign activity'
-                }
-                aria-label={
-                  isFlagged
-                    ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
-                    : 'Assign activity'
-                }
-                onClick={() => setAssignModalOpen(true)}
-                disabled={isFlagPending}
-                className="relative shrink-0"
-              >
-                {isFlagged && currentFlag ? (
-                  <>
-                    <Avatar size="sm" className="size-full">
-                      <AvatarFallback className="text-[10px] font-medium">
-                        {currentFlag.assigneeName
-                          .split(' ')
-                          .slice(0, 2)
-                          .map((n) => n[0])
-                          .join('')
-                          .toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <Flag
-                      className="absolute -right-0.5 -bottom-0.5 size-2.5"
-                      style={{
-                        fill:
-                          currentFlag.assigneeFlagColour ??
-                          'var(--flag-button-icon)',
-                        color:
-                          currentFlag.assigneeFlagColour ??
-                          'var(--flag-button-icon)',
-                      }}
-                      aria-hidden
-                    />
-                  </>
-                ) : (
-                  <Flag className="h-4 w-4" />
-                )}
-              </Button>
-            )}
-            {!canFlag && isFlagged && currentFlag && onFlagUnassign && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                title={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
-                aria-label={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
-                onClick={() =>
-                  onFlagUnassign(currentFlag.teamId, currentFlag.assigneeName)
-                }
-                disabled={isFlagPending}
-                className="relative shrink-0"
-              >
-                <Avatar size="sm" className="size-full">
-                  <AvatarFallback className="text-[10px] font-medium">
-                    {currentFlag.assigneeName
-                      .split(' ')
-                      .slice(0, 2)
-                      .map((n) => n[0])
-                      .join('')
-                      .toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <Flag
-                  className="absolute -right-0.5 -bottom-0.5 size-2.5"
-                  style={{
-                    fill:
-                      currentFlag.assigneeFlagColour ??
-                      'var(--flag-button-icon)',
-                    color:
-                      currentFlag.assigneeFlagColour ??
-                      'var(--flag-button-icon)',
-                  }}
-                  aria-hidden
-                />
-              </Button>
-            )}
-            {onFavouriteToggle && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                title={
-                  isFavourite ? 'Remove from watchlist' : 'Add to watchlist'
-                }
-                onClick={onFavouriteToggle}
-                disabled={isFavouriteToggling}
-                className="shrink-0"
-              >
-                <Star
-                  className="h-4 w-4"
-                  fill={isFavourite ? 'currentColor' : 'none'}
-                />
-              </Button>
-            )}
-            {onHistoryClick && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                title="View history"
-                onClick={onHistoryClick}
-                className="shrink-0"
-              >
-                <History className="h-4 w-4" />
-              </Button>
-            )}
-          </div>
-        )}
       </div>
+
+      {showActionButtons && (
+        <div className="col-start-2 row-start-4 flex items-center gap-2 self-center sm:col-start-2 sm:row-start-3 sm:mt-auto sm:self-end sm:justify-self-end">
+          {canFlag && onFlagAssign && onFlagUnassign && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              title={
+                isFlagged
+                  ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
+                  : 'Assign activity'
+              }
+              aria-label={
+                isFlagged
+                  ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
+                  : 'Assign activity'
+              }
+              onClick={() => setAssignModalOpen(true)}
+              disabled={isFlagPending}
+              className={`relative ${iconButtonClassName}`}
+            >
+              {isFlagged && currentFlag ? (
+                <>
+                  <Avatar size="sm" className="size-full">
+                    <AvatarFallback className="text-[10px] font-medium">
+                      {currentFlag.assigneeName
+                        .split(' ')
+                        .slice(0, 2)
+                        .map((n) => n[0])
+                        .join('')
+                        .toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <Flag
+                    className="absolute -right-0.5 -bottom-0.5 size-2.5"
+                    style={{
+                      fill:
+                        currentFlag.assigneeFlagColour ??
+                        'var(--flag-button-icon)',
+                      color:
+                        currentFlag.assigneeFlagColour ??
+                        'var(--flag-button-icon)',
+                    }}
+                    aria-hidden
+                  />
+                </>
+              ) : (
+                <Flag className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+          {!canFlag && isFlagged && currentFlag && onFlagUnassign && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              title={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
+              aria-label={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
+              onClick={() =>
+                onFlagUnassign(currentFlag.teamId, currentFlag.assigneeName)
+              }
+              disabled={isFlagPending}
+              className={`relative ${iconButtonClassName}`}
+            >
+              <Avatar size="sm" className="size-full">
+                <AvatarFallback className="text-[10px] font-medium">
+                  {currentFlag.assigneeName
+                    .split(' ')
+                    .slice(0, 2)
+                    .map((n) => n[0])
+                    .join('')
+                    .toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <Flag
+                className="absolute -right-0.5 -bottom-0.5 size-2.5"
+                style={{
+                  fill:
+                    currentFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
+                  color:
+                    currentFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
+                }}
+                aria-hidden
+              />
+            </Button>
+          )}
+          {onFavouriteToggle && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              title={isFavourite ? 'Remove from watchlist' : 'Add to watchlist'}
+              onClick={onFavouriteToggle}
+              disabled={isFavouriteToggling}
+              className={iconButtonClassName}
+            >
+              <Star
+                className="h-4 w-4"
+                fill={isFavourite ? 'currentColor' : 'none'}
+              />
+            </Button>
+          )}
+          {onHistoryClick && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              title="View history"
+              onClick={onHistoryClick}
+              className={iconButtonClassName}
+            >
+              <History className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      )}
 
       {canFlag && onFlagAssign && onFlagUnassign && (
         <AssignActivityModal

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -116,7 +116,7 @@ export function ActivityPageHeader({
       <div className="col-span-2 row-start-2 min-w-0 sm:col-span-1 sm:col-start-1">
         <h1 className="text-lg font-bold">{title}</h1>
         {categories.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-2">
+          <div className="mt-2 flex flex-wrap gap-1.5">
             {categories.map((cat, idx) => (
               <Badge
                 key={idx}

--- a/calendar-ui/src/components/activity/activities/ActivityFlagIcon.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagIcon.tsx
@@ -1,0 +1,59 @@
+import { Flag } from 'lucide-react';
+import type { ReactElement } from 'react';
+
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+type ActivityFlagIconProps = {
+  assigneeName?: string | null;
+  assigneeFlagColour?: string | null;
+  className?: string;
+};
+
+function getAssigneeInitials(assigneeName: string): string {
+  return assigneeName
+    .split(' ')
+    .slice(0, 2)
+    .map((namePart) => namePart[0])
+    .join('')
+    .toUpperCase();
+}
+
+const iconContainerClassName =
+  'relative inline-flex size-6 shrink-0 items-center justify-center';
+
+/**
+ * Shared activity flag affordance used in the activity list and activity page header.
+ * Icon content is always laid out in a 24px positioning box so the badge anchor
+ * stays consistent regardless of the outer button size.
+ */
+export function ActivityFlagIcon({
+  assigneeName,
+  assigneeFlagColour,
+  className,
+}: ActivityFlagIconProps): ReactElement {
+  if (!assigneeName) {
+    return (
+      <span className={cn(iconContainerClassName, className)}>
+        <Flag className="text-muted-foreground size-4" aria-hidden />
+      </span>
+    );
+  }
+
+  const flagColour = assigneeFlagColour ?? 'var(--flag-button-icon)';
+
+  return (
+    <span className={cn(iconContainerClassName, className)}>
+      <Avatar size="sm" className="size-full">
+        <AvatarFallback className="text-[8px] font-medium">
+          {getAssigneeInitials(assigneeName)}
+        </AvatarFallback>
+      </Avatar>
+      <Flag
+        className="absolute -right-0.5 -bottom-0.5 size-2.5"
+        style={{ fill: flagColour, color: flagColour }}
+        aria-hidden
+      />
+    </span>
+  );
+}

--- a/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
@@ -7,13 +7,12 @@
  *
  * Same flag semantics as AssignActivityModal but inline, no note field.
  */
-import { Flag } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ActivityFlagResponse } from '@corpcal/shared/api/types';
 import { fetchTeamById } from '@/api/teamsApi';
+import { ActivityFlagIcon } from '@/components/activity/activities/ActivityFlagIcon';
 import { FilterSearchableList } from '@/components/activity/ActivityTable/FilterSearchableList';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -23,7 +22,6 @@ import {
 } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { useAuth } from '@/hooks/useAuth';
-import { cn } from '@/lib/utils';
 
 interface TeamMemberOption {
   userId: number;
@@ -132,27 +130,12 @@ export function ActivityFlagPopover({
     if (!isFlagged || !existingFlag) return null;
     return (
       <span
-        className="relative inline-flex size-6 shrink-0 items-center justify-center"
         title={`Assigned to ${existingFlag.assigneeName}`}
         aria-label={`Assigned to ${existingFlag.assigneeName}`}
       >
-        <Avatar size="sm" className="size-full">
-          <AvatarFallback className="text-[8px] font-medium">
-            {existingFlag.assigneeName
-              .split(' ')
-              .slice(0, 2)
-              .map((n) => n[0])
-              .join('')
-              .toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-        <Flag
-          className="absolute -right-0.5 -bottom-0.5 size-2.5"
-          style={{
-            fill: existingFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
-            color: existingFlag.assigneeFlagColour ?? 'var(--flag-button-icon)',
-          }}
-          aria-hidden
+        <ActivityFlagIcon
+          assigneeName={existingFlag.assigneeName}
+          assigneeFlagColour={existingFlag.assigneeFlagColour}
         />
       </span>
     );
@@ -176,36 +159,12 @@ export function ActivityFlagPopover({
           disabled={isPending || !primaryTeamId}
           data-no-row-nav
           onClick={(e) => e.stopPropagation()}
-          className="relative size-6 shrink-0"
+          className="size-6 shrink-0"
         >
-          {isFlagged ? (
-            <>
-              <Avatar size="sm" className="size-full">
-                <AvatarFallback className="text-[8px] font-medium">
-                  {existingFlag.assigneeName
-                    .split(' ')
-                    .slice(0, 2)
-                    .map((n) => n[0])
-                    .join('')
-                    .toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-              <Flag
-                className="absolute -right-0.5 -bottom-0.5 size-2.5"
-                style={{
-                  fill:
-                    existingFlag.assigneeFlagColour ??
-                    'var(--flag-button-icon)',
-                  color:
-                    existingFlag.assigneeFlagColour ??
-                    'var(--flag-button-icon)',
-                }}
-                aria-hidden
-              />
-            </>
-          ) : (
-            <Flag className={cn('text-muted-foreground size-4')} aria-hidden />
-          )}
+          <ActivityFlagIcon
+            assigneeName={isFlagged ? existingFlag.assigneeName : null}
+            assigneeFlagColour={existingFlag?.assigneeFlagColour}
+          />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/calendar-ui/src/components/activity/index.ts
+++ b/calendar-ui/src/components/activity/index.ts
@@ -1,4 +1,5 @@
 export { ActivityFormBody } from './ActivityFormBody';
+export { ActivityFormMissingFieldsHint } from './ActivityFormMissingFieldsHint';
 export { ActivityFormStickyHeader } from './ActivityFormStickyHeader';
 export type { ActivityLeadTeamFieldConfig } from './activity-lead-team-field-config';
 export { defaultActivityLeadTeamFieldConfig } from './activity-lead-team-field-config';

--- a/calendar-ui/src/components/reports/__tests__/ReportFiltersBar.test.tsx
+++ b/calendar-ui/src/components/reports/__tests__/ReportFiltersBar.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/lib/analytics', () => ({
 // Mock useAuth to avoid needing AuthProvider
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({
-    user: { roleName: 'user' },
+    user: { roleName: 'user', permissions: [] },
     isLoading: false,
     isAuthenticated: true,
     pendingLoginModal: false,
@@ -31,6 +31,19 @@ vi.mock('@/hooks/useAuth', () => ({
     hasAnyPermission: () => false,
     hasAllPermissions: () => false,
   }),
+}));
+
+vi.mock('@/hooks/useLookups', () => ({
+  useActivityStatuses: () => ({ data: [] }),
+  useCategories: () => ({ data: [] }),
+  useEventPlanners: () => ({ data: [] }),
+  useMinistries: () => ({ data: [] }),
+  useOrganizations: () => ({ data: [] }),
+  usePitchRequiredStatuses: () => ({ data: [] }),
+  useTags: () => ({ data: [] }),
+  useTranslationLanguages: () => ({ data: [] }),
+  useTranslationRequiredStatuses: () => ({ data: [] }),
+  useUsers: () => ({ data: [] }),
 }));
 
 describe('ReportFiltersBar analytics', () => {
@@ -67,9 +80,13 @@ describe('ReportFiltersBar analytics', () => {
     const input = getByLabelText('Search activities');
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
 
-    expect(mockTrackCalendarAction).toHaveBeenCalled();
-    const [[payload]] = mockTrackCalendarAction.mock.calls;
-    expect(payload.action).toBe('Search');
+    expect(mockTrackCalendarAction).toHaveBeenCalledWith({
+      action: 'Search',
+      filters: expect.objectContaining({
+        search_present: true,
+        search_length_bucket: '<20',
+      }),
+    });
   });
 
   it('sends calendar_click on clear search click and clears search', () => {

--- a/calendar-ui/src/components/ui/badge.tsx
+++ b/calendar-ui/src/components/ui/badge.tsx
@@ -6,9 +6,14 @@ import { normalizeActivityStatusLabel } from '@corpcal/shared';
 import { cn } from '../../lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
+      size: {
+        default: 'px-2.5 py-0.5 text-xs',
+        md: 'px-3 py-1 text-sm',
+        lg: 'px-4 py-1.5 text-base',
+      },
       variant: {
         default:
           'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
@@ -44,6 +49,7 @@ const badgeVariants = cva(
       },
     },
     defaultVariants: {
+      size: 'default',
       variant: 'default',
     },
   }
@@ -97,9 +103,12 @@ export function getActivityStatusBadgeVariant(
 export interface BadgeProps
   extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
+function Badge({ className, variant, size, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <div
+      className={cn(badgeVariants({ variant, size }), className)}
+      {...props}
+    />
   );
 }
 

--- a/calendar-ui/src/components/ui/form.tsx
+++ b/calendar-ui/src/components/ui/form.tsx
@@ -107,6 +107,10 @@ const useFormField = () => {
 
   const fieldState = getFieldState(fieldContext.name, formState);
   const { id, ariaRequired } = itemContext;
+  const showError = Boolean(
+    fieldState.error &&
+    (fieldState.isTouched || fieldState.isDirty || formState.submitCount > 0)
+  );
 
   return {
     id,
@@ -116,6 +120,7 @@ const useFormField = () => {
     formMessageId: `${id}-form-item-message`,
     ariaRequired,
     ...fieldState,
+    showError,
   };
 };
 
@@ -284,19 +289,24 @@ const FormControl = forwardRef<
   ElementRef<typeof Slot>,
   ComponentPropsWithoutRef<typeof Slot>
 >(({ ...props }, ref) => {
-  const { error, formItemId, formDescriptionId, formMessageId, ariaRequired } =
-    useFormField();
+  const {
+    showError,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+    ariaRequired,
+  } = useFormField();
 
   return (
     <Slot
       ref={ref}
       id={formItemId}
       aria-describedby={
-        !error
+        !showError
           ? `${formDescriptionId}`
           : `${formDescriptionId} ${formMessageId}`
       }
-      aria-invalid={!!error}
+      aria-invalid={showError}
       {...props}
       aria-required={ariaRequired ? true : undefined}
     />
@@ -325,8 +335,8 @@ const FormMessage = forwardRef<
   HTMLParagraphElement,
   HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
-  const { error, formMessageId } = useFormField();
-  const body = error ? String(error?.message) : children;
+  const { error, showError, formMessageId } = useFormField();
+  const body = showError && error ? String(error?.message) : children;
 
   if (!body) {
     return null;

--- a/calendar-ui/src/components/ui/form.tsx
+++ b/calendar-ui/src/components/ui/form.tsx
@@ -183,7 +183,7 @@ const FormLabel = forwardRef<
     },
     ref
   ) => {
-    const { error, formItemId, isDirty, name } = useFormField();
+    const { showError, formItemId, isDirty, name } = useFormField();
     const { setAriaRequired } = useContext(FormItemContext)!;
     const { showChangedBadges, reviewerChangedPaths } = useFormDisplayOptions();
 
@@ -199,7 +199,7 @@ const FormLabel = forwardRef<
       <Label
         ref={ref}
         className={cn(
-          error && 'text-destructive',
+          showError && 'text-destructive',
           className,
           'flex items-center gap-2',
           showChangedBadges && showDirtyIndicator && 'min-h-[18px]'

--- a/calendar-ui/src/hooks/useActivityEditActions.ts
+++ b/calendar-ui/src/hooks/useActivityEditActions.ts
@@ -11,11 +11,11 @@ export type ActivityEditActionFlags = {
   canSubmitUpdate: boolean;
   /** Show Review for users with activities.review who may edit this activity. */
   showReviewAction: boolean;
-  /** Review button is clickable (not submitting, not blocked by another user's lock). */
+  /** Review button is clickable when not submitting and, if saving first, validation passes. */
   reviewActionEnabled: boolean;
   /** Show Complete / Save and complete for users with activities.complete when eligible. */
   showCompleteAction: boolean;
-  /** Complete button is clickable. */
+  /** Complete button is clickable when not submitting and, if saving first, validation passes. */
   completeActionEnabled: boolean;
 };
 
@@ -60,7 +60,10 @@ export function useActivityEditActions({
   const showReviewAction =
     canReviewActivities && mayEditFormFields && !isLockedByOther;
 
-  const reviewActionEnabled = showReviewAction && !isSubmitting;
+  const reviewActionEnabled =
+    showReviewAction &&
+    !isSubmitting &&
+    (!isDirty || canSubmitWithoutValidationErrors);
 
   const showCompleteAction =
     canCompleteActivities &&
@@ -68,7 +71,10 @@ export function useActivityEditActions({
     mayEditFormFields &&
     !isLockedByOther;
 
-  const completeActionEnabled = showCompleteAction && !isSubmitting;
+  const completeActionEnabled =
+    showCompleteAction &&
+    !isSubmitting &&
+    (!isDirty || canSubmitWithoutValidationErrors);
 
   return {
     isLockedByOther,

--- a/calendar-ui/src/hooks/useActivityFormSetup.ts
+++ b/calendar-ui/src/hooks/useActivityFormSetup.ts
@@ -188,21 +188,6 @@ export function useActivityFormSetup({
     }
   }, [mode, leadTeamOptions, userTeamIds, lookups.organizations, form]);
 
-  // Seed full-form validation after create defaults hydrate so Submit gating is accurate on first paint.
-  useEffect(() => {
-    if (mode !== 'create') return;
-    if (lookups.isLoading) return;
-    void form.trigger();
-  }, [
-    mode,
-    lookups.isLoading,
-    lookups.dateStatuses,
-    lookups.timeStatuses,
-    leadTeamOptions,
-    lookups.organizations,
-    form,
-  ]);
-
   return {
     form,
     lookups,

--- a/calendar-ui/src/hooks/useActivityFormSetup.ts
+++ b/calendar-ui/src/hooks/useActivityFormSetup.ts
@@ -188,6 +188,21 @@ export function useActivityFormSetup({
     }
   }, [mode, leadTeamOptions, userTeamIds, lookups.organizations, form]);
 
+  // Seed full-form validation after create defaults hydrate so Submit gating is accurate on first paint.
+  useEffect(() => {
+    if (mode !== 'create') return;
+    if (lookups.isLoading) return;
+    void form.trigger();
+  }, [
+    mode,
+    lookups.isLoading,
+    lookups.dateStatuses,
+    lookups.timeStatuses,
+    leadTeamOptions,
+    lookups.organizations,
+    form,
+  ]);
+
   return {
     form,
     lookups,

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
@@ -1,0 +1,70 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { act, renderHook } from '@testing-library/react';
+import { useForm, type Resolver } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { getDefaultFormValues } from '../lib/activity-form-defaults';
+import { useActivityFormSubmitState } from './useActivityFormSubmitState';
+
+const testSchema = z.object({
+  title: z.string().min(1),
+  categoryIds: z.array(z.number()).min(1),
+});
+
+type TestFormData = z.infer<typeof testSchema>;
+
+function useTestActivityFormSubmitState() {
+  const form = useForm<TestFormData>({
+    resolver: zodResolver(testSchema) as Resolver<TestFormData>,
+    mode: 'onChange',
+    defaultValues: {
+      title: getDefaultFormValues().title ?? '',
+      categoryIds: getDefaultFormValues().categoryIds ?? [],
+    },
+  });
+
+  const submitState = useActivityFormSubmitState(form, {
+    getFieldLabel: (field) => field,
+    schema: testSchema,
+  });
+
+  return { form, submitState };
+}
+
+describe('useActivityFormSubmitState', () => {
+  it('updates missing fields as values are filled', () => {
+    const { result } = renderHook(() => useTestActivityFormSubmitState());
+
+    expect(result.current.submitState.missingFields).toContain('title');
+    expect(result.current.submitState.missingFields).toContain('categoryIds');
+    expect(result.current.submitState.missingFieldsHelperText).toBe(
+      '2 required fields missing'
+    );
+
+    act(() => {
+      result.current.form.setValue('title', 'Quarterly planning session', {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    });
+
+    expect(result.current.submitState.missingFields).not.toContain('title');
+    expect(result.current.submitState.missingFields).toEqual(['categoryIds']);
+    expect(result.current.submitState.missingFieldsHelperText).toBe(
+      '1 required field missing'
+    );
+    expect(result.current.submitState.isFormValid).toBe(false);
+
+    act(() => {
+      result.current.form.setValue('categoryIds', [1], {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    });
+
+    expect(result.current.submitState.missingFields).toEqual([]);
+    expect(result.current.submitState.missingFieldsHelperText).toBeNull();
+    expect(result.current.submitState.isFormValid).toBe(true);
+  });
+});

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
@@ -48,7 +48,7 @@ describe('useActivityFormSubmitState', () => {
     expect(result.current.submitState.missingFields).toContain('title');
     expect(result.current.submitState.missingFields).toContain('categoryIds');
     expect(result.current.submitState.missingFieldsHelperText).toBe(
-      '2 required fields missing'
+      '2 more required fields'
     );
 
     act(() => {
@@ -61,7 +61,7 @@ describe('useActivityFormSubmitState', () => {
     expect(result.current.submitState.missingFields).not.toContain('title');
     expect(result.current.submitState.missingFields).toEqual(['categoryIds']);
     expect(result.current.submitState.missingFieldsHelperText).toBe(
-      '1 required field missing'
+      '1 more required field'
     );
     expect(result.current.submitState.isFormValid).toBe(false);
 
@@ -120,7 +120,7 @@ describe('useActivityFormSubmitState', () => {
     expect(result.current.submitState.isFormValid).toBe(false);
     expect(result.current.submitState.missingFields).toContain('commsContacts');
     expect(result.current.submitState.missingFieldsHelperText).toBe(
-      '1 required field missing'
+      '1 more required field'
     );
   });
 
@@ -128,7 +128,7 @@ describe('useActivityFormSubmitState', () => {
     const { result } = renderHook(() => useTestActivityFormSubmitState());
 
     expect(result.current.submitState.missingFieldsHelperText).toBe(
-      '2 required fields missing'
+      '2 more required fields'
     );
 
     act(() => {
@@ -139,7 +139,7 @@ describe('useActivityFormSubmitState', () => {
 
     expect(result.current.submitState.missingFields).toEqual(['categoryIds']);
     expect(result.current.submitState.missingFieldsHelperText).toBe(
-      '1 required field missing'
+      '1 more required field'
     );
   });
 });

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx
@@ -4,7 +4,16 @@ import { useForm, type Resolver } from 'react-hook-form';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
+import {
+  createActivityRequestSchema,
+  type ActivityFormData,
+} from '@corpcal/shared/schemas';
+
 import { getDefaultFormValues } from '../lib/activity-form-defaults';
+import {
+  ACTIVITY_FIELD_SET_OPTS,
+  setActivityFormFieldValue,
+} from '../lib/activity-form-set-field';
 import { useActivityFormSubmitState } from './useActivityFormSubmitState';
 
 const testSchema = z.object({
@@ -16,7 +25,7 @@ type TestFormData = z.infer<typeof testSchema>;
 
 function useTestActivityFormSubmitState() {
   const form = useForm<TestFormData>({
-    resolver: zodResolver(testSchema) as Resolver<TestFormData>,
+    resolver: zodResolver(testSchema as never) as Resolver<TestFormData>,
     mode: 'onChange',
     defaultValues: {
       title: getDefaultFormValues().title ?? '',
@@ -66,5 +75,71 @@ describe('useActivityFormSubmitState', () => {
     expect(result.current.submitState.missingFields).toEqual([]);
     expect(result.current.submitState.missingFieldsHelperText).toBeNull();
     expect(result.current.submitState.isFormValid).toBe(true);
+  });
+
+  it('updates missing fields when commsContacts is cleared', () => {
+    const validSummary =
+      '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Summary text"}]}]}';
+
+    const { result } = renderHook(() => {
+      const form = useForm<ActivityFormData>({
+        resolver: zodResolver(
+          createActivityRequestSchema as never
+        ) as Resolver<ActivityFormData>,
+        mode: 'onChange',
+        defaultValues: {
+          ...getDefaultFormValues(),
+          title: 'Quarterly planning session',
+          summary: validSummary,
+          leadTeamId: 1,
+          leadMinistryId: 1,
+          categoryIds: [1],
+          dateStatusId: 1,
+          timeStatusId: 1,
+          commsContacts: [{ userId: 1, isLead: true }],
+        } as ActivityFormData,
+      });
+
+      const submitState = useActivityFormSubmitState(form, {
+        getFieldLabel: (field) => field,
+        schema: createActivityRequestSchema,
+      });
+
+      return { form, submitState };
+    });
+
+    expect(result.current.submitState.isFormValid).toBe(true);
+    expect(result.current.submitState.missingFields).not.toContain(
+      'commsContacts'
+    );
+
+    act(() => {
+      setActivityFormFieldValue(result.current.form, 'commsContacts', []);
+    });
+
+    expect(result.current.submitState.isFormValid).toBe(false);
+    expect(result.current.submitState.missingFields).toContain('commsContacts');
+    expect(result.current.submitState.missingFieldsHelperText).toBe(
+      '1 required field missing'
+    );
+  });
+
+  it('updates missing fields when setValue runs without validation', () => {
+    const { result } = renderHook(() => useTestActivityFormSubmitState());
+
+    expect(result.current.submitState.missingFieldsHelperText).toBe(
+      '2 required fields missing'
+    );
+
+    act(() => {
+      result.current.form.setValue('title', 'Quarterly planning session', {
+        ...ACTIVITY_FIELD_SET_OPTS,
+      });
+    });
+
+    expect(result.current.submitState.missingFields).toEqual(['categoryIds']);
+    expect(result.current.submitState.missingFieldsHelperText).toBe(
+      '1 required field missing'
+    );
   });
 });

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.ts
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.ts
@@ -53,6 +53,7 @@ export function useActivityFormSubmitState<TFieldValues extends FieldValues>(
   const values = form.getValues();
   const { isValid, errors } = useFormState({
     control: form.control,
+    disabled: Boolean(options?.schema),
   });
 
   if (options?.schema) {

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.ts
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.ts
@@ -1,0 +1,78 @@
+import {
+  useFormState,
+  useWatch,
+  type FieldValues,
+  type FormState,
+  type UseFormReturn,
+} from 'react-hook-form';
+import type { ZodType } from 'zod';
+
+import {
+  formatMissingRequiredFieldsCountMessage,
+  getMissingRequiredFields,
+  getMissingRequiredFieldsFromZodError,
+} from '../lib/form-utils';
+
+type UseActivityFormSubmitStateOptions<TFieldValues extends FieldValues> = {
+  getFieldLabel?: (fieldName: string) => string;
+  /**
+   * When provided, validity and missing-field UI derive from live safeParse of
+   * watched values so the sticky bar updates as the user edits (not only after
+   * RHF async validation settles).
+   */
+  schema?: ZodType<TFieldValues>;
+};
+
+export type ActivityFormSubmitState = {
+  isFormValid: boolean;
+  missingFields: string[];
+  missingFieldsHelperText: string | null;
+  canSubmit: boolean;
+};
+
+/**
+ * Subscribes to activity form values / validation for create/edit submit gating.
+ */
+export function useActivityFormSubmitState<TFieldValues extends FieldValues>(
+  form: UseFormReturn<TFieldValues>,
+  options?: UseActivityFormSubmitStateOptions<TFieldValues>
+): ActivityFormSubmitState {
+  const watchedValues = useWatch({ control: form.control });
+  const { isValid, errors } = useFormState({
+    control: form.control,
+  });
+
+  if (options?.schema) {
+    const values = (watchedValues ?? form.getValues()) as TFieldValues;
+    const result = options.schema.safeParse(values);
+    const missingFields = result.success
+      ? []
+      : getMissingRequiredFieldsFromZodError(
+          result.error,
+          options.getFieldLabel
+        );
+
+    return {
+      isFormValid: result.success,
+      missingFields,
+      missingFieldsHelperText: formatMissingRequiredFieldsCountMessage(
+        missingFields.length
+      ),
+      canSubmit: result.success,
+    };
+  }
+
+  const missingFields = getMissingRequiredFields(
+    { errors } as FormState<TFieldValues>,
+    options?.getFieldLabel
+  );
+
+  return {
+    isFormValid: isValid,
+    missingFields,
+    missingFieldsHelperText: formatMissingRequiredFieldsCountMessage(
+      missingFields.length
+    ),
+    canSubmit: isValid,
+  };
+}

--- a/calendar-ui/src/hooks/useActivityFormSubmitState.ts
+++ b/calendar-ui/src/hooks/useActivityFormSubmitState.ts
@@ -5,13 +5,22 @@ import {
   type FormState,
   type UseFormReturn,
 } from 'react-hook-form';
-import type { ZodType } from 'zod';
 
 import {
   formatMissingRequiredFieldsCountMessage,
-  getMissingRequiredFields,
-  getMissingRequiredFieldsFromZodError,
+  getMissingRequiredFieldItems,
+  getMissingRequiredFieldItemsFromZodError,
+  type MissingRequiredFieldItem,
 } from '../lib/form-utils';
+
+type ActivityFormValidationSchema<TFieldValues extends FieldValues> = {
+  safeParse: (data: unknown) =>
+    | { success: true; data: TFieldValues }
+    | {
+        success: false;
+        error: Parameters<typeof getMissingRequiredFieldItemsFromZodError>[0];
+      };
+};
 
 type UseActivityFormSubmitStateOptions<TFieldValues extends FieldValues> = {
   getFieldLabel?: (fieldName: string) => string;
@@ -20,12 +29,13 @@ type UseActivityFormSubmitStateOptions<TFieldValues extends FieldValues> = {
    * watched values so the sticky bar updates as the user edits (not only after
    * RHF async validation settles).
    */
-  schema?: ZodType<TFieldValues>;
+  schema?: ActivityFormValidationSchema<TFieldValues>;
 };
 
 export type ActivityFormSubmitState = {
   isFormValid: boolean;
   missingFields: string[];
+  missingFieldItems: MissingRequiredFieldItem[];
   missingFieldsHelperText: string | null;
   canSubmit: boolean;
 };
@@ -37,41 +47,45 @@ export function useActivityFormSubmitState<TFieldValues extends FieldValues>(
   form: UseFormReturn<TFieldValues>,
   options?: UseActivityFormSubmitStateOptions<TFieldValues>
 ): ActivityFormSubmitState {
-  const watchedValues = useWatch({ control: form.control });
+  // useWatch subscribes to edits; getValues() reads the latest store on each render.
+  // Do not memoize getValues() on watchedValues — RHF may reuse the watch object reference.
+  useWatch({ control: form.control });
+  const values = form.getValues();
   const { isValid, errors } = useFormState({
     control: form.control,
   });
 
   if (options?.schema) {
-    const values = (watchedValues ?? form.getValues()) as TFieldValues;
     const result = options.schema.safeParse(values);
-    const missingFields = result.success
+    const missingFieldItems = result.success
       ? []
-      : getMissingRequiredFieldsFromZodError(
+      : getMissingRequiredFieldItemsFromZodError(
           result.error,
           options.getFieldLabel
         );
 
     return {
       isFormValid: result.success,
-      missingFields,
+      missingFields: missingFieldItems.map((field) => field.label),
+      missingFieldItems,
       missingFieldsHelperText: formatMissingRequiredFieldsCountMessage(
-        missingFields.length
+        missingFieldItems.length
       ),
       canSubmit: result.success,
     };
   }
 
-  const missingFields = getMissingRequiredFields(
+  const missingFieldItems = getMissingRequiredFieldItems(
     { errors } as FormState<TFieldValues>,
     options?.getFieldLabel
   );
 
   return {
     isFormValid: isValid,
-    missingFields,
+    missingFields: missingFieldItems.map((field) => field.label),
+    missingFieldItems,
     missingFieldsHelperText: formatMissingRequiredFieldsCountMessage(
-      missingFields.length
+      missingFieldItems.length
     ),
     canSubmit: isValid,
   };

--- a/calendar-ui/src/lib/activity-form-set-field.test.ts
+++ b/calendar-ui/src/lib/activity-form-set-field.test.ts
@@ -102,4 +102,32 @@ describe('setActivityFormFieldValue', () => {
       expect(result.current.getFieldState('summary').error).toBeUndefined();
     });
   });
+
+  it('sets commsContacts error when the field is cleared', async () => {
+    const { result } = renderHook(() =>
+      useForm<ActivityFormData>({
+        resolver: zodResolver(
+          createActivityRequestSchema
+        ) as Resolver<ActivityFormData>,
+        mode: 'onChange',
+        defaultValues: {
+          ...getDefaultFormValues(),
+          title: 'Test',
+          summary:
+            '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Summary text"}]}]}',
+          leadTeamId: 1,
+          categoryIds: [1],
+          commsContacts: [{ userId: 1, isLead: true }],
+        } as ActivityFormData,
+      })
+    );
+
+    act(() => {
+      setActivityFormFieldValue(result.current, 'commsContacts', []);
+    });
+
+    await waitFor(() => {
+      expect(result.current.getFieldState('commsContacts').error).toBeDefined();
+    });
+  });
 });

--- a/calendar-ui/src/lib/analytics.ts
+++ b/calendar-ui/src/lib/analytics.ts
@@ -24,7 +24,7 @@ export function trackCalendarClick(action: string) {
       schema: 'iglu:ca.bc.gov.bcs/calendar_click/jsonschema/1-0-0',
       data: { action },
     });
-  } catch (e) {
+  } catch {
     // swallow errors to avoid breaking the app
     // logging can be added here if desired
   }
@@ -42,7 +42,7 @@ export function trackCalendarAction(payload: CalendarAction) {
       schema: 'iglu:ca.bc.gov.bcs/calendar_action/jsonschema/1-0-0',
       data: eventData,
     });
-  } catch (e) {
+  } catch {
     // swallow
   }
 }

--- a/calendar-ui/src/lib/form-utils.test.ts
+++ b/calendar-ui/src/lib/form-utils.test.ts
@@ -16,13 +16,13 @@ describe('formatMissingRequiredFieldsCountMessage', () => {
 
   it('uses singular copy for one field', () => {
     expect(formatMissingRequiredFieldsCountMessage(1)).toBe(
-      '1 required field missing'
+      '1 more required field'
     );
   });
 
   it('uses plural copy for multiple fields', () => {
     expect(formatMissingRequiredFieldsCountMessage(4)).toBe(
-      '4 required fields missing'
+      '4 more required fields'
     );
   });
 });

--- a/calendar-ui/src/lib/form-utils.test.ts
+++ b/calendar-ui/src/lib/form-utils.test.ts
@@ -9,7 +9,6 @@ import {
   getMissingRequiredFieldItemsFromZodError,
   getMissingRequiredFields,
   getMissingRequiredFieldsFromZodError,
-  isZodMissingRequiredIssue,
 } from './form-utils';
 
 function minimalCreateRequest(overrides: Record<string, unknown> = {}) {
@@ -80,26 +79,6 @@ describe('getMissingRequiredFieldsFromZodError', () => {
   });
 });
 
-describe('isZodMissingRequiredIssue', () => {
-  it('excludes max-length issues', () => {
-    const schema = z.object({ title: z.string().max(5) });
-    const result = schema.safeParse({ title: 'too long title' });
-    expect(result.success).toBe(false);
-    if (result.success) return;
-
-    expect(isZodMissingRequiredIssue(result.error.issues[0])).toBe(false);
-  });
-
-  it('includes empty-string min-length issues', () => {
-    const schema = z.object({ title: z.string().min(1) });
-    const result = schema.safeParse({ title: '' });
-    expect(result.success).toBe(false);
-    if (result.success) return;
-
-    expect(isZodMissingRequiredIssue(result.error.issues[0])).toBe(true);
-  });
-});
-
 describe('getMissingRequiredFieldItemsFromZodError', () => {
   it('excludes max-length failures from the missing-fields hint', () => {
     const result = createActivityRequestSchema.safeParse(
@@ -129,6 +108,22 @@ describe('getMissingRequiredFieldItemsFromZodError', () => {
     );
 
     expect(missing.map((item) => item.name)).toContain('summary');
+  });
+
+  it('excludes commsContacts when contacts exist but no lead is selected', () => {
+    const result = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({
+        commsContacts: [{ userId: 1, isLead: false }],
+      })
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldItemsFromZodError(
+      result.error,
+      (field) => field
+    );
+    expect(missing).toEqual([]);
   });
 
   it('excludes event-planner lead refine failures', () => {

--- a/calendar-ui/src/lib/form-utils.test.ts
+++ b/calendar-ui/src/lib/form-utils.test.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 
 import {
   formatMissingRequiredFieldsCountMessage,
+  getMissingRequiredFieldItems,
+  getMissingRequiredFieldItemsFromZodError,
   getMissingRequiredFields,
   getMissingRequiredFieldsFromZodError,
 } from './form-utils';
@@ -58,5 +60,47 @@ describe('getMissingRequiredFieldsFromZodError', () => {
     );
 
     expect(missing).toEqual(['Label:title', 'Label:categoryIds']);
+  });
+});
+
+describe('getMissingRequiredFieldItemsFromZodError', () => {
+  it('returns field names and labels while deduping top-level paths', () => {
+    const schema = z.object({
+      title: z.string().min(1),
+      categoryIds: z.array(z.number()).min(1),
+    });
+
+    const result = schema.safeParse({ title: '', categoryIds: [] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldItemsFromZodError(
+      result.error,
+      (field) => `Label:${field}`
+    );
+
+    expect(missing).toEqual([
+      { name: 'title', label: 'Label:title' },
+      { name: 'categoryIds', label: 'Label:categoryIds' },
+    ]);
+  });
+});
+
+describe('getMissingRequiredFieldItems', () => {
+  it('extracts top-level field names and labels from nested errors', () => {
+    const missing = getMissingRequiredFieldItems(
+      {
+        errors: {
+          title: { type: 'too_small', message: 'Required' },
+          categoryIds: { type: 'too_small', message: 'At least one category' },
+        },
+      } as never,
+      (field) => `Label:${field}`
+    );
+
+    expect(missing).toEqual([
+      { name: 'title', label: 'Label:title' },
+      { name: 'categoryIds', label: 'Label:categoryIds' },
+    ]);
   });
 });

--- a/calendar-ui/src/lib/form-utils.test.ts
+++ b/calendar-ui/src/lib/form-utils.test.ts
@@ -1,13 +1,30 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
+import { createActivityRequestSchema } from '@corpcal/shared/schemas';
+
 import {
   formatMissingRequiredFieldsCountMessage,
   getMissingRequiredFieldItems,
   getMissingRequiredFieldItemsFromZodError,
   getMissingRequiredFields,
   getMissingRequiredFieldsFromZodError,
+  isZodMissingRequiredIssue,
 } from './form-utils';
+
+function minimalCreateRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Test Activity',
+    summary: 'Summary',
+    dateStatusId: 1,
+    timeStatusId: 1,
+    leadTeamId: 1,
+    leadMinistryId: 1,
+    categoryIds: [1],
+    commsContacts: [{ userId: 1, isLead: true }],
+    ...overrides,
+  };
+}
 
 describe('formatMissingRequiredFieldsCountMessage', () => {
   it('returns null when count is zero', () => {
@@ -63,7 +80,74 @@ describe('getMissingRequiredFieldsFromZodError', () => {
   });
 });
 
+describe('isZodMissingRequiredIssue', () => {
+  it('excludes max-length issues', () => {
+    const schema = z.object({ title: z.string().max(5) });
+    const result = schema.safeParse({ title: 'too long title' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(isZodMissingRequiredIssue(result.error.issues[0])).toBe(false);
+  });
+
+  it('includes empty-string min-length issues', () => {
+    const schema = z.object({ title: z.string().min(1) });
+    const result = schema.safeParse({ title: '' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(isZodMissingRequiredIssue(result.error.issues[0])).toBe(true);
+  });
+});
+
 describe('getMissingRequiredFieldItemsFromZodError', () => {
+  it('excludes max-length failures from the missing-fields hint', () => {
+    const result = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({ title: 'a'.repeat(256) })
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldItemsFromZodError(
+      result.error,
+      (field) => field
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('includes summary required refine failures', () => {
+    const result = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({ summary: '' })
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldItemsFromZodError(
+      result.error,
+      (field) => field
+    );
+
+    expect(missing.map((item) => item.name)).toContain('summary');
+  });
+
+  it('excludes event-planner lead refine failures', () => {
+    const result = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({
+        eventPlanners: [{ eventPlannerName: 'Planner A', isLead: false }],
+      })
+    );
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldItemsFromZodError(
+      result.error,
+      (field) => field
+    );
+
+    expect(missing).toEqual([]);
+  });
+
   it('returns field names and labels while deduping top-level paths', () => {
     const schema = z.object({
       title: z.string().min(1),

--- a/calendar-ui/src/lib/form-utils.test.ts
+++ b/calendar-ui/src/lib/form-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  formatMissingRequiredFieldsCountMessage,
+  getMissingRequiredFields,
+  getMissingRequiredFieldsFromZodError,
+} from './form-utils';
+
+describe('formatMissingRequiredFieldsCountMessage', () => {
+  it('returns null when count is zero', () => {
+    expect(formatMissingRequiredFieldsCountMessage(0)).toBeNull();
+  });
+
+  it('uses singular copy for one field', () => {
+    expect(formatMissingRequiredFieldsCountMessage(1)).toBe(
+      '1 required field missing'
+    );
+  });
+
+  it('uses plural copy for multiple fields', () => {
+    expect(formatMissingRequiredFieldsCountMessage(4)).toBe(
+      '4 required fields missing'
+    );
+  });
+});
+
+describe('getMissingRequiredFields', () => {
+  it('extracts top-level field labels from nested errors', () => {
+    const missing = getMissingRequiredFields(
+      {
+        errors: {
+          title: { type: 'too_small', message: 'Required' },
+          categoryIds: { type: 'too_small', message: 'At least one category' },
+        },
+      } as never,
+      (field) => `Label:${field}`
+    );
+
+    expect(missing).toEqual(['Label:title', 'Label:categoryIds']);
+  });
+});
+
+describe('getMissingRequiredFieldsFromZodError', () => {
+  it('dedupes issues by top-level field path', () => {
+    const schema = z.object({
+      title: z.string().min(1),
+      categoryIds: z.array(z.number()).min(1),
+    });
+
+    const result = schema.safeParse({ title: '', categoryIds: [] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const missing = getMissingRequiredFieldsFromZodError(
+      result.error,
+      (field) => `Label:${field}`
+    );
+
+    expect(missing).toEqual(['Label:title', 'Label:categoryIds']);
+  });
+});

--- a/calendar-ui/src/lib/form-utils.ts
+++ b/calendar-ui/src/lib/form-utils.ts
@@ -1,5 +1,12 @@
 import type { FieldErrors, FieldValues, FormState } from 'react-hook-form';
 
+import {
+  isZodMissingRequiredIssue,
+  type ZodIssueLike,
+} from '@corpcal/shared/validation';
+
+export { isZodMissingRequiredIssue };
+
 export type MissingRequiredFieldItem = {
   name: string;
   label: string;
@@ -75,45 +82,11 @@ export function getMissingRequiredFields<TFieldValues extends FieldValues>(
   );
 }
 
-type ZodIssueLike = {
-  path: ReadonlyArray<PropertyKey>;
-  code?: string;
-  message?: unknown;
-};
-
 /**
- * True when a Zod issue represents an empty/missing required value, not length,
- * format, or structural refine rules (e.g. event-planner lead selection).
+ * Maps Zod safeParse issues to top-level field names/labels for submit gating UI.
+ * Issue classification is defined in `@corpcal/shared` — see REQUIRED_FIELDS.md
+ * when adding required activity fields.
  */
-export function isZodMissingRequiredIssue(issue: ZodIssueLike): boolean {
-  const code = issue.code;
-
-  if (code === 'too_big' || code === 'too_long') {
-    return false;
-  }
-
-  if (code === 'too_small' || code === 'invalid_type') {
-    return true;
-  }
-
-  if (code === 'custom') {
-    const message = typeof issue.message === 'string' ? issue.message : '';
-    if (
-      message.includes('Maximum character limit exceeded') ||
-      message.startsWith('When event planners are provided') ||
-      message.includes('markAsReviewed and markAsCompleted')
-    ) {
-      return false;
-    }
-    if (/ is required$/i.test(message) || /^At least one /i.test(message)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/** Maps Zod safeParse issues to top-level field names/labels for submit gating UI. */
 export function getMissingRequiredFieldItemsFromZodError(
   error: { issues: ReadonlyArray<ZodIssueLike> },
   getFieldLabel?: (fieldName: string) => string

--- a/calendar-ui/src/lib/form-utils.ts
+++ b/calendar-ui/src/lib/form-utils.ts
@@ -116,6 +116,6 @@ export function formatMissingRequiredFieldsCountMessage(
 ): string | null {
   if (count <= 0) return null;
   return count === 1
-    ? '1 required field missing'
-    : `${count} required fields missing`;
+    ? '1 more required field'
+    : `${count} more required fields`;
 }

--- a/calendar-ui/src/lib/form-utils.ts
+++ b/calendar-ui/src/lib/form-utils.ts
@@ -1,4 +1,5 @@
 import type { FieldErrors, FieldValues, FormState } from 'react-hook-form';
+import type { ZodError } from 'zod';
 
 /**
  * Extracts missing required field labels from react-hook-form FormState errors.
@@ -59,4 +60,36 @@ export function getMissingRequiredFields<TFieldValues extends FieldValues>(
 
   extractErrors(errors);
   return missingFields;
+}
+
+/** Maps Zod safeParse issues to top-level field labels for submit gating UI. */
+export function getMissingRequiredFieldsFromZodError(
+  error: ZodError,
+  getFieldLabel?: (fieldName: string) => string
+): string[] {
+  const missingFields: string[] = [];
+  const seenFields = new Set<string>();
+
+  for (const issue of error.issues) {
+    const topLevelField = issue.path[0];
+    if (typeof topLevelField !== 'string' || seenFields.has(topLevelField)) {
+      continue;
+    }
+    seenFields.add(topLevelField);
+    missingFields.push(
+      getFieldLabel ? getFieldLabel(topLevelField) : topLevelField
+    );
+  }
+
+  return missingFields;
+}
+
+/** Muted sticky-bar copy when create/edit submit is blocked by required fields. */
+export function formatMissingRequiredFieldsCountMessage(
+  count: number
+): string | null {
+  if (count <= 0) return null;
+  return count === 1
+    ? '1 required field missing'
+    : `${count} required fields missing`;
 }

--- a/calendar-ui/src/lib/form-utils.ts
+++ b/calendar-ui/src/lib/form-utils.ts
@@ -1,5 +1,9 @@
 import type { FieldErrors, FieldValues, FormState } from 'react-hook-form';
-import type { ZodError } from 'zod';
+
+export type MissingRequiredFieldItem = {
+  name: string;
+  label: string;
+};
 
 /**
  * Extracts missing required field labels from react-hook-form FormState errors.
@@ -18,12 +22,12 @@ import type { ZodError } from 'zod';
  * );
  * ```
  */
-export function getMissingRequiredFields<TFieldValues extends FieldValues>(
+export function getMissingRequiredFieldItems<TFieldValues extends FieldValues>(
   formState: FormState<TFieldValues>,
   getFieldLabel?: (fieldName: string) => string
-): string[] {
+): MissingRequiredFieldItem[] {
   const errors = formState.errors;
-  const missingFields: string[] = [];
+  const missingFields: MissingRequiredFieldItem[] = [];
   const seenFields = new Set<string>();
 
   const extractErrors = (
@@ -41,10 +45,10 @@ export function getMissingRequiredFields<TFieldValues extends FieldValues>(
         const topLevelField = currentPath.split('.')[0];
         if (!seenFields.has(topLevelField)) {
           seenFields.add(topLevelField);
-          const label = getFieldLabel
-            ? getFieldLabel(topLevelField)
-            : topLevelField;
-          missingFields.push(label);
+          missingFields.push({
+            name: topLevelField,
+            label: getFieldLabel ? getFieldLabel(topLevelField) : topLevelField,
+          });
         }
       } else if (
         error &&
@@ -62,12 +66,23 @@ export function getMissingRequiredFields<TFieldValues extends FieldValues>(
   return missingFields;
 }
 
-/** Maps Zod safeParse issues to top-level field labels for submit gating UI. */
-export function getMissingRequiredFieldsFromZodError(
-  error: ZodError,
+export function getMissingRequiredFields<TFieldValues extends FieldValues>(
+  formState: FormState<TFieldValues>,
   getFieldLabel?: (fieldName: string) => string
 ): string[] {
-  const missingFields: string[] = [];
+  return getMissingRequiredFieldItems(formState, getFieldLabel).map(
+    (field) => field.label
+  );
+}
+
+type ZodIssueLike = { path: ReadonlyArray<PropertyKey> };
+
+/** Maps Zod safeParse issues to top-level field names/labels for submit gating UI. */
+export function getMissingRequiredFieldItemsFromZodError(
+  error: { issues: ReadonlyArray<ZodIssueLike> },
+  getFieldLabel?: (fieldName: string) => string
+): MissingRequiredFieldItem[] {
+  const missingFields: MissingRequiredFieldItem[] = [];
   const seenFields = new Set<string>();
 
   for (const issue of error.issues) {
@@ -76,12 +91,23 @@ export function getMissingRequiredFieldsFromZodError(
       continue;
     }
     seenFields.add(topLevelField);
-    missingFields.push(
-      getFieldLabel ? getFieldLabel(topLevelField) : topLevelField
-    );
+    missingFields.push({
+      name: topLevelField,
+      label: getFieldLabel ? getFieldLabel(topLevelField) : topLevelField,
+    });
   }
 
   return missingFields;
+}
+
+/** Maps Zod safeParse issues to top-level field labels for submit gating UI. */
+export function getMissingRequiredFieldsFromZodError(
+  error: { issues: ReadonlyArray<ZodIssueLike> },
+  getFieldLabel?: (fieldName: string) => string
+): string[] {
+  return getMissingRequiredFieldItemsFromZodError(error, getFieldLabel).map(
+    (field) => field.label
+  );
 }
 
 /** Muted sticky-bar copy when create/edit submit is blocked by required fields. */

--- a/calendar-ui/src/lib/form-utils.ts
+++ b/calendar-ui/src/lib/form-utils.ts
@@ -75,7 +75,43 @@ export function getMissingRequiredFields<TFieldValues extends FieldValues>(
   );
 }
 
-type ZodIssueLike = { path: ReadonlyArray<PropertyKey> };
+type ZodIssueLike = {
+  path: ReadonlyArray<PropertyKey>;
+  code?: string;
+  message?: unknown;
+};
+
+/**
+ * True when a Zod issue represents an empty/missing required value, not length,
+ * format, or structural refine rules (e.g. event-planner lead selection).
+ */
+export function isZodMissingRequiredIssue(issue: ZodIssueLike): boolean {
+  const code = issue.code;
+
+  if (code === 'too_big' || code === 'too_long') {
+    return false;
+  }
+
+  if (code === 'too_small' || code === 'invalid_type') {
+    return true;
+  }
+
+  if (code === 'custom') {
+    const message = typeof issue.message === 'string' ? issue.message : '';
+    if (
+      message.includes('Maximum character limit exceeded') ||
+      message.startsWith('When event planners are provided') ||
+      message.includes('markAsReviewed and markAsCompleted')
+    ) {
+      return false;
+    }
+    if (/ is required$/i.test(message) || /^At least one /i.test(message)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 /** Maps Zod safeParse issues to top-level field names/labels for submit gating UI. */
 export function getMissingRequiredFieldItemsFromZodError(
@@ -86,6 +122,10 @@ export function getMissingRequiredFieldItemsFromZodError(
   const seenFields = new Set<string>();
 
   for (const issue of error.issues) {
+    if (!isZodMissingRequiredIssue(issue)) {
+      continue;
+    }
+
     const topLevelField = issue.path[0];
     if (typeof topLevelField !== 'string' || seenFields.has(topLevelField)) {
       continue;

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -845,7 +845,7 @@ export function ActivityPage({
         displayId={displayId}
         title={activity.title ?? ''}
         categories={categories}
-        leadOrg={activity.leadOrg ?? null}
+        leadMinistry={activity.leadMinistry ?? null}
         activityStatus={activity.activityStatus ?? null}
         lastUpdatedDateTime={activity.lastUpdatedDateTime ?? null}
         createdDateTime={activity.createdDateTime ?? null}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@corpcal/shared/schemas';
 import {
   ActivityFormBody,
+  ActivityFormMissingFieldsHint,
   ActivityFormStickyHeader,
   ActivityPageHeader,
   ActivityStatusBanner,
@@ -44,11 +45,6 @@ import {
 import { cloneActivity, fetchActivityHistory } from '../api/activitiesApi';
 import { ApiError } from '../api/errors';
 import { cancelForceHandoff, requestForceHandoff } from '../api/locksApi';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '../components/ui/popover';
 import { useActivityEditActions } from '../hooks/useActivityEditActions';
 import { useActivityEditFormHydration } from '../hooks/useActivityEditFormHydration';
 import { useActivityFormSetup } from '../hooks/useActivityFormSetup';
@@ -134,7 +130,7 @@ export function ActivityPage({
     userTeamIds: user?.teamIds,
     hasCreateAny,
   });
-  const { isFormValid, missingFields, missingFieldItems } =
+  const { isFormValid, missingFields, missingFieldsHelperText } =
     useActivityFormSubmitState(form, {
       getFieldLabel: getActivityFieldLabel,
       schema: createActivityRequestSchema,
@@ -242,8 +238,6 @@ export function ActivityPage({
   const [deleteModalInitialNotes, setDeleteModalInitialNotes] = useState<
     string | undefined
   >(undefined);
-  const [showMissingFieldsPopover, setShowMissingFieldsPopover] =
-    useState(false);
   /**
    * Forces remount of form-body UI controls (combobox/popover/select internals)
    * when edit lock is externally lost, so open overlays cannot remain stuck.
@@ -984,19 +978,25 @@ export function ActivityPage({
                     Delete
                   </Button>
                 )}
+                {isDirty && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="animate-in fade-in duration-200"
+                    onClick={() => setShowLeaveConfirm(true)}
+                    disabled={isSubmitting}
+                  >
+                    Discard changes
+                  </Button>
+                )}
               </div>
             </div>
-            <div className="flex shrink-0 gap-4">
-              {isDirty && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="animate-in fade-in duration-200"
-                  onClick={() => setShowLeaveConfirm(true)}
-                  disabled={isSubmitting}
-                >
-                  Discard changes
-                </Button>
+            <div className="flex shrink-0 flex-wrap items-center gap-4">
+              {missingFieldsHelperText != null && (
+                <ActivityFormMissingFieldsHint
+                  helperText={missingFieldsHelperText}
+                  fields={missingFields}
+                />
               )}
               {canCloneActivity && (
                 <Button
@@ -1008,62 +1008,26 @@ export function ActivityPage({
                   Clone
                 </Button>
               )}
-              {!isFormValid ? (
-                <Popover open={showMissingFieldsPopover}>
-                  <PopoverTrigger asChild>
-                    <div
-                      onMouseEnter={() => setShowMissingFieldsPopover(true)}
-                      onMouseLeave={() => setShowMissingFieldsPopover(false)}
-                    >
-                      <Button
-                        type="submit"
-                        disabled={true}
-                        variant={
-                          canReviewActivities || actionFlags.showCompleteAction
-                            ? 'outline'
-                            : 'default'
-                        }
-                        className="cursor-not-allowed"
-                      >
-                        {isSubmitting ? 'Saving...' : 'Save'}
-                      </Button>
-                    </div>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-80"
-                    onMouseEnter={() => setShowMissingFieldsPopover(true)}
-                    onMouseLeave={() => setShowMissingFieldsPopover(false)}
-                  >
-                    <div>
-                      <h4 className="mb-3 text-sm font-medium">
-                        Required fields remaining:
-                      </h4>
-                      <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-                        {missingFieldItems.map((field) => (
-                          <li key={field.name}>{field.label}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              ) : (
-                <Button
-                  type="submit"
-                  variant={
-                    canReviewActivities || actionFlags.showCompleteAction
-                      ? 'outline'
-                      : 'default'
-                  }
-                  disabled={!actionFlags.canSubmitUpdate}
-                >
-                  {isSubmitting ? 'Saving...' : 'Save'}
-                </Button>
-              )}
+              <Button
+                type="submit"
+                variant={
+                  canReviewActivities || actionFlags.showCompleteAction
+                    ? 'outline'
+                    : 'default'
+                }
+                disabled={!actionFlags.canSubmitUpdate}
+                className={!isFormValid ? 'cursor-not-allowed' : undefined}
+              >
+                {isSubmitting ? 'Saving...' : 'Save'}
+              </Button>
               {actionFlags.showReviewAction && (
                 <Button
                   type="button"
                   aria-label={isDirty ? 'Save and Review' : 'Review'}
                   disabled={!actionFlags.reviewActionEnabled}
+                  className={
+                    isDirty && !isFormValid ? 'cursor-not-allowed' : undefined
+                  }
                   onClick={() => ensureEditThen(() => setShowReviewModal(true))}
                 >
                   <ReviewActionButtonLabel isDirty={isDirty} />
@@ -1075,6 +1039,9 @@ export function ActivityPage({
                     type="button"
                     aria-label={isDirty ? 'Save and complete' : 'Complete'}
                     disabled={!actionFlags.completeActionEnabled}
+                    className={
+                      isDirty && !isFormValid ? 'cursor-not-allowed' : undefined
+                    }
                     onClick={() =>
                       ensureEditThen(() => setShowCompleteModal(true))
                     }

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { buildActivityDisplayId, TEAM_PREFIX_FALLBACK } from '@corpcal/shared';
 import { PERMISSIONS, SYSTEM_ROLES } from '@corpcal/shared/auth';
 import {
+  createActivityRequestSchema,
   type ActivityFormData,
   type ActivityResponse,
   type CloneActivityRequest,
@@ -51,6 +52,7 @@ import {
 import { useActivityEditActions } from '../hooks/useActivityEditActions';
 import { useActivityEditFormHydration } from '../hooks/useActivityEditFormHydration';
 import { useActivityFormSetup } from '../hooks/useActivityFormSetup';
+import { useActivityFormSubmitState } from '../hooks/useActivityFormSubmitState';
 import { useActivityLock } from '../hooks/useActivityLock';
 import { useActivityWebSocket } from '../hooks/useActivityWebSocket';
 import { useAuth } from '../hooks/useAuth';
@@ -82,7 +84,6 @@ import { showActivityMutationSuccessToast } from '../lib/activity-mutation-succe
 import { resolveActivityToastDisplayId } from '../lib/activity-toast-options';
 import { formatActivityEndDateTimeLabel } from '../lib/datetime-utils';
 import { showErrorToast } from '../lib/error-toast';
-import { getMissingRequiredFields } from '../lib/form-utils';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger('ActivityPage');
@@ -133,6 +134,11 @@ export function ActivityPage({
     userTeamIds: user?.teamIds,
     hasCreateAny,
   });
+  const { isFormValid, missingFields, missingFieldItems } =
+    useActivityFormSubmitState(form, {
+      getFieldLabel: getActivityFieldLabel,
+      schema: createActivityRequestSchema,
+    });
   const canReviewActivities = hasPermission(PERMISSIONS.ACTIVITIES.REVIEW);
   const reviewerChangedPaths = useMemo<ReadonlySet<string>>(() => {
     const paths = canReviewActivities
@@ -371,11 +377,6 @@ export function ActivityPage({
   });
 
   const isDirty = form.formState.isDirty;
-  const isFormValid = form.formState.isValid;
-  const missingFields = getMissingRequiredFields(
-    form.formState,
-    getActivityFieldLabel
-  );
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -424,9 +425,6 @@ export function ActivityPage({
     LOCK_BANNER_INTERSECTION_ROOT_MARGIN,
     0
   );
-  const canSubmitWithoutValidationErrors =
-    isFormValid || missingFields.length === 0;
-
   const actionFlags = useActivityEditActions({
     lockState,
     mayEditFormFields,
@@ -434,7 +432,7 @@ export function ActivityPage({
     canCompleteActivities,
     markCompleteEligible,
     hasEditLock,
-    canSubmitWithoutValidationErrors,
+    canSubmitWithoutValidationErrors: isFormValid,
     isSubmitting,
     readOnly,
     isDirty,
@@ -636,13 +634,9 @@ export function ActivityPage({
 
   const onError = () => {
     logger.error('Form validation failed');
-    const missing = getMissingRequiredFields(
-      form.formState,
-      getActivityFieldLabel
-    );
     const detail =
-      missing.length > 0
-        ? `Required fields missing: ${missing.join(', ')}`
+      missingFields.length > 0
+        ? `Required fields missing: ${missingFields.join(', ')}`
         : 'Please fix the validation errors and try again.';
     toast.error('Submission failed', {
       description: detail,
@@ -1014,7 +1008,7 @@ export function ActivityPage({
                   Clone
                 </Button>
               )}
-              {!canSubmitWithoutValidationErrors ? (
+              {!isFormValid ? (
                 <Popover open={showMissingFieldsPopover}>
                   <PopoverTrigger asChild>
                     <div
@@ -1045,8 +1039,8 @@ export function ActivityPage({
                         Required fields missing:
                       </h4>
                       <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-                        {missingFields.map((field) => (
-                          <li key={field}>{field}</li>
+                        {missingFieldItems.map((field) => (
+                          <li key={field.name}>{field.label}</li>
                         ))}
                       </ul>
                     </div>

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -1034,9 +1034,9 @@ export function ActivityPage({
                     onMouseEnter={() => setShowMissingFieldsPopover(true)}
                     onMouseLeave={() => setShowMissingFieldsPopover(false)}
                   >
-                    <div className="space-y-2">
-                      <h4 className="text-sm font-medium">
-                        Required fields missing:
+                    <div>
+                      <h4 className="mb-3 text-sm font-medium">
+                        Required fields remaining:
                       </h4>
                       <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
                         {missingFieldItems.map((field) => (

--- a/calendar-ui/src/pages/CreateActivityForm.tsx
+++ b/calendar-ui/src/pages/CreateActivityForm.tsx
@@ -21,8 +21,8 @@ import { Button } from '@/components/ui/button';
 import { Form } from '../components/ui/form';
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from '../components/ui/popover';
 import { useActivityFormSetup } from '../hooks/useActivityFormSetup';
 import { useActivityFormSubmitState } from '../hooks/useActivityFormSubmitState';
@@ -38,7 +38,6 @@ import {
   ACCESS_DENIED_TITLE,
 } from '../lib/error-messages';
 import { showErrorToast } from '../lib/error-toast';
-import { getMissingRequiredFields } from '../lib/form-utils';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger('CreateActivityForm');
@@ -154,13 +153,9 @@ export const CreateActivityForm: FC = () => {
 
   const onError = () => {
     logger.error('Form validation failed');
-    const missing = getMissingRequiredFields(
-      form.formState,
-      getActivityFieldLabel
-    );
     const detail =
-      missing.length > 0
-        ? `Required fields missing: ${missing.join(', ')}`
+      missingFields.length > 0
+        ? `Required fields missing: ${missingFields.join(', ')}`
         : 'Please fix the validation errors and try again.';
     toast.error('Submission failed', {
       description: detail,
@@ -252,13 +247,6 @@ export const CreateActivityForm: FC = () => {
 
           <div className="bg-background sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-4 py-4">
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-2">
-              {missingFieldsHelperText != null && (
-                <p className="text-muted-foreground text-sm">
-                  {missingFieldsHelperText}
-                </p>
-              )}
-            </div>
-            <div className="flex shrink-0 gap-4">
               <Button
                 type="button"
                 variant="outline"
@@ -270,25 +258,24 @@ export const CreateActivityForm: FC = () => {
               >
                 Cancel
               </Button>
-              {!isFormValid && missingFields.length > 0 ? (
+            </div>
+            <div className="flex shrink-0 flex-wrap items-center gap-4">
+              {missingFieldsHelperText != null && (
                 <Popover open={showMissingFieldsPopover}>
-                  <PopoverTrigger asChild>
-                    <div
+                  <PopoverAnchor asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="text-muted-foreground h-auto px-2 py-1 font-normal"
                       onMouseEnter={() => setShowMissingFieldsPopover(true)}
                       onMouseLeave={() => setShowMissingFieldsPopover(false)}
                     >
-                      <Button
-                        type="submit"
-                        disabled={!isFormValid || isSubmitting}
-                        variant="default"
-                        className="cursor-not-allowed"
-                      >
-                        {isSubmitting ? 'Submitting...' : 'Submit'}
-                      </Button>
-                    </div>
-                  </PopoverTrigger>
+                      {missingFieldsHelperText}
+                    </Button>
+                  </PopoverAnchor>
                   <PopoverContent
                     className="w-80"
+                    align="end"
                     onMouseEnter={() => setShowMissingFieldsPopover(true)}
                     onMouseLeave={() => setShowMissingFieldsPopover(false)}
                   >
@@ -304,15 +291,15 @@ export const CreateActivityForm: FC = () => {
                     </div>
                   </PopoverContent>
                 </Popover>
-              ) : (
-                <Button
-                  type="submit"
-                  variant="default"
-                  disabled={!isFormValid || isSubmitting}
-                >
-                  {isSubmitting ? 'Submitting...' : 'Submit'}
-                </Button>
               )}
+              <Button
+                type="submit"
+                variant="default"
+                disabled={!isFormValid || isSubmitting}
+                className={!isFormValid ? 'cursor-not-allowed' : undefined}
+              >
+                {isSubmitting ? 'Submitting...' : 'Submit'}
+              </Button>
             </div>
           </div>
         </form>

--- a/calendar-ui/src/pages/CreateActivityForm.tsx
+++ b/calendar-ui/src/pages/CreateActivityForm.tsx
@@ -5,6 +5,7 @@ import { useState, type FC } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared/auth';
 import {
+  createActivityRequestSchema,
   type ActivityFormData,
   type CreateActivityRequest,
 } from '@corpcal/shared/schemas';
@@ -24,6 +25,7 @@ import {
   PopoverTrigger,
 } from '../components/ui/popover';
 import { useActivityFormSetup } from '../hooks/useActivityFormSetup';
+import { useActivityFormSubmitState } from '../hooks/useActivityFormSubmitState';
 import { useAuth } from '../hooks/useAuth';
 import { useCreateActivity } from '../hooks/useCalendar';
 import { getActivityFieldLabel } from '../lib/activity-form-labels';
@@ -77,6 +79,12 @@ export const CreateActivityForm: FC = () => {
     userTeamIds: user?.teamIds,
     hasCreateAny,
   });
+
+  const { isFormValid, missingFields, missingFieldsHelperText } =
+    useActivityFormSubmitState(form, {
+      getFieldLabel: getActivityFieldLabel,
+      schema: createActivityRequestSchema,
+    });
 
   const handleCancel = () => {
     void form.reset();
@@ -160,12 +168,6 @@ export const CreateActivityForm: FC = () => {
     });
   };
 
-  const isFormValid = form.formState.isValid;
-  const missingFields = getMissingRequiredFields(
-    form.formState,
-    getActivityFieldLabel
-  );
-
   // Show loading state while checking auth
   if (isAuthLoading) {
     return (
@@ -248,61 +250,70 @@ export const CreateActivityForm: FC = () => {
             }}
           />
 
-          <div className="flex justify-end gap-4 pt-6">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => {
-                void handleCancel();
-              }}
-              disabled={isSubmitting}
-              title="Close the create window without saving"
-            >
-              Cancel
-            </Button>
-            {!isFormValid && missingFields.length > 0 ? (
-              <Popover open={showMissingFieldsPopover}>
-                <PopoverTrigger asChild>
-                  <div
+          <div className="bg-background sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-4 py-4">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-2">
+              {missingFieldsHelperText != null && (
+                <p className="text-muted-foreground text-sm">
+                  {missingFieldsHelperText}
+                </p>
+              )}
+            </div>
+            <div className="flex shrink-0 gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  void handleCancel();
+                }}
+                disabled={isSubmitting}
+                title="Close the create window without saving"
+              >
+                Cancel
+              </Button>
+              {!isFormValid && missingFields.length > 0 ? (
+                <Popover open={showMissingFieldsPopover}>
+                  <PopoverTrigger asChild>
+                    <div
+                      onMouseEnter={() => setShowMissingFieldsPopover(true)}
+                      onMouseLeave={() => setShowMissingFieldsPopover(false)}
+                    >
+                      <Button
+                        type="submit"
+                        disabled={!isFormValid || isSubmitting}
+                        variant="default"
+                        className="cursor-not-allowed"
+                      >
+                        {isSubmitting ? 'Submitting...' : 'Submit'}
+                      </Button>
+                    </div>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-80"
                     onMouseEnter={() => setShowMissingFieldsPopover(true)}
                     onMouseLeave={() => setShowMissingFieldsPopover(false)}
                   >
-                    <Button
-                      type="submit"
-                      disabled={true}
-                      variant={canReviewActivities ? 'outline' : 'default'}
-                      className="cursor-not-allowed"
-                    >
-                      {isSubmitting ? 'Submitting...' : 'Submit'}
-                    </Button>
-                  </div>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="w-80"
-                  onMouseEnter={() => setShowMissingFieldsPopover(true)}
-                  onMouseLeave={() => setShowMissingFieldsPopover(false)}
+                    <div className="space-y-2">
+                      <h4 className="text-sm font-medium">
+                        Required fields missing:
+                      </h4>
+                      <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
+                        {missingFields.map((field) => (
+                          <li key={field}>{field}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                <Button
+                  type="submit"
+                  variant="default"
+                  disabled={!isFormValid || isSubmitting}
                 >
-                  <div className="space-y-2">
-                    <h4 className="text-sm font-medium">
-                      Required fields missing:
-                    </h4>
-                    <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-                      {missingFields.map((field) => (
-                        <li key={field}>{field}</li>
-                      ))}
-                    </ul>
-                  </div>
-                </PopoverContent>
-              </Popover>
-            ) : (
-              <Button
-                type="submit"
-                variant={canReviewActivities ? 'outline' : 'default'}
-                disabled={isSubmitting}
-              >
-                {isSubmitting ? 'Submitting...' : 'Submit'}
-              </Button>
-            )}
+                  {isSubmitting ? 'Submitting...' : 'Submit'}
+                </Button>
+              )}
+            </div>
           </div>
         </form>
       </Form>

--- a/calendar-ui/src/pages/CreateActivityForm.tsx
+++ b/calendar-ui/src/pages/CreateActivityForm.tsx
@@ -11,6 +11,7 @@ import {
 } from '@corpcal/shared/schemas';
 import {
   ActivityFormBody,
+  ActivityFormMissingFieldsHint,
   ActivityFormStickyHeader,
 } from '@/components/activity';
 import { CreateActivityConfirmModal } from '@/components/activity/activities/CreateActivityConfirmModal';
@@ -19,11 +20,6 @@ import { FormErrorFallback, StatusMessage } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 
 import { Form } from '../components/ui/form';
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-} from '../components/ui/popover';
 import { useActivityFormSetup } from '../hooks/useActivityFormSetup';
 import { useActivityFormSubmitState } from '../hooks/useActivityFormSubmitState';
 import { useAuth } from '../hooks/useAuth';
@@ -49,8 +45,6 @@ export const CreateActivityForm: FC = () => {
   const listOrBackPath = getActivityFormBackTarget(location.state) ?? '/';
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showMissingFieldsPopover, setShowMissingFieldsPopover] =
-    useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [validatedData, setValidatedData] = useState<ActivityFormData | null>(
     null
@@ -261,36 +255,10 @@ export const CreateActivityForm: FC = () => {
             </div>
             <div className="flex shrink-0 flex-wrap items-center gap-4">
               {missingFieldsHelperText != null && (
-                <Popover open={showMissingFieldsPopover}>
-                  <PopoverAnchor asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="text-muted-foreground h-auto px-2 py-1 font-normal"
-                      onMouseEnter={() => setShowMissingFieldsPopover(true)}
-                      onMouseLeave={() => setShowMissingFieldsPopover(false)}
-                    >
-                      {missingFieldsHelperText}
-                    </Button>
-                  </PopoverAnchor>
-                  <PopoverContent
-                    className="w-80"
-                    align="end"
-                    onMouseEnter={() => setShowMissingFieldsPopover(true)}
-                    onMouseLeave={() => setShowMissingFieldsPopover(false)}
-                  >
-                    <div className="space-y-2">
-                      <h4 className="text-sm font-medium">
-                        Required fields missing:
-                      </h4>
-                      <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
-                        {missingFields.map((field) => (
-                          <li key={field}>{field}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                <ActivityFormMissingFieldsHint
+                  helperText={missingFieldsHelperText}
+                  fields={missingFields}
+                />
               )}
               <Button
                 type="submit"

--- a/calendar-ui/src/test/setup.ts
+++ b/calendar-ui/src/test/setup.ts
@@ -19,6 +19,21 @@ global.ResizeObserver = class ResizeObserver {
 // Mock scrollIntoView (required by cmdk)
 Element.prototype.scrollIntoView = vi.fn();
 
+// Mock matchMedia (required by ActivityFormMissingFieldsHint, use-mobile, etc.)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // Cleanup after each test
 afterEach(() => {
   cleanup();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,6 +28,12 @@
       "require": "./dist/cjs/utils/index.js",
       "default": "./dist/esm/utils/index.js"
     },
+    "./validation": {
+      "types": "./dist/esm/validation/index.d.ts",
+      "import": "./dist/esm/validation/index.js",
+      "require": "./dist/cjs/validation/index.js",
+      "default": "./dist/esm/validation/index.js"
+    },
     "./api": {
       "types": "./dist/esm/api/index.d.ts",
       "import": "./dist/esm/api/index.js",

--- a/packages/shared/src/schemas/activity.schema.spec.ts
+++ b/packages/shared/src/schemas/activity.schema.spec.ts
@@ -60,11 +60,14 @@ describe('createActivityRequestSchema', () => {
     expect(undefinedTitle.error.issues[0].message).toBe(
       'An activity title is required'
     );
-    expect(() =>
-      createActivityRequestSchema.parse(
-        minimalCreateRequest({ title: 'a'.repeat(256) })
-      )
-    ).toThrow();
+    const tooLongTitle = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({ title: 'a'.repeat(256) })
+    );
+    if (tooLongTitle.success) throw new Error('Expected failure');
+    expect(tooLongTitle.error.issues[0].path).toEqual(['title']);
+    expect(tooLongTitle.error.issues[0].message).toBe(
+      'Maximum character limit exceeded'
+    );
   });
 
   it('rejects create when summary is empty or missing', () => {

--- a/packages/shared/src/schemas/activity.schema.spec.ts
+++ b/packages/shared/src/schemas/activity.schema.spec.ts
@@ -44,11 +44,50 @@ describe('createActivityRequestSchema', () => {
     expect(() =>
       createActivityRequestSchema.parse(minimalCreateRequest({ title: '' }))
     ).toThrow();
+    const emptyTitle = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({ title: '' })
+    );
+    if (emptyTitle.success) throw new Error('Expected failure');
+    expect(emptyTitle.error.issues[0].path).toEqual(['title']);
+    expect(emptyTitle.error.issues[0].message).toBe(
+      'An activity title is required'
+    );
+    const missingTitle = minimalCreateRequest();
+    delete (missingTitle as Record<string, unknown>).title;
+    const undefinedTitle = createActivityRequestSchema.safeParse(missingTitle);
+    if (undefinedTitle.success) throw new Error('Expected failure');
+    expect(undefinedTitle.error.issues[0].path).toEqual(['title']);
+    expect(undefinedTitle.error.issues[0].message).toBe(
+      'An activity title is required'
+    );
     expect(() =>
       createActivityRequestSchema.parse(
         minimalCreateRequest({ title: 'a'.repeat(256) })
       )
     ).toThrow();
+  });
+
+  it('rejects create when summary is empty or missing', () => {
+    const emptySummary = createActivityRequestSchema.safeParse(
+      minimalCreateRequest({ summary: '' })
+    );
+    if (emptySummary.success) throw new Error('Expected failure');
+    expect(emptySummary.error.issues.some((i) => i.path[0] === 'summary')).toBe(
+      true
+    );
+    expect(
+      emptySummary.error.issues.find((i) => i.path[0] === 'summary')?.message
+    ).toBe('A summary is required');
+
+    const missingSummary = minimalCreateRequest();
+    delete (missingSummary as Record<string, unknown>).summary;
+    const undefinedSummary =
+      createActivityRequestSchema.safeParse(missingSummary);
+    if (undefinedSummary.success) throw new Error('Expected failure');
+    expect(
+      undefinedSummary.error.issues.find((i) => i.path[0] === 'summary')
+        ?.message
+    ).toBe('A summary is required');
   });
 
   it('enforces summary and significance max rich-text bytes and valid storage', () => {
@@ -213,7 +252,7 @@ describe('createActivityRequestSchema', () => {
     const err = createActivityRequestSchema.safeParse(withoutComms);
     if (err.success) throw new Error('Expected failure');
     expect(err.error.issues[0].path).toEqual(['commsContacts']);
-    expect(err.error.issues[0].message).toBe('A lead contact is required.');
+    expect(err.error.issues[0].message).toBe('A lead contact is required');
   });
 
   it('rejects create when commsContacts is empty array', () => {
@@ -307,7 +346,7 @@ describe('createActivityRequestSchema', () => {
     if (err.success) throw new Error('Expected failure');
     expect(err.error.issues[0].path).toEqual(['eventPlanners']);
     expect(err.error.issues[0].message).toBe(
-      'When event planners are provided, exactly one must be marked as lead.'
+      'When event planners are provided, exactly one must be marked as lead'
     );
   });
 
@@ -414,7 +453,7 @@ describe('updateActivityRequestSchema', () => {
     });
     if (err.success) throw new Error('Expected failure');
     expect(err.error.issues[0].path).toEqual(['commsContacts']);
-    expect(err.error.issues[0].message).toBe('A lead contact is required.');
+    expect(err.error.issues[0].message).toBe('A lead contact is required');
   });
 
   it('rejects update when commsContacts has two leads', () => {
@@ -464,7 +503,7 @@ describe('updateActivityRequestSchema', () => {
     if (err.success) throw new Error('Expected failure');
     expect(err.error.issues[0].path).toEqual(['categoryIds']);
     expect(err.error.issues[0].message).toBe(
-      'At least one category is required.'
+      'At least one category is required'
     );
   });
 

--- a/packages/shared/src/schemas/activity.schema.ts
+++ b/packages/shared/src/schemas/activity.schema.ts
@@ -76,12 +76,16 @@ const activityRichTextStoredStringSchema = z
  */
 const TITLE_REQUIRED_MESSAGE = 'An activity title is required';
 const SUMMARY_REQUIRED_MESSAGE = 'A summary is required';
+const MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE = 'Maximum character limit exceeded';
 
 const activityCoreFieldsSchema = z.object({
   // Required fields
   title: z.preprocess(
     (val) => (val === undefined || val === null ? '' : val),
-    z.string().min(1, { message: TITLE_REQUIRED_MESSAGE }).max(255)
+    z
+      .string()
+      .min(1, { message: TITLE_REQUIRED_MESSAGE })
+      .max(255, MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE)
   ),
   summary: z.preprocess(
     (val) => (val === undefined || val === null ? '' : val),
@@ -101,7 +105,11 @@ const activityCoreFieldsSchema = z.object({
       ])
       .optional()
   ),
-  schedulingNotes: z.string().max(500).optional().nullable(),
+  schedulingNotes: z
+    .string()
+    .max(500, MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE)
+    .optional()
+    .nullable(),
   strategy: z.string().nullable().optional(),
 
   // Status IDs (numbers for database; venue optional when activity has no venue)
@@ -162,7 +170,11 @@ const activityCoreFieldsSchema = z.object({
     emptyStringToNull,
     z.number().int().nullable().optional()
   ),
-  leadOrgName: z.string().max(255).nullable().optional(),
+  leadOrgName: z
+    .string()
+    .max(255, MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE)
+    .nullable()
+    .optional(),
   newsReleaseId: z.preprocess(
     emptyStringToNull,
     z.string().uuid().nullable().optional()
@@ -195,7 +207,10 @@ const activityCoreFieldsSchema = z.object({
 const representativeSchema = z
   .object({
     representativeId: z.number().int().optional(),
-    representativeName: z.string().max(255).optional(),
+    representativeName: z
+      .string()
+      .max(255, MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE)
+      .optional(),
   })
   .refine(
     (data) => {
@@ -219,7 +234,10 @@ const representativeSchema = z
  */
 const eventPlannerSchema = z.object({
   eventPlannerId: z.number().int().optional(),
-  eventPlannerName: z.string().max(255).optional(),
+  eventPlannerName: z
+    .string()
+    .max(255, MAX_CHARACTER_LIMIT_EXCEEDED_MESSAGE)
+    .optional(),
   isLead: z.boolean().default(false),
 });
 

--- a/packages/shared/src/schemas/activity.schema.ts
+++ b/packages/shared/src/schemas/activity.schema.ts
@@ -74,10 +74,19 @@ const activityRichTextStoredStringSchema = z
  * Core activity fields schema
  * These fields exist in the database activities table
  */
+const TITLE_REQUIRED_MESSAGE = 'An activity title is required';
+const SUMMARY_REQUIRED_MESSAGE = 'A summary is required';
+
 const activityCoreFieldsSchema = z.object({
   // Required fields
-  title: z.string().min(1).max(255),
-  summary: activityRichTextStoredStringSchema,
+  title: z.preprocess(
+    (val) => (val === undefined || val === null ? '' : val),
+    z.string().min(1, { message: TITLE_REQUIRED_MESSAGE }).max(255)
+  ),
+  summary: z.preprocess(
+    (val) => (val === undefined || val === null ? '' : val),
+    activityRichTextStoredStringSchema
+  ),
   significance: z.preprocess(
     emptyStringToNull,
     z
@@ -261,7 +270,9 @@ const junctionTableIdsSchema = z.object({
   reportSettings: z.array(reportSettingSchema).optional(), // Report settings for the activity
 });
 
-const CATEGORY_IDS_MIN_MESSAGE = 'At least one category is required.';
+const CATEGORY_IDS_MIN_MESSAGE = 'At least one category is required';
+const LEAD_CONTACT_REFINE_MESSAGE = 'A lead contact is required';
+const LEAD_CONTACT_REFINE_PATH = ['commsContacts'] as const;
 
 /** Create requests require at least one category ID. */
 const createJunctionTableIdsSchema = junctionTableIdsSchema.extend({
@@ -270,8 +281,14 @@ const createJunctionTableIdsSchema = junctionTableIdsSchema.extend({
     .min(1, { message: CATEGORY_IDS_MIN_MESSAGE }),
 });
 
-const LEAD_CONTACT_REFINE_MESSAGE = 'A lead contact is required.';
-const LEAD_CONTACT_REFINE_PATH = ['commsContacts'] as const;
+/** Field-level create validation so RHF trigger('commsContacts') catches empty arrays. */
+const createCommsContactsFieldSchema = z
+  .array(commsContactSchema)
+  .min(1, { message: LEAD_CONTACT_REFINE_MESSAGE })
+  .refine((contacts) => contacts.filter((c) => c.isLead).length === 1, {
+    message: LEAD_CONTACT_REFINE_MESSAGE,
+  })
+  .optional();
 
 /** Create: commsContacts must have at least one contact and exactly one lead. */
 function createLeadContactRefine(data: {
@@ -291,7 +308,7 @@ function updateLeadContactRefine(data: {
 }
 
 const EVENT_PLANNER_LEAD_REFINE_MESSAGE =
-  'When event planners are provided, exactly one must be marked as lead.';
+  'When event planners are provided, exactly one must be marked as lead';
 const EVENT_PLANNER_LEAD_REFINE_PATH = ['eventPlanners'] as const;
 
 /** When eventPlanners is provided and non-empty, exactly one must have isLead true. */
@@ -329,9 +346,10 @@ const createBaseSchema = activityCoreFieldsSchema
  * Excludes auto-generated fields (id, displayId, audit fields, rowVersion).
  * Requires at least one Comms contact with exactly one marked as lead.
  */
-const SUMMARY_REQUIRED_MESSAGE = 'Summary is required.';
-
 export const createActivityRequestSchema = createBaseSchema
+  .extend({
+    commsContacts: createCommsContactsFieldSchema,
+  })
   .refine(createLeadContactRefine, {
     message: LEAD_CONTACT_REFINE_MESSAGE,
     path: [...LEAD_CONTACT_REFINE_PATH],
@@ -372,7 +390,7 @@ export const updateActivityRequestSchema = createBaseSchema
     (data) => !(data.markAsReviewed === true && data.markAsCompleted === true),
     {
       message:
-        'markAsReviewed and markAsCompleted are mutually exclusive; set at most one.',
+        'markAsReviewed and markAsCompleted are mutually exclusive; set at most one',
       path: ['markAsCompleted'],
     }
   );

--- a/packages/shared/src/schemas/activity.schema.ts
+++ b/packages/shared/src/schemas/activity.schema.ts
@@ -6,6 +6,10 @@ import {
   isActivityRichTextStorageRefine,
   plainTextFromActivityRichField,
 } from '../utils/activity-rich-text';
+import {
+  zodConstraintIssueParams,
+  zodRequiredIssueParams,
+} from '../validation/zod-issue-kind';
 
 /**
  * Activity Zod Schemas
@@ -13,6 +17,8 @@ import {
  * These schemas are source of truth for and define API request/response contracts.
  * The database schema (Drizzle) is the source of truth for DB types.
  * Compile-time checks in schema-helpers.ts ensure alignment.
+ *
+ * When adding required create/edit fields, see `src/validation/REQUIRED_FIELDS.md`.
  */
 
 // ============================================================================
@@ -64,6 +70,7 @@ const activityRichTextStoredStringSchema = z
   .max(ACTIVITY_RICH_TEXT_MAX_BYTES)
   .refine(isActivityRichTextStorageRefine, {
     message: ACTIVITY_RICH_TEXT_INVALID_STORAGE,
+    ...zodConstraintIssueParams(),
   });
 
 // ============================================================================
@@ -100,6 +107,7 @@ const activityCoreFieldsSchema = z.object({
           .max(ACTIVITY_RICH_TEXT_MAX_BYTES)
           .refine(isActivityRichTextStorageRefine, {
             message: ACTIVITY_RICH_TEXT_INVALID_STORAGE,
+            ...zodConstraintIssueParams(),
           }),
         z.null(),
       ])
@@ -147,6 +155,7 @@ const activityCoreFieldsSchema = z.object({
           .max(ACTIVITY_RICH_TEXT_MAX_BYTES)
           .refine(isActivityRichTextStorageRefine, {
             message: ACTIVITY_RICH_TEXT_INVALID_STORAGE,
+            ...zodConstraintIssueParams(),
           }),
         z.null(),
       ])
@@ -224,6 +233,7 @@ const representativeSchema = z
     {
       message:
         'Each representative must have a representativeId or a non-empty representativeName',
+      ...zodConstraintIssueParams(),
     }
   );
 
@@ -303,17 +313,21 @@ const createJunctionTableIdsSchema = junctionTableIdsSchema.extend({
 const createCommsContactsFieldSchema = z
   .array(commsContactSchema)
   .min(1, { message: LEAD_CONTACT_REFINE_MESSAGE })
-  .refine((contacts) => contacts.filter((c) => c.isLead).length === 1, {
-    message: LEAD_CONTACT_REFINE_MESSAGE,
-  })
+  .refine(
+    (contacts) =>
+      contacts.length === 0 || contacts.filter((c) => c.isLead).length === 1,
+    {
+      message: LEAD_CONTACT_REFINE_MESSAGE,
+      ...zodConstraintIssueParams(),
+    }
+  )
   .optional();
 
-/** Create: commsContacts must have at least one contact and exactly one lead. */
-function createLeadContactRefine(data: {
+/** Create: commsContacts must include at least one entry. */
+function createLeadContactPresenceRefine(data: {
   commsContacts?: Array<{ userId: number; isLead: boolean }>;
 }): boolean {
-  const contacts = data.commsContacts ?? [];
-  return contacts.length >= 1 && contacts.filter((c) => c.isLead).length === 1;
+  return (data.commsContacts ?? []).length >= 1;
 }
 
 /** Update: when commsContacts is provided and non-empty, exactly one must be lead. */
@@ -368,19 +382,22 @@ export const createActivityRequestSchema = createBaseSchema
   .extend({
     commsContacts: createCommsContactsFieldSchema,
   })
-  .refine(createLeadContactRefine, {
+  .refine(createLeadContactPresenceRefine, {
     message: LEAD_CONTACT_REFINE_MESSAGE,
     path: [...LEAD_CONTACT_REFINE_PATH],
+    ...zodRequiredIssueParams(),
   })
   .refine(eventPlannerLeadRefine, {
     message: EVENT_PLANNER_LEAD_REFINE_MESSAGE,
     path: [...EVENT_PLANNER_LEAD_REFINE_PATH],
+    ...zodConstraintIssueParams(),
   })
   .refine(
     (data) => plainTextFromActivityRichField(data.summary).trim().length > 0,
     {
       message: SUMMARY_REQUIRED_MESSAGE,
       path: ['summary'],
+      ...zodRequiredIssueParams(),
     }
   );
 
@@ -399,10 +416,12 @@ export const updateActivityRequestSchema = createBaseSchema
   .refine(updateLeadContactRefine, {
     message: LEAD_CONTACT_REFINE_MESSAGE,
     path: [...LEAD_CONTACT_REFINE_PATH],
+    ...zodConstraintIssueParams(),
   })
   .refine(eventPlannerLeadRefine, {
     message: EVENT_PLANNER_LEAD_REFINE_MESSAGE,
     path: [...EVENT_PLANNER_LEAD_REFINE_PATH],
+    ...zodConstraintIssueParams(),
   })
   .refine(
     (data) => !(data.markAsReviewed === true && data.markAsCompleted === true),
@@ -410,6 +429,7 @@ export const updateActivityRequestSchema = createBaseSchema
       message:
         'markAsReviewed and markAsCompleted are mutually exclusive; set at most one',
       path: ['markAsCompleted'],
+      ...zodConstraintIssueParams(),
     }
   );
 

--- a/packages/shared/src/utils/activity-field-labels.ts
+++ b/packages/shared/src/utils/activity-field-labels.ts
@@ -27,6 +27,9 @@ export type ActivityFieldLabelKey =
  * Form/API field keys that are required on create (matches createActivityRequestSchema
  * and comms lead rule). Visibility is omitted — it defaults to global in the schema.
  * Use for required indicators in the UI; keep in sync when validation changes.
+ *
+ * When adding a required field, also follow `src/validation/REQUIRED_FIELDS.md`
+ * (schema validation, `params.kind` on custom refines, label here, contract test).
  */
 export const ACTIVITY_CREATE_REQUIRED_FIELD_KEYS = [
   'categoryIds',

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './activity-form-canonicalize';
 export * from './activity-review-diff';
 export * from './apply-update-activity-request';
 export * from './activity-field-labels';
+export * from '../validation';
 export * from './build-review-diff-lookups';
 export * from './report-settings';
 export * from './redact-activity-response';

--- a/packages/shared/src/validation/REQUIRED_FIELDS.md
+++ b/packages/shared/src/validation/REQUIRED_FIELDS.md
@@ -1,0 +1,80 @@
+# Adding required activity form fields
+
+Activity create/edit forms show a sticky-bar hint (`"N more required fields"`) driven by
+`createActivityRequestSchema` / `updateActivityRequestSchema` and
+`isZodMissingRequiredIssue` (calendar-ui `form-utils.ts`).
+
+Classification uses **stable Zod issue metadata**, not validation message text.
+
+## Checklist when adding a required create field
+
+1. **Add schema validation** in `activity.schema.ts` (or the relevant request schema).
+2. **Choose how the empty state is detected** (see below).
+3. **Add a user-facing label** in `ACTIVITY_FIELD_LABELS` (`activity-field-labels.ts`).
+4. **Update `ACTIVITY_CREATE_REQUIRED_FIELD_KEYS`** if the field is required on create
+   (used for UI required indicators; keep in sync with the schema).
+5. **Add a contract test** in `activity.schema.spec.ts` or
+   `is-zod-missing-required-issue.spec.ts`: empty payload → `safeParse` fails → issue for
+   that field is classified as missing-required.
+6. **Rebuild `@corpcal/shared`** (`npm run build` in `packages/shared`) before running
+   calendar-ui tests — vitest resolves shared from `dist/esm`.
+
+## How issues are classified
+
+| Validation style                               | Issue signal                                | Counts as missing-required? |
+| ---------------------------------------------- | ------------------------------------------- | --------------------------- |
+| `z.string().min(1)`                            | `too_small`                                 | Yes (automatic)             |
+| `z.array(...).min(1)`                          | `too_small`                                 | Yes (automatic)             |
+| Required `z.number().int()` etc.               | `invalid_type`                              | Yes (automatic)             |
+| `z.string().max(n)` when too long              | `too_big`                                   | No (automatic)              |
+| Custom `.refine()` — field empty               | `custom` + `params: { kind: 'required' }`   | Yes                         |
+| Custom `.refine()` — value present but invalid | `custom` + `params: { kind: 'constraint' }` | No                          |
+
+Use helpers from `zod-issue-kind.ts`:
+
+```ts
+import {
+  zodRequiredIssueParams,
+  zodConstraintIssueParams,
+} from '../validation/zod-issue-kind';
+
+// Empty/missing required value (e.g. rich-text summary after plain-text check)
+.refine((data) => hasSummary(data), {
+  message: SUMMARY_REQUIRED_MESSAGE,
+  path: ['summary'],
+  ...zodRequiredIssueParams(),
+})
+
+// Structural rule when data is already provided (e.g. exactly one lead planner)
+.refine(eventPlannerLeadRefine, {
+  message: EVENT_PLANNER_LEAD_REFINE_MESSAGE,
+  path: ['eventPlanners'],
+  ...zodConstraintIssueParams(),
+})
+```
+
+For Zod v4, spread `zodRequiredIssueParams()` / `zodConstraintIssueParams()` into the
+refine options object. Each helper sets `params: { kind: 'required' | 'constraint' }`
+on the emitted issue (do not put `kind` at the top level of the refine options).
+
+## Same path, two failure modes
+
+Some fields fail in more than one way (e.g. `commsContacts`):
+
+- **Empty array / missing** → `.min(1)` → `too_small` → missing-required.
+- **Entries present but no lead** → separate `.refine()` with `kind: 'constraint'`.
+
+Do not use a single object-level refine for both cases unless you use `superRefine` and
+emit the correct `kind` per branch.
+
+## What you do not need to change
+
+- `calendar-ui/src/lib/form-utils.ts` — imports `isZodMissingRequiredIssue` from `@corpcal/shared/validation`.
+- `useActivityFormSubmitState.ts` — derives missing fields from live `safeParse`.
+
+## Related files
+
+- `packages/shared/src/validation/zod-issue-kind.ts` — `ZOD_ISSUE_KIND` constants
+- `packages/shared/src/validation/is-zod-missing-required-issue.ts` — classifier
+- `packages/shared/src/utils/activity-field-labels.ts` — labels and required-key list
+- `calendar-ui/src/lib/form-utils.ts` — maps classified issues to sticky-bar copy

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -1,0 +1,2 @@
+export * from './zod-issue-kind';
+export * from './is-zod-missing-required-issue';

--- a/packages/shared/src/validation/is-zod-missing-required-issue.spec.ts
+++ b/packages/shared/src/validation/is-zod-missing-required-issue.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { createActivityRequestSchema } from '../schemas/activity.schema';
+import {
+  isZodMissingRequiredIssue,
+  type ZodIssueLike,
+} from './is-zod-missing-required-issue';
+import {
+  getZodIssueKind,
+  ZOD_ISSUE_KIND,
+  zodConstraintIssueParams,
+  zodRequiredIssueParams,
+} from './zod-issue-kind';
+
+function minimalCreateRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Test Activity',
+    summary: 'Summary',
+    dateStatusId: 1,
+    timeStatusId: 1,
+    leadTeamId: 1,
+    leadMinistryId: 1,
+    categoryIds: [1],
+    commsContacts: [{ userId: 1, isLead: true }],
+    ...overrides,
+  };
+}
+
+function missingRequiredPaths(data: Record<string, unknown>): string[] {
+  const result = createActivityRequestSchema.safeParse(data);
+  if (result.success) return [];
+  return result.error.issues
+    .filter(isZodMissingRequiredIssue)
+    .map((issue) => issue.path[0])
+    .filter((path): path is string => typeof path === 'string');
+}
+
+function commsContactsIssues(data: Record<string, unknown>) {
+  const result = createActivityRequestSchema.safeParse(data);
+  if (result.success) return [];
+  return result.error.issues.filter(
+    (issue) => issue.path[0] === 'commsContacts'
+  );
+}
+
+describe('isZodMissingRequiredIssue', () => {
+  it('classifies built-in too_small and invalid_type as missing-required', () => {
+    const schema = z.object({
+      title: z.string().min(1),
+      leadTeamId: z.number().int(),
+    });
+    const result = schema.safeParse({ title: '', leadTeamId: undefined });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    for (const issue of result.error.issues) {
+      expect(isZodMissingRequiredIssue(issue)).toBe(true);
+    }
+  });
+
+  it('excludes too_big length violations', () => {
+    const schema = z.object({ title: z.string().max(5) });
+    const result = schema.safeParse({ title: 'too long title' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(isZodMissingRequiredIssue(result.error.issues[0])).toBe(false);
+  });
+
+  it('keys off params.kind for custom refines', () => {
+    const schema = z
+      .object({ name: z.string() })
+      .refine((data) => data.name.length > 0, {
+        message: 'Name is required',
+        path: ['name'],
+        ...zodRequiredIssueParams(),
+      })
+      .refine((data) => data.name !== 'bad', {
+        message: 'Name is invalid',
+        path: ['name'],
+        ...zodConstraintIssueParams(),
+      });
+
+    const empty = schema.safeParse({ name: '' });
+    expect(empty.success).toBe(false);
+    if (empty.success) return;
+    expect(empty.error.issues.some(isZodMissingRequiredIssue)).toBe(true);
+
+    const invalid = schema.safeParse({ name: 'bad' });
+    expect(invalid.success).toBe(false);
+    if (invalid.success) return;
+    expect(
+      invalid.error.issues.every((issue) => !isZodMissingRequiredIssue(issue))
+    ).toBe(true);
+  });
+});
+
+describe('createActivityRequestSchema missing-required contract', () => {
+  it('includes summary when empty', () => {
+    expect(
+      missingRequiredPaths(minimalCreateRequest({ summary: '' }))
+    ).toContain('summary');
+  });
+
+  it('excludes max-length title failures', () => {
+    expect(
+      missingRequiredPaths(minimalCreateRequest({ title: 'a'.repeat(256) }))
+    ).toEqual([]);
+  });
+
+  it('excludes event-planner lead constraint failures', () => {
+    expect(
+      missingRequiredPaths(
+        minimalCreateRequest({
+          eventPlanners: [{ eventPlannerName: 'Planner A', isLead: false }],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it('includes commsContacts when empty or omitted but not when lead is missing', () => {
+    expect(
+      missingRequiredPaths(minimalCreateRequest({ commsContacts: [] }))
+    ).toContain('commsContacts');
+
+    const withoutComms = minimalCreateRequest();
+    delete (withoutComms as Record<string, unknown>).commsContacts;
+    expect(missingRequiredPaths(withoutComms)).toContain('commsContacts');
+
+    expect(
+      missingRequiredPaths(
+        minimalCreateRequest({
+          commsContacts: [{ userId: 1, isLead: false }],
+        })
+      )
+    ).not.toContain('commsContacts');
+  });
+
+  it('emits no constraint issues for empty commsContacts', () => {
+    const issues = commsContactsIssues(
+      minimalCreateRequest({ commsContacts: [] })
+    );
+    expect(issues.every((issue) => isZodMissingRequiredIssue(issue))).toBe(
+      true
+    );
+    expect(
+      issues.some(
+        (issue) =>
+          getZodIssueKind(issue as ZodIssueLike) === ZOD_ISSUE_KIND.CONSTRAINT
+      )
+    ).toBe(false);
+  });
+
+  it('emits a single constraint issue when commsContacts has no lead', () => {
+    const issues = commsContactsIssues(
+      minimalCreateRequest({
+        commsContacts: [{ userId: 1, isLead: false }],
+      })
+    );
+    expect(issues).toHaveLength(1);
+    expect(getZodIssueKind(issues[0] as ZodIssueLike)).toBe(
+      ZOD_ISSUE_KIND.CONSTRAINT
+    );
+    expect(isZodMissingRequiredIssue(issues[0] as ZodIssueLike)).toBe(false);
+  });
+});

--- a/packages/shared/src/validation/is-zod-missing-required-issue.ts
+++ b/packages/shared/src/validation/is-zod-missing-required-issue.ts
@@ -1,0 +1,32 @@
+import {
+  getZodIssueKind,
+  ZOD_ISSUE_KIND,
+  type ZodIssueKind,
+} from './zod-issue-kind';
+
+export type ZodIssueLike = {
+  path: ReadonlyArray<PropertyKey>;
+  code?: string;
+  message?: unknown;
+  params?: unknown;
+};
+
+/**
+ * True when a Zod issue represents an empty/missing required value.
+ *
+ * Classification order:
+ * 1. `params.kind` from shared schema refines (`required` vs `constraint`)
+ * 2. Built-in Zod codes: `too_small` and `invalid_type` (e.g. `.min(1)`, required types)
+ * 3. Excludes length violations (`too_big`, `too_long`) and untagged `custom` issues
+ */
+export function isZodMissingRequiredIssue(issue: ZodIssueLike): boolean {
+  const kind: ZodIssueKind | undefined = getZodIssueKind(issue);
+  if (kind === ZOD_ISSUE_KIND.CONSTRAINT) return false;
+  if (kind === ZOD_ISSUE_KIND.REQUIRED) return true;
+
+  const code = issue.code;
+  if (code === 'too_big' || code === 'too_long') return false;
+  if (code === 'too_small' || code === 'invalid_type') return true;
+
+  return false;
+}

--- a/packages/shared/src/validation/zod-issue-kind.ts
+++ b/packages/shared/src/validation/zod-issue-kind.ts
@@ -1,0 +1,45 @@
+/**
+ * Stable discriminators for Zod custom issues.
+ *
+ * Activity form submit-gating (`isZodMissingRequiredIssue` in calendar-ui) keys off
+ * `params.kind` instead of validation message text. See REQUIRED_FIELDS.md when adding
+ * required create/edit fields.
+ */
+export const ZOD_ISSUE_KIND = {
+  /** Empty or absent value for a required field (counts toward "N more required fields"). */
+  REQUIRED: 'required',
+  /**
+   * Value is present but fails a structural/business rule (e.g. exactly one lead planner).
+   * Does not count toward the missing-required-fields hint.
+   */
+  CONSTRAINT: 'constraint',
+} as const;
+
+export type ZodIssueKind = (typeof ZOD_ISSUE_KIND)[keyof typeof ZOD_ISSUE_KIND];
+
+export type ZodIssueParams = {
+  kind?: ZodIssueKind;
+};
+
+/** Reads `params.kind` from a Zod issue when present. */
+export function getZodIssueKind(issue: {
+  params?: unknown;
+}): ZodIssueKind | undefined {
+  const params = issue.params;
+  if (!params || typeof params !== 'object') return undefined;
+  const kind = (params as ZodIssueParams).kind;
+  if (kind === ZOD_ISSUE_KIND.REQUIRED || kind === ZOD_ISSUE_KIND.CONSTRAINT) {
+    return kind;
+  }
+  return undefined;
+}
+
+/** Refine options fragment: tags the issue as empty/missing required. */
+export function zodRequiredIssueParams(): { params: ZodIssueParams } {
+  return { params: { kind: ZOD_ISSUE_KIND.REQUIRED } };
+}
+
+/** Refine options fragment: tags the issue as a structural constraint violation. */
+export function zodConstraintIssueParams(): { params: ZodIssueParams } {
+  return { params: { kind: ZOD_ISSUE_KIND.CONSTRAINT } };
+}


### PR DESCRIPTION
# PR: feat/CORPCAL-254-activity-form-polish

## Summary

Polishes activity create/edit UX: clearer validation feedback, consistent submit gating, and a tidier activity page header. Shared Zod schema messages and field-level rules now drive both inline errors and the sticky footer state.

## Important

- `npm run build:packages`
- no schema changes or new deps 


<img width="1600" height="228" alt="Screenshot 2026-06-11 at 12 41 11 AM" src="https://github.com/user-attachments/assets/83120856-2de6-425c-8bbe-3e31e4f960df" />

<img width="1472" height="167" alt="Screenshot 2026-06-11 at 12 51 10 AM" src="https://github.com/user-attachments/assets/30d87224-6a38-484a-9de0-5428ea2b00b6" />

<img width="674" height="133" alt="Screenshot 2026-06-11 at 12 51 19 AM" src="https://github.com/user-attachments/assets/26c35063-9a26-4800-a60a-c5b85489d143" />


## Changes

1. **Submit gating:** centralize create/edit footer logic in `useActivityFormSubmitState`.
   - Live `safeParse` keeps the sticky bar in sync while typing.
   - Inline errors stay deferred until submit or field touch.

2. **Missing-fields hint:** add `ActivityFormMissingFieldsHint` with softer copy and hover/tap popover.
   - Lists remaining required fields without blocking the footer layout.

3. **Validation schema:** improve activity Zod messages and required-field detection.
   - Consistent max-length and required copy.
   - Field-level `commsContacts` validation for create flows.

4. **Form UI:** tighten label/error display in shared form components.
   - Missing-field helper text and error styling align across create and edit.

5. **Activity page header:** refactor layout for display ID, status, timestamps, and actions.
   - Extract shared `ActivityFlagIcon` for list and header parity.

6. **Tests:** cover submit state, form utils, schema messages, and activity page regressions.

## Testing

- `npm run test -- --run calendar-ui/src/hooks/useActivityFormSubmitState.test.tsx calendar-ui/src/lib/form-utils.test.ts`
- calendar-ui suite: 505 passed
- Manual: create/edit activity — footer disabled until valid; info popover lists missing fields; header flag matches list styling
