### PR TITLE
Fix/corpcal 246 report filters

### DIFF
--- a/calendar-ui/src/api/reportsApi.spec.ts
+++ b/calendar-ui/src/api/reportsApi.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchReportData } from './reportsApi';
+
+const mockGet = vi.fn();
+
+vi.mock('./axios', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+describe('fetchReportData', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGet.mockResolvedValue({
+      data: { report: { name: 'exec' }, sections: [] },
+    });
+  });
+
+  it('serializes array filter params as comma-separated strings', async () => {
+    await fetchReportData('exec', {
+      includeCompleted: false,
+      activityStatusIds: [1, 2],
+      categoryNames: ['Event', 'FYI'],
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/reports/data/exec', {
+      params: {
+        includeCompleted: false,
+        activityStatusIds: '1,2',
+        categoryNames: 'Event,FYI',
+      },
+    });
+  });
+});

--- a/calendar-ui/src/api/reportsApi.ts
+++ b/calendar-ui/src/api/reportsApi.ts
@@ -3,7 +3,10 @@ import type {
   ReportDataResponse,
   ReportSectionData,
 } from '@corpcal/shared/api/types';
-import type { ReportDataQueryParams } from '@corpcal/shared/schemas';
+import {
+  serializeFilterActivitiesQueryParams,
+  type ReportDataQueryParams,
+} from '@corpcal/shared/schemas';
 
 import api from './axios';
 
@@ -18,12 +21,19 @@ export type ReportDataRequestParams = Partial<ReportDataQueryParams>;
  */
 const REPORT_PDF_EXPORT_TIMEOUT_MS = 60_000;
 
+/** Axios bracket-array encoding is not parsed by report query schemas; use comma-separated IDs. */
+function serializeReportDataQueryParams(
+  params?: ReportDataRequestParams
+): Record<string, string | number | boolean | undefined> {
+  return serializeFilterActivitiesQueryParams(params);
+}
+
 export async function fetchReportData(
   type: string,
   params?: ReportDataRequestParams
 ): Promise<ReportDataResponse> {
   const response = await api.get<ReportDataResponse>(`/reports/data/${type}`, {
-    params,
+    params: serializeReportDataQueryParams(params),
   });
   return response.data;
 }
@@ -34,7 +44,7 @@ async function downloadReportFile(
   params?: ReportDataRequestParams
 ): Promise<void> {
   const response = await api.get(`/reports/export/${type}/${ext}`, {
-    params,
+    params: serializeReportDataQueryParams(params),
     responseType: 'blob',
     timeout: ext === 'pdf' ? REPORT_PDF_EXPORT_TIMEOUT_MS : undefined,
   });


### PR DESCRIPTION
## Summary

Axios was sending array params as activityStatusIds[]=1, which the report API’s Zod schema doesn’t parse, so Status (and other multi-select filters) were ignored server-side.

## Changes

Report fetch and export now use the same serializeFilterActivitiesQueryParams helper as the activities API, producing comma-separated values

- serialize array params as comma-separated strings in reportsApi fetch and export
- reuse serializeFilterActivitiesQueryParams so status and multi-select filters apply
- add reportsApi unit test to prevent axios bracket-array regression

## Test
- regression test added to reportApi.spec passing
- manual smoke test of report filters work as expected