### PR TITLE
fix(build): remove conditional sercret check

### DIFF
--- a/.github/workflows/update-calendar-ui-config.yml
+++ b/.github/workflows/update-calendar-ui-config.yml
@@ -55,10 +55,13 @@ jobs:
           oc rollout status deployment/calendar-ui -w
 
       - name: Smoke-check config.js served (optional)
-        if: ${{ secrets.CALENDAR_UI_URL }}
         env:
           CALENDAR_UI_URL: ${{ secrets.CALENDAR_UI_URL }}
         run: |
+          if [ -z "$CALENDAR_UI_URL" ]; then
+            echo "Skipping smoke check (CALENDAR_UI_URL secret not set)"
+            exit 0
+          fi
           echo "Checking $CALENDAR_UI_URL/config.js"
           curl -fsS "$CALENDAR_UI_URL/config.js" | head -n 5
 


### PR DESCRIPTION
## Summary

Fixes failing syntax in .github/workflows/update-calendar-ui-config.yml causing the run to fail

- Actions does not allow the secrets context in if expressions
- Removed the if: line and handle the optional check in an added shell script
- Secret is still passed via env, which is allowed
- If unset or empty, the step prints a skip message and exits successfully

## Testing

- Only tested that the syntax passes
- Untested that the config file is working successfully to connect Snowplow