### PR TITLE
Refactor/corpcal 254 centralize activity form section registry

### DIFF
--- a/calendar-service/docs/ACTIVITY.md
+++ b/calendar-service/docs/ACTIVITY.md
@@ -8,6 +8,7 @@ This is the root document for activity-domain service docs. Use it as the entry 
 - [ACTIVITY_EDIT_ELIGIBILITY.md](./ACTIVITY_EDIT_ELIGIBILITY.md) - who may edit, permission guards, and related UI/API edit constraints.
 - [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) - "changed since last review" snapshot model, versioning, diff behavior, and backfill details.
 - [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md) - review-exempt fields (code + admin settings, API, UI, and maintenance when the form changes).
+- [ACTIVITY_FORM_SECTIONS.md](../../packages/shared/docs/ACTIVITY_FORM_SECTIONS.md) - canonical form section order, labels, and field membership (shared registry for review-exempt, clone modal, and UI).
 
 ## Field-Add Playbook (Activity Form)
 
@@ -18,13 +19,15 @@ Use this checklist whenever you add, remove, rename, or materially change an `Ac
 3. Set the canonical empty value in `packages/shared/src/utils/activity-review-diff.ts` (`getEmptyReviewBaseline`).
 4. Confirm canonicalization/diff behavior in `packages/shared/src/utils/activity-form-canonicalize.ts` and `packages/shared/src/utils/activity-review-diff.ts` (`diffReviewFields`) matches intended semantics (ordering, null/empty normalization, object keying).
 5. If the field has a user-visible review badge label/path mapping, update `packages/shared/src/utils/activity-field-labels.ts`.
-6. **Review impact (review-exempt list):** If the new field is a **top-level** `ActivityFormData` key, decide whether it should ever be **review-exempt** (edits that do not force Reviewed → Changed or show in `changedFieldsSinceReview`). Update `packages/shared/src/review-exempt-settings.ts`:
-   - If it should be **configurable** by System Admins in Settings, add it to the appropriate `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` group (order aligned with `ActivityFormBody` / section components in `calendar-ui`). Ensure it is **not** listed in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` if admins should control it.
-   - If it should **always** be exempt (product rule, not admin-toggleable), add it to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and do **not** add it to the configurable sections. Rebuild `@corpcal/shared` so `review-exempt-field-keys.schema.ts` stays aligned.
+6. **Form section registry:** Add or move the top-level key in `packages/shared/src/activity-form-sections.ts` and the matching `Activity*Section` component. See `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md`.
+7. **Review impact (review-exempt list):** If the new field is a **top-level** `ActivityFormData` key, decide whether it should ever be **review-exempt** (edits that do not force Reviewed → Changed or show in `changedFieldsSinceReview`):
+   - If it should be **configurable** by System Admins in Settings, list it in the registry and ensure it is **not** in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`. The admin UI grouping is derived automatically.
+   - If it should **always** be exempt (product rule, not admin-toggleable), add it to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` in `review-exempt-settings.ts`. It may remain in the registry for documentation; it will not appear in Settings.
    - If the field must **never** be exempt (e.g. primary content or compliance-sensitive), do not add it to either list; it will always affect review state when it changes. Fields that are **system-only** in the diff (see `EXCLUDED_FIELDS` in `activity-review-diff.ts`) are not admin options.
-7. For full details and API reference, see [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md).
-8. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
-9. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
+8. **Clone modal:** If the field is optional on clone, ensure clone exclusions in `packages/shared/src/schemas/clone-activity.schema.ts` are correct (`CLONE_NEVER_COPIED_FIELD_KEYS`, etc.). Advanced field groups are derived from the section registry.
+9. For full details and API reference, see [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md).
+10. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
+11. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
 
 ### When to update `buildReviewDiffLookups()`
 

--- a/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
+++ b/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
@@ -23,19 +23,20 @@ It complements [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) (sna
 
 ## UI
 
-- **Settings** page, section “Review-exempt fields”: `ReviewExemptFieldsSettingsAdmin` in `calendar-ui` renders `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` as grouped checkboxes; labels use `getActivityFieldLabel` / `ACTIVITY_FIELD_LABELS` from shared.
+- **Settings** page, section “Review-exempt fields”: `ReviewExemptFieldsSettingsAdmin` in `calendar-ui` renders `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` (derived from `activity-form-sections.ts`) in a grouped combobox; labels use `getActivityFieldLabel` / `ACTIVITY_FIELD_LABELS` from shared.
 
 ## When you change the activity form or schema
 
-Adding, removing, or renaming a **top-level** `ActivityFormData` field that should be **available** in the admin “review-exempt” list (or that must be **code**-exempt) requires **manual** updates in shared—there is no codegen from the Zod form schema today. Follow the [Field-Add Playbook in ACTIVITY.md](./ACTIVITY.md#field-add-playbook-activity-form), including the review-exempt step.
+Adding, removing, or renaming a **top-level** `ActivityFormData` field that should be **available** in the admin “review-exempt” list (or that must be **code**-exempt) requires updates in shared—there is no codegen from the Zod form schema today. Follow the [Field-Add Playbook in ACTIVITY.md](./ACTIVITY.md#field-add-playbook-activity-form), including the section registry and review-exempt steps. See also [ACTIVITY_FORM_SECTIONS.md](../../packages/shared/docs/ACTIVITY_FORM_SECTIONS.md).
 
 **Files to touch (review-exempt-specific):**
 
-| File                                                             | What to do                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/shared/src/review-exempt-settings.ts`                  | For a new **configurable** field: add the key to the correct entry in `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` (and ensure it is not in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` unless it should be fixed in code). For a new **code-only** exempt field: add to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and **remove** it from the configurable section list if it was listed. |
-| `packages/shared/src/schemas/review-exempt-field-keys.schema.ts` | The allowlist is derived from the same configurable keys; ensure the `z.enum` input stays consistent after edits to `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS` (rebuild shared).                                                                                                                                                                                            |
-| `packages/shared/src/utils/activity-review-diff.ts`              | If the field affects `getEmptyReviewBaseline` or comparison rules, follow the main playbook.                                                                                                                                                                                                                                                                                |
+| File                                                             | What to do                                                                                                                                                              |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/shared/src/activity-form-sections.ts`                  | Add or move the field under the correct section. This drives admin UI grouping and clone modal sections.                                                                |
+| `packages/shared/src/review-exempt-settings.ts`                  | For a new **code-only** exempt field: add to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`. Configurable keys are derived from the section registry (filtered by code-exempt set). |
+| `packages/shared/src/schemas/review-exempt-field-keys.schema.ts` | The allowlist is derived from the same configurable keys; rebuild `@corpcal/shared` after registry changes.                                                             |
+| `packages/shared/src/utils/activity-review-diff.ts`              | If the field affects `getEmptyReviewBaseline` or comparison rules, follow the main playbook.                                                                            |
 
 **Deployment:** no extra migration for the setting row beyond seed; if you add new allowed keys, existing DB values remain valid; unknown keys in stored JSON are stripped on read/save.
 

--- a/calendar-ui/src/components/activity/activities/CloneActivityModal.tsx
+++ b/calendar-ui/src/components/activity/activities/CloneActivityModal.tsx
@@ -59,15 +59,6 @@ function resolveNotConfirmedStatusId<
   return firstByDisplay?.id;
 }
 
-const SECTION_LABELS: Record<CloneAdvancedSection, string> = {
-  overview: ACTIVITY_FORM_SECTION_LABELS.overview,
-  comms: ACTIVITY_FORM_SECTION_LABELS.comms,
-  reports: ACTIVITY_FORM_SECTION_LABELS.reports,
-  schedule: ACTIVITY_FORM_SECTION_LABELS.schedule,
-  event: ACTIVITY_FORM_SECTION_LABELS.event,
-  sharing: ACTIVITY_FORM_SECTION_LABELS.sharing,
-};
-
 /**
  * Map each clone advanced field path to the field-level scope that governs
  * edit permission. Unlisted paths are always allowed (no scope gating).
@@ -570,7 +561,7 @@ export function CloneActivityModal({
                     return (
                       <div key={section} className="space-y-2">
                         <p className="text-xs font-semibold tracking-wide uppercase">
-                          {SECTION_LABELS[section]}
+                          {ACTIVITY_FORM_SECTION_LABELS[section]}
                         </p>
                         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                           {paths.map((path) => {

--- a/calendar-ui/src/lib/activity-form-section-labels.ts
+++ b/calendar-ui/src/lib/activity-form-section-labels.ts
@@ -1,29 +1,9 @@
 /**
- * Section IDs for the activity form. Matches the logical grouping of fields.
+ * Re-exported from `@corpcal/shared`. Section registry: `activity-form-sections.ts`.
+ * See `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md` when changing form layout.
  */
-export type ActivityFormSectionId =
-  | 'overview'
-  | 'comms'
-  | 'newsRelease'
-  | 'reports'
-  | 'schedule'
-  | 'event'
-  | 'sharing'
-  | 'venue';
-
-/**
- * User-facing labels for activity form sections. Single source of truth for section titles.
- */
-export const ACTIVITY_FORM_SECTION_LABELS: Record<
-  ActivityFormSectionId,
-  string
-> = {
-  overview: 'Overview',
-  comms: 'Comms',
-  newsRelease: 'Release',
-  reports: 'Reports',
-  schedule: 'Schedule',
-  event: 'Event',
-  sharing: 'Sharing',
-  venue: 'Venue',
-};
+export {
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_LABELS,
+  type ActivityFormSectionId,
+} from '@corpcal/shared';

--- a/packages/shared/docs/ACTIVITY_FORM_SECTIONS.md
+++ b/packages/shared/docs/ACTIVITY_FORM_SECTIONS.md
@@ -1,0 +1,50 @@
+# Activity form sections
+
+Canonical section order, labels, and field membership live in:
+
+`packages/shared/src/activity-form-sections.ts`
+
+The activity form UI is composed in `calendar-ui/src/components/activity/ActivityFormBody.tsx` using one component per section under `ActivityFormSections/`.
+
+## When you change the form
+
+1. **Update the registry** — add/move/remove the top-level `ActivityFormData` key under the correct section in `ACTIVITY_FORM_SECTION_FIELDS`. Adjust `ACTIVITY_FORM_SECTION_IDS` and `ACTIVITY_FORM_SECTION_LABELS` if you add or rename a section.
+2. **Update the section component** — render the field in the matching `Activity*Section.tsx` file.
+3. **Update `ActivityFormBody`** — if section order or column layout changes.
+4. **Review-exempt** — if the field should be admin-configurable, ensure it is listed in the registry and **not** in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` (`review-exempt-settings.ts`). The admin UI grouping is derived automatically.
+5. **Clone modal** — optional advanced fields are derived from the registry minus exclusions in `clone-activity.schema.ts` (`CLONE_NEVER_COPIED_FIELD_KEYS`, etc.). Add clone-specific exclusions there; do not duplicate section lists.
+6. **Run tests** — `npm test -- activity-form-sections` in `packages/shared`.
+
+## Derived consumers (do not duplicate section lists)
+
+| Consumer                              | Source                                                      |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Review-exempt Settings combobox       | `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS`              |
+| Clone modal “More options” checkboxes | `CLONE_ADVANCED_SECTIONS` / `CLONE_ADVANCED_FIELD_GROUPS`   |
+| Section headings in form components   | `ACTIVITY_FORM_SECTION_LABELS` (re-exported in calendar-ui) |
+
+## Section order (current)
+
+| Column | Sections                                       |
+| ------ | ---------------------------------------------- |
+| Left   | Overview → Comms                               |
+| Right  | Reports → Schedule → Release → Event → Sharing |
+
+## Notes
+
+- **`newsReleaseId`** — still on `ActivityFormData` but not rendered in the form; listed under Release for review-exempt configurability only. Excluded from clone advanced options in `clone-activity.schema.ts`.
+- **Nested paths** (e.g. `venueAddress.city`) are not listed here; clone/review use top-level keys (`venueAddress`) where applicable.
+- **Code-exempt review fields** (`ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`) remain in the registry but are filtered out of the admin Settings UI.
+
+## Keys intentionally omitted from the registry
+
+These top-level `ActivityFormData` keys are listed in `ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS` and must not appear in any section. A compile-time and runtime test in `activity-form-sections.test.ts` fails if a schema key is missing from both the registry and this list.
+
+| Key                    | Reason                                                     |
+| ---------------------- | ---------------------------------------------------------- |
+| `activityStatusId`     | Backend-owned status; excluded from review diff            |
+| `markAsReviewed`       | Create/clone workflow flag, not a form section field       |
+| `markAsCompleted`      | Complete workflow flag, not a form section field           |
+| `activityHistoryNotes` | Audit/history note on create or clone, not the main form   |
+| `commsContactLeadId`   | UI convenience; submitted as `commsContacts` with `isLead` |
+| `leadMinistryId`       | Derived from lead team ministry                            |

--- a/packages/shared/src/activity-form-sections.test.ts
+++ b/packages/shared/src/activity-form-sections.test.ts
@@ -12,30 +12,12 @@ import {
   ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS,
   ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS,
 } from './review-exempt-settings';
-import {
-  createActivityRequestSchema,
-  type ActivityFormData,
-} from './schemas/activity.schema';
+import { createActivityRequestSchema } from './schemas/activity.schema';
 import {
   CLONE_ADVANCED_FIELD_GROUPS,
   CLONE_ADVANCED_FIELD_PATHS,
   CLONE_ADVANCED_SECTIONS,
 } from './schemas/clone-activity.schema';
-
-type RegistryFieldKey = {
-  [Section in (typeof ACTIVITY_FORM_SECTION_IDS)[number]]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
-}[(typeof ACTIVITY_FORM_SECTION_IDS)[number]];
-
-type UnaccountedActivityFormKey = Exclude<
-  keyof ActivityFormData,
-  | RegistryFieldKey
-  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
->;
-
-/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
-const _registryCompleteness: UnaccountedActivityFormKey extends never
-  ? true
-  : UnaccountedActivityFormKey = true;
 
 describe('activity-form-sections', () => {
   it('uses unique field keys across sections', () => {
@@ -145,5 +127,3 @@ describe('activity-form-sections', () => {
     );
   });
 });
-
-void _registryCompleteness;

--- a/packages/shared/src/activity-form-sections.test.ts
+++ b/packages/shared/src/activity-form-sections.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS,
+  getActivityFormSectionFieldKeys,
+  getActivityFormSectionFieldKeySet,
+} from './activity-form-sections';
+import {
+  ACTIVITY_REVIEW_EXEMPT_CODE_KEYS,
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS,
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS,
+} from './review-exempt-settings';
+import {
+  createActivityRequestSchema,
+  type ActivityFormData,
+} from './schemas/activity.schema';
+import {
+  CLONE_ADVANCED_FIELD_GROUPS,
+  CLONE_ADVANCED_FIELD_PATHS,
+  CLONE_ADVANCED_SECTIONS,
+} from './schemas/clone-activity.schema';
+
+type RegistryFieldKey = {
+  [Section in (typeof ACTIVITY_FORM_SECTION_IDS)[number]]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
+}[(typeof ACTIVITY_FORM_SECTION_IDS)[number]];
+
+type UnaccountedActivityFormKey = Exclude<
+  keyof ActivityFormData,
+  | RegistryFieldKey
+  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
+>;
+
+/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
+const _registryCompleteness: UnaccountedActivityFormKey extends never
+  ? true
+  : UnaccountedActivityFormKey = true;
+
+describe('activity-form-sections', () => {
+  it('uses unique field keys across sections', () => {
+    const keys = getActivityFormSectionFieldKeys();
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('accounts for every ActivityFormData key via registry or omitted list', () => {
+    const registryKeys = getActivityFormSectionFieldKeySet();
+    const omittedKeys = new Set(
+      ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS.map(String)
+    );
+    const schemaKeys = Object.keys(createActivityRequestSchema.shape);
+
+    expect(registryKeys.size + omittedKeys.size).toBe(schemaKeys.length);
+    for (const key of schemaKeys) {
+      expect(registryKeys.has(key) || omittedKeys.has(key)).toBe(true);
+    }
+    for (const key of registryKeys) {
+      expect(omittedKeys.has(key)).toBe(false);
+    }
+  });
+
+  it('derives review-exempt sections in form order with Release after Schedule', () => {
+    const sectionIds = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.map(
+      (s) => s.id
+    );
+    expect(sectionIds).toEqual([
+      'overview',
+      'comms',
+      'reports',
+      'schedule',
+      'newsRelease',
+      'event',
+      'sharing',
+    ]);
+  });
+
+  it('places release fields under newsRelease, not comms', () => {
+    const commsKeys =
+      ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.find((s) => s.id === 'comms')
+        ?.keys ?? [];
+    const releaseKeys =
+      ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.find(
+        (s) => s.id === 'newsRelease'
+      )?.keys ?? [];
+
+    expect(commsKeys).toEqual([
+      'commsContacts',
+      'strategy',
+      'commsMaterialIds',
+    ]);
+    expect(releaseKeys).toEqual([
+      'newsReleaseId',
+      'newsReleaseOriginId',
+      'newsReleaseDistributionId',
+      'translationsRequiredStatusId',
+      'translationLanguageIds',
+    ]);
+  });
+
+  it('derives review-exempt keys from registry minus code-exempt keys', () => {
+    const expected = ACTIVITY_FORM_SECTION_IDS.flatMap((id) =>
+      ACTIVITY_FORM_SECTION_FIELDS[id].filter(
+        (key) => !ACTIVITY_REVIEW_EXEMPT_CODE_KEYS.has(String(key))
+      )
+    ).map(String);
+    expect([...ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS]).toEqual(expected);
+  });
+
+  it('derives clone advanced field groups from registry minus clone exclusions', () => {
+    expect(CLONE_ADVANCED_SECTIONS).toEqual([
+      'overview',
+      'comms',
+      'reports',
+      'schedule',
+      'newsRelease',
+      'event',
+      'sharing',
+    ]);
+    expect(CLONE_ADVANCED_FIELD_GROUPS).toEqual({
+      overview: [
+        'tagIds',
+        'leadOrgId',
+        'leadOrgName',
+        'significance',
+        'isIssue',
+        'isConfidential',
+        'notes',
+      ],
+      comms: ['strategy', 'commsMaterialIds'],
+      reports: ['reportSettings'],
+      schedule: ['schedulingNotes'],
+      newsRelease: ['newsReleaseOriginId', 'newsReleaseDistributionId'],
+      event: [
+        'venueStatusId',
+        'venueAddress',
+        'premierRequestedId',
+        'representatives',
+        'eventPlanners',
+      ],
+      sharing: ['visibility', 'sharedWithTeamIds'],
+    });
+    expect(CLONE_ADVANCED_FIELD_PATHS).not.toContain('newsReleaseId');
+    expect(CLONE_ADVANCED_FIELD_PATHS).not.toContain(
+      'translationsRequiredStatusId'
+    );
+  });
+});
+
+void _registryCompleteness;

--- a/packages/shared/src/activity-form-sections.ts
+++ b/packages/shared/src/activity-form-sections.ts
@@ -1,0 +1,131 @@
+import type { ActivityFormData } from './schemas/activity.schema';
+
+/**
+ * Canonical activity form section registry.
+ *
+ * Single source of truth for section order, labels, and top-level field membership.
+ * Mirrors `ActivityFormBody` in calendar-ui and the `Activity*Section` components.
+ *
+ * Downstream consumers derive their groupings from here:
+ * - Review-exempt admin UI — `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` in
+ *   `review-exempt-settings.ts` (filters out code-exempt keys).
+ * - Clone modal advanced options — `CLONE_ADVANCED_*` in `clone-activity.schema.ts`
+ *   (filters out clone-specific exclusions).
+ *
+ * When the form changes, update this file first, then the matching section component
+ * in `calendar-ui/src/components/activity/ActivityFormSections/`. See
+ * `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md`.
+ */
+
+/** Section order as rendered in the activity form (left column, then right). */
+export const ACTIVITY_FORM_SECTION_IDS = [
+  'overview',
+  'comms',
+  'reports',
+  'schedule',
+  'newsRelease',
+  'event',
+  'sharing',
+] as const;
+
+export type ActivityFormSectionId = (typeof ACTIVITY_FORM_SECTION_IDS)[number];
+
+/** User-facing section titles. */
+export const ACTIVITY_FORM_SECTION_LABELS: Record<
+  ActivityFormSectionId,
+  string
+> = {
+  overview: 'Overview',
+  comms: 'Comms',
+  reports: 'Reports',
+  schedule: 'Schedule',
+  newsRelease: 'Release',
+  event: 'Event',
+  sharing: 'Sharing',
+};
+
+/**
+ * Top-level `ActivityFormData` keys owned by each section.
+ * Include code-exempt or clone-excluded keys here for completeness; consumers filter.
+ */
+export const ACTIVITY_FORM_SECTION_FIELDS: Record<
+  ActivityFormSectionId,
+  readonly (keyof ActivityFormData)[]
+> = {
+  overview: [
+    'title',
+    'categoryIds',
+    'tagIds',
+    'leadTeamId',
+    'leadOrgId',
+    'leadOrgName',
+    'significance',
+    'isIssue',
+    'isConfidential',
+    'summary',
+    'notes',
+    'pitchRequiredStatusId',
+    'pitchDate',
+  ],
+  comms: ['commsContacts', 'strategy', 'commsMaterialIds'],
+  reports: [
+    'reportSettings',
+    'executiveSummary',
+    'lookAheadStatus',
+    'lookAheadSection',
+  ],
+  schedule: [
+    'startDate',
+    'endDate',
+    'startTime',
+    'endTime',
+    'isAllDay',
+    'dateStatusId',
+    'timeStatusId',
+    'schedulingNotes',
+  ],
+  newsRelease: [
+    'newsReleaseId',
+    'newsReleaseOriginId',
+    'newsReleaseDistributionId',
+    'translationsRequiredStatusId',
+    'translationLanguageIds',
+  ],
+  event: [
+    'venueStatusId',
+    'venueAddress',
+    'premierRequestedId',
+    'representatives',
+    'eventPlanners',
+  ],
+  sharing: ['visibility', 'sharedWithTeamIds'],
+};
+
+/**
+ * Top-level `ActivityFormData` keys intentionally omitted from the section registry.
+ * System-owned, derived, or UI-only convenience fields — not grouped in the form.
+ */
+export const ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS = [
+  'activityStatusId',
+  'markAsCompleted',
+  'markAsReviewed',
+  'activityHistoryNotes',
+  'commsContactLeadId',
+  'leadMinistryId',
+] as const satisfies readonly (keyof ActivityFormData)[];
+
+/** Flat list of all section field keys in section order (each key appears at most once). */
+export function getActivityFormSectionFieldKeys(): readonly string[] {
+  const keys: string[] = [];
+  for (const id of ACTIVITY_FORM_SECTION_IDS) {
+    for (const key of ACTIVITY_FORM_SECTION_FIELDS[id]) {
+      keys.push(String(key));
+    }
+  }
+  return keys;
+}
+
+/** Set of all keys listed in {@link ACTIVITY_FORM_SECTION_FIELDS}. */
+export function getActivityFormSectionFieldKeySet(): ReadonlySet<string> {
+  return new Set(getActivityFormSectionFieldKeys());
+}

--- a/packages/shared/src/activity-form-sections.ts
+++ b/packages/shared/src/activity-form-sections.ts
@@ -48,10 +48,7 @@ export const ACTIVITY_FORM_SECTION_LABELS: Record<
  * Top-level `ActivityFormData` keys owned by each section.
  * Include code-exempt or clone-excluded keys here for completeness; consumers filter.
  */
-export const ACTIVITY_FORM_SECTION_FIELDS: Record<
-  ActivityFormSectionId,
-  readonly (keyof ActivityFormData)[]
-> = {
+export const ACTIVITY_FORM_SECTION_FIELDS = {
   overview: [
     'title',
     'categoryIds',
@@ -99,7 +96,10 @@ export const ACTIVITY_FORM_SECTION_FIELDS: Record<
     'eventPlanners',
   ],
   sharing: ['visibility', 'sharedWithTeamIds'],
-};
+} as const satisfies Record<
+  ActivityFormSectionId,
+  readonly (keyof ActivityFormData)[]
+>;
 
 /**
  * Top-level `ActivityFormData` keys intentionally omitted from the section registry.
@@ -113,6 +113,24 @@ export const ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS = [
   'commsContactLeadId',
   'leadMinistryId',
 ] as const satisfies readonly (keyof ActivityFormData)[];
+
+type ActivityFormSectionFieldKey = {
+  [Section in ActivityFormSectionId]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
+}[ActivityFormSectionId];
+
+type UnaccountedActivityFormDataKey = Exclude<
+  keyof ActivityFormData,
+  | ActivityFormSectionFieldKey
+  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
+>;
+
+/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
+type AssertRegistryComplete = UnaccountedActivityFormDataKey extends never
+  ? true
+  : UnaccountedActivityFormDataKey;
+
+const _assertRegistryComplete: AssertRegistryComplete = true;
+void _assertRegistryComplete;
 
 /** Flat list of all section field keys in section order (each key appears at most once). */
 export function getActivityFormSectionFieldKeys(): readonly string[] {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './activities';
 export * from './activity-filter-state';
 export * from './activity-completion';
+export * from './activity-form-sections';
 export * from './datetime';
 export * from './filters/activityFilterStateToQueryParams';
 export * from './filters/activity-filter-active';

--- a/packages/shared/src/review-exempt-settings.ts
+++ b/packages/shared/src/review-exempt-settings.ts
@@ -1,4 +1,16 @@
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_LABELS,
+  type ActivityFormSectionId,
+} from './activity-form-sections';
 import type { ActivityFormData } from './schemas/activity.schema';
+
+export type ReviewExemptConfigurableSection = {
+  readonly id: ActivityFormSectionId;
+  readonly title: string;
+  readonly keys: readonly (keyof ActivityFormData)[];
+};
 
 /**
  * `application_settings.key` for JSON array of admin-configurable review-exempt
@@ -34,76 +46,17 @@ export const ACTIVITY_REVIEW_EXEMPT_CODE_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Admin UI + server allowlist, grouped to mirror {@link ActivityFormBody} section
- * order (left: Overview, Comms; right: Reports, Schedule, Event, Sharing).
- * Keep in sync when form sections or top-level field sets change.
+ * Admin UI + server allowlist, grouped from {@link ACTIVITY_FORM_SECTION_FIELDS}.
+ * Omits {@link ACTIVITY_REVIEW_EXEMPT_CODE_KEYS}. See `docs/ACTIVITY_FORM_SECTIONS.md`.
  */
-export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS = [
-  {
-    id: 'overview' as const,
-    title: 'Overview',
-    keys: [
-      'title',
-      'categoryIds',
-      'tagIds',
-      'leadTeamId',
-      'leadOrgId',
-      'significance',
-      'isIssue',
-      'isConfidential',
-      'notes',
-      'pitchRequiredStatusId',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'comms' as const,
-    title: 'Comms',
-    keys: [
-      'commsContacts',
-      'strategy',
-      'commsMaterialIds',
-      'newsReleaseId',
-      'newsReleaseOriginId',
-      'newsReleaseDistributionId',
-      'translationsRequiredStatusId',
-      'translationLanguageIds',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'reports' as const,
-    title: 'Reports',
-    keys: [
-      'reportSettings',
-      'executiveSummary',
-      'lookAheadStatus',
-      'lookAheadSection',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'schedule' as const,
-    title: 'Schedule',
-    keys: ['schedulingNotes'] as const satisfies ReadonlyArray<
-      keyof ActivityFormData
-    >,
-  },
-  {
-    id: 'event' as const,
-    title: 'Event',
-    keys: [
-      'venueAddress',
-      'premierRequestedId',
-      'representatives',
-      'eventPlanners',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'sharing' as const,
-    title: 'Sharing',
-    keys: ['visibility', 'sharedWithTeamIds'] as const satisfies ReadonlyArray<
-      keyof ActivityFormData
-    >,
-  },
-] as const;
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS: readonly ReviewExemptConfigurableSection[] =
+  ACTIVITY_FORM_SECTION_IDS.map((id) => ({
+    id,
+    title: ACTIVITY_FORM_SECTION_LABELS[id],
+    keys: ACTIVITY_FORM_SECTION_FIELDS[id].filter(
+      (key) => !ACTIVITY_REVIEW_EXEMPT_CODE_KEYS.has(String(key))
+    ),
+  })).filter((section) => section.keys.length > 0);
 
 const CONFIGURABLE_FLAT: string[] = [];
 for (const s of ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS) {
@@ -118,11 +71,6 @@ export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET: ReadonlySet<string> =
 /** Flat allowlist in stable order (section order) for zod/validation. */
 export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS: readonly string[] =
   CONFIGURABLE_FLAT;
-
-const ZOD_ENUM = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS as [
-  string,
-  ...string[],
-];
 
 /**
  * Merges code-exempt keys with allowlisted configurable keys (typically from DB).

--- a/packages/shared/src/schemas/clone-activity.schema.ts
+++ b/packages/shared/src/schemas/clone-activity.schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+} from '../activity-form-sections';
 import type { ActivityFormData } from './activity.schema';
 
 /**
@@ -102,69 +106,6 @@ export const CLONE_SYSTEM_FIELD_KEYS = [
 export type CloneSystemFieldKey = (typeof CLONE_SYSTEM_FIELD_KEYS)[number];
 
 /**
- * Section identifiers used to group the advanced field list in the clone
- * modal. These match the form section labels used elsewhere in the UI.
- */
-export const CLONE_ADVANCED_SECTIONS = [
-  'overview',
-  'comms',
-  'reports',
-  'schedule',
-  'event',
-  'sharing',
-] as const;
-
-export type CloneAdvancedSection = (typeof CLONE_ADVANCED_SECTIONS)[number];
-
-/**
- * Advanced field inventory for the clone modal, grouped by form section.
- * Each entry is a top-level `ActivityFormData` key (or dotted path) that
- * the user can toggle on/off before confirming the clone.
- *
- * Keys are excluded when they:
- * - appear in `CLONE_MODAL_SCHEDULE_FIELD_KEYS` (handled in the modal)
- * - appear in `CLONE_NEVER_COPIED_FIELD_KEYS` (never carried over)
- * - appear in `CLONE_SYSTEM_FIELD_KEYS` (owned by the server)
- * - are required on create (title, categoryIds, leadTeamId, summary,
- *   commsContacts) — always copied or re-entered, never optional
- */
-export const CLONE_ADVANCED_FIELD_GROUPS: Record<
-  CloneAdvancedSection,
-  readonly string[]
-> = {
-  overview: [
-    'leadOrgId',
-    'isConfidential',
-    'isIssue',
-    'significance',
-    'notes',
-    'tagIds',
-  ],
-  comms: [
-    'strategy',
-    'commsMaterialIds',
-    'newsReleaseOriginId',
-    'newsReleaseDistributionId',
-  ],
-  reports: ['reportSettings'],
-  schedule: ['schedulingNotes'],
-  event: [
-    'premierRequestedId',
-    'representatives',
-    'venueStatusId',
-    'venueAddress',
-    'eventPlanners',
-  ],
-  sharing: ['visibility', 'sharedWithTeamIds'],
-} as const;
-
-/** Flat list of all advanced field paths a user may toggle. */
-export const CLONE_ADVANCED_FIELD_PATHS: readonly string[] =
-  CLONE_ADVANCED_SECTIONS.flatMap(
-    (section) => CLONE_ADVANCED_FIELD_GROUPS[section]
-  );
-
-/**
  * Fields that are always copied on clone (required on create, and not in the
  * modal). The server applies these regardless of `includeFieldPaths`.
  */
@@ -177,6 +118,53 @@ export const CLONE_ALWAYS_COPIED_FIELD_KEYS = [
 
 export type CloneAlwaysCopiedFieldKey =
   (typeof CLONE_ALWAYS_COPIED_FIELD_KEYS)[number];
+
+/**
+ * Top-level keys excluded from the clone modal advanced field list.
+ * Section membership comes from {@link ACTIVITY_FORM_SECTION_FIELDS}; see
+ * `docs/ACTIVITY_FORM_SECTIONS.md`.
+ */
+const CLONE_ADVANCED_FIELD_EXCLUSIONS = new Set<string>([
+  ...CLONE_MODAL_SCHEDULE_FIELD_KEYS,
+  ...CLONE_NEVER_COPIED_FIELD_KEYS,
+  ...CLONE_ALWAYS_COPIED_FIELD_KEYS,
+  ...CLONE_SYSTEM_FIELD_KEYS,
+  'title',
+  'newsReleaseId', // on schema only; not rendered or cloneable in UI
+]);
+
+function isCloneAdvancedField(key: keyof ActivityFormData): boolean {
+  return !CLONE_ADVANCED_FIELD_EXCLUSIONS.has(String(key));
+}
+
+/** Sections that have at least one clone-advanced field after exclusions. */
+export const CLONE_ADVANCED_SECTIONS = ACTIVITY_FORM_SECTION_IDS.filter((id) =>
+  ACTIVITY_FORM_SECTION_FIELDS[id].some(isCloneAdvancedField)
+);
+
+export type CloneAdvancedSection = (typeof CLONE_ADVANCED_SECTIONS)[number];
+
+function buildCloneAdvancedFieldGroups(): Record<
+  CloneAdvancedSection,
+  readonly string[]
+> {
+  const groups = {} as Record<CloneAdvancedSection, readonly string[]>;
+  for (const id of CLONE_ADVANCED_SECTIONS) {
+    groups[id] = ACTIVITY_FORM_SECTION_FIELDS[id]
+      .filter(isCloneAdvancedField)
+      .map(String);
+  }
+  return groups;
+}
+
+/** Advanced field inventory for the clone modal, grouped by form section. */
+export const CLONE_ADVANCED_FIELD_GROUPS = buildCloneAdvancedFieldGroups();
+
+/** Flat list of all advanced field paths a user may toggle. */
+export const CLONE_ADVANCED_FIELD_PATHS: readonly string[] =
+  CLONE_ADVANCED_SECTIONS.flatMap(
+    (section) => CLONE_ADVANCED_FIELD_GROUPS[section]
+  );
 
 /**
  * Allowed values the server will accept in `includeFieldPaths`. Anything


### PR DESCRIPTION
# PR: refactor/CORPCAL-254-activity-sections

## Summary
**Issue:** Activity form, Clone modal, and admin Review exempt fields each had representations of activity form sections/fields, but had no common source of truth and had drifted.

This PR centralizes activity form section order, labels, and field membership in `@corpcal/shared`. Review-exempt admin grouping and clone modal advanced options are derived from this registry instead of duplicated manual lists.

Release fields move from Comms into a dedicated `newsRelease` section, matching the form layout.

## Important

- Rebuild shared before running service/UI locally:
  - `npm run build:packages`

## Changes

1. **Shared registry:** new canonical source in `activity-form-sections.ts`.
   - Section IDs, labels, and top-level field keys.
   - `ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS` for system/derived fields.
   - `getActivityFormSectionFieldKeySet()` helper.

2. **Review-exempt settings:** derived from the registry.
   - Removed hand-maintained section lists in `review-exempt-settings.ts`.
   - Added `ReviewExemptConfigurableSection` type.
   - Admin UI now groups release fields under **Release** (not Comms).

3. **Clone modal:** derived advanced field groups from the registry.
   - Release fields appear under a **Release** section in “More options”.
   - `leadOrgName` included in overview advanced options.

4. **Calendar UI:** re-export section labels from `@corpcal/shared`.
   - Removed duplicate label map in `activity-form-section-labels.ts`.
   - `CloneActivityModal` uses shared labels directly.

5. **Tests:** registry sync and completeness guards in `activity-form-sections.test.ts`.
   - Compile-time + runtime coverage of all `ActivityFormData` keys.
   - Full snapshot of `CLONE_ADVANCED_FIELD_GROUPS`.

6. **Docs:** playbook and maintenance updates.
   - `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md`
   - `calendar-service/docs/ACTIVITY.md`
   - `calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md` (combobox wording fix)

## Testing

- `npm run typecheck` — `packages/shared`
- `npm run test -- src/activity-form-sections.test.ts` — 6 passed
- Manual (recommended):
  - Settings → Review-exempt fields: confirm **Release** group and field labels
  - Clone activity → More options: confirm **Release** section and `leadOrgName` toggle
