### PR TITLE
Refactor/corpcal 254 activity form polish b

### DIFF
--- a/calendar-service/docs/ACTIVITY.md
+++ b/calendar-service/docs/ACTIVITY.md
@@ -8,6 +8,7 @@ This is the root document for activity-domain service docs. Use it as the entry 
 - [ACTIVITY_EDIT_ELIGIBILITY.md](./ACTIVITY_EDIT_ELIGIBILITY.md) - who may edit, permission guards, and related UI/API edit constraints.
 - [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) - "changed since last review" snapshot model, versioning, diff behavior, and backfill details.
 - [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md) - review-exempt fields (code + admin settings, API, UI, and maintenance when the form changes).
+- [ACTIVITY_FORM_SECTIONS.md](../../packages/shared/docs/ACTIVITY_FORM_SECTIONS.md) - canonical form section order, labels, and field membership (shared registry for review-exempt, clone modal, and UI).
 
 ## Field-Add Playbook (Activity Form)
 
@@ -18,13 +19,15 @@ Use this checklist whenever you add, remove, rename, or materially change an `Ac
 3. Set the canonical empty value in `packages/shared/src/utils/activity-review-diff.ts` (`getEmptyReviewBaseline`).
 4. Confirm canonicalization/diff behavior in `packages/shared/src/utils/activity-form-canonicalize.ts` and `packages/shared/src/utils/activity-review-diff.ts` (`diffReviewFields`) matches intended semantics (ordering, null/empty normalization, object keying).
 5. If the field has a user-visible review badge label/path mapping, update `packages/shared/src/utils/activity-field-labels.ts`.
-6. **Review impact (review-exempt list):** If the new field is a **top-level** `ActivityFormData` key, decide whether it should ever be **review-exempt** (edits that do not force Reviewed → Changed or show in `changedFieldsSinceReview`). Update `packages/shared/src/review-exempt-settings.ts`:
-   - If it should be **configurable** by System Admins in Settings, add it to the appropriate `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` group (order aligned with `ActivityFormBody` / section components in `calendar-ui`). Ensure it is **not** listed in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` if admins should control it.
-   - If it should **always** be exempt (product rule, not admin-toggleable), add it to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and do **not** add it to the configurable sections. Rebuild `@corpcal/shared` so `review-exempt-field-keys.schema.ts` stays aligned.
+6. **Form section registry:** Add or move the top-level key in `packages/shared/src/activity-form-sections.ts` and the matching `Activity*Section` component. See `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md`.
+7. **Review impact (review-exempt list):** If the new field is a **top-level** `ActivityFormData` key, decide whether it should ever be **review-exempt** (edits that do not force Reviewed → Changed or show in `changedFieldsSinceReview`):
+   - If it should be **configurable** by System Admins in Settings, list it in the registry and ensure it is **not** in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`. The admin UI grouping is derived automatically.
+   - If it should **always** be exempt (product rule, not admin-toggleable), add it to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` in `review-exempt-settings.ts`. It may remain in the registry for documentation; it will not appear in Settings.
    - If the field must **never** be exempt (e.g. primary content or compliance-sensitive), do not add it to either list; it will always affect review state when it changes. Fields that are **system-only** in the diff (see `EXCLUDED_FIELDS` in `activity-review-diff.ts`) are not admin options.
-7. For full details and API reference, see [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md).
-8. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
-9. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
+8. **Clone modal:** If the field is optional on clone, ensure clone exclusions in `packages/shared/src/schemas/clone-activity.schema.ts` are correct (`CLONE_NEVER_COPIED_FIELD_KEYS`, etc.). Advanced field groups are derived from the section registry.
+9. For full details and API reference, see [ACTIVITY_REVIEW_EXEMPT_SETTINGS.md](./ACTIVITY_REVIEW_EXEMPT_SETTINGS.md).
+10. Bump `REVIEW_SNAPSHOT_VERSION` in `packages/shared/src/constants/constants.ts`.
+11. Add or update tests for changed-path detection and snapshot behavior in shared utils tests.
 
 ### When to update `buildReviewDiffLookups()`
 

--- a/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
+++ b/calendar-service/docs/ACTIVITY_REVIEW_EXEMPT_SETTINGS.md
@@ -23,19 +23,20 @@ It complements [ACTIVITY_REVIEW_SNAPSHOT.md](./ACTIVITY_REVIEW_SNAPSHOT.md) (sna
 
 ## UI
 
-- **Settings** page, section “Review-exempt fields”: `ReviewExemptFieldsSettingsAdmin` in `calendar-ui` renders `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` as grouped checkboxes; labels use `getActivityFieldLabel` / `ACTIVITY_FIELD_LABELS` from shared.
+- **Settings** page, section “Review-exempt fields”: `ReviewExemptFieldsSettingsAdmin` in `calendar-ui` renders `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` (derived from `activity-form-sections.ts`) in a grouped combobox; labels use `getActivityFieldLabel` / `ACTIVITY_FIELD_LABELS` from shared.
 
 ## When you change the activity form or schema
 
-Adding, removing, or renaming a **top-level** `ActivityFormData` field that should be **available** in the admin “review-exempt” list (or that must be **code**-exempt) requires **manual** updates in shared—there is no codegen from the Zod form schema today. Follow the [Field-Add Playbook in ACTIVITY.md](./ACTIVITY.md#field-add-playbook-activity-form), including the review-exempt step.
+Adding, removing, or renaming a **top-level** `ActivityFormData` field that should be **available** in the admin “review-exempt” list (or that must be **code**-exempt) requires updates in shared—there is no codegen from the Zod form schema today. Follow the [Field-Add Playbook in ACTIVITY.md](./ACTIVITY.md#field-add-playbook-activity-form), including the section registry and review-exempt steps. See also [ACTIVITY_FORM_SECTIONS.md](../../packages/shared/docs/ACTIVITY_FORM_SECTIONS.md).
 
 **Files to touch (review-exempt-specific):**
 
-| File                                                             | What to do                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/shared/src/review-exempt-settings.ts`                  | For a new **configurable** field: add the key to the correct entry in `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` (and ensure it is not in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` unless it should be fixed in code). For a new **code-only** exempt field: add to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` and **remove** it from the configurable section list if it was listed. |
-| `packages/shared/src/schemas/review-exempt-field-keys.schema.ts` | The allowlist is derived from the same configurable keys; ensure the `z.enum` input stays consistent after edits to `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS` (rebuild shared).                                                                                                                                                                                            |
-| `packages/shared/src/utils/activity-review-diff.ts`              | If the field affects `getEmptyReviewBaseline` or comparison rules, follow the main playbook.                                                                                                                                                                                                                                                                                |
+| File                                                             | What to do                                                                                                                                                              |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/shared/src/activity-form-sections.ts`                  | Add or move the field under the correct section. This drives admin UI grouping and clone modal sections.                                                                |
+| `packages/shared/src/review-exempt-settings.ts`                  | For a new **code-only** exempt field: add to `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`. Configurable keys are derived from the section registry (filtered by code-exempt set). |
+| `packages/shared/src/schemas/review-exempt-field-keys.schema.ts` | The allowlist is derived from the same configurable keys; rebuild `@corpcal/shared` after registry changes.                                                             |
+| `packages/shared/src/utils/activity-review-diff.ts`              | If the field affects `getEmptyReviewBaseline` or comparison rules, follow the main playbook.                                                                            |
 
 **Deployment:** no extra migration for the setting row beyond seed; if you add new allowed keys, existing DB values remain valid; unknown keys in stored JSON are stripped on read/save.
 

--- a/calendar-service/src/lookups/lookups.controller.spec.ts
+++ b/calendar-service/src/lookups/lookups.controller.spec.ts
@@ -418,7 +418,7 @@ describe('LookupsController', () => {
       await expect(
         controller.updatePermissionVisibility(
           '10',
-          { showInUserManagement: true } as any,
+          { showInUserManagement: true },
           mockUser
         )
       ).rejects.toThrow(

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm } from 'react-hook-form';
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
 import { getDefaultFormValues } from '@/lib/activity-form-defaults';
 
@@ -73,10 +75,14 @@ function ActivityReleaseSectionHarness({
   readOnly,
   canEditFieldScope,
   defaultValues,
+  translationRequiredStatuses = mockLookups.translationRequiredStatuses,
+  onFormReady,
 }: {
   readOnly: boolean;
   canEditFieldScope?: (s: string) => boolean;
   defaultValues?: Partial<ActivityFormData>;
+  translationRequiredStatuses?: TranslationRequiredStatusLookupItem[];
+  onFormReady?: (form: ReturnType<typeof useForm<ActivityFormData>>) => void;
 }) {
   const form = useForm<ActivityFormData>({
     defaultValues: {
@@ -84,6 +90,8 @@ function ActivityReleaseSectionHarness({
       ...defaultValues,
     },
   });
+
+  onFormReady?.(form);
 
   return (
     <FormProvider {...form}>
@@ -97,7 +105,7 @@ function ActivityReleaseSectionHarness({
         <ActivityReleaseSection
           newsReleaseDistributionOptions={mockLookups.newsReleaseDistributions}
           newsReleaseOriginOptions={mockLookups.newsReleaseOrigins}
-          translationRequiredStatuses={mockLookups.translationRequiredStatuses}
+          translationRequiredStatuses={translationRequiredStatuses}
           translationLanguageOptions={mockLookups.translationLanguages}
         />
       </ActivityEditProvider>
@@ -155,5 +163,71 @@ describe('ActivityReleaseSection translation languages visibility', () => {
     expect(
       await screen.findByPlaceholderText(/Select translation languages/i)
     ).toBeInTheDocument();
+  });
+});
+
+const translationRequiredStatusesWithoutRequired =
+  mockTranslationRequiredStatuses.filter(
+    (status) => status.name !== 'required'
+  );
+
+describe('ActivityReleaseSection translation status change', () => {
+  it('clears translation languages when status changes away from required', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivityReleaseSectionHarness
+        readOnly={false}
+        defaultValues={{
+          translationsRequiredStatusId: 2,
+          translationLanguageIds: [1, 2],
+        }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    const statusSelect = await screen.findByRole('combobox', {
+      name: /^Translations required$/i,
+    });
+    await user.click(statusSelect);
+    await user.click(await screen.findByText('Not required'));
+
+    await waitFor(() => {
+      expect(formRef!.getValues('translationsRequiredStatusId')).toBe(3);
+      expect(formRef!.getValues('translationLanguageIds')).toEqual([]);
+    });
+  });
+
+  it('preserves translation languages when required status lookup is unresolved', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivityReleaseSectionHarness
+        readOnly={false}
+        translationRequiredStatuses={translationRequiredStatusesWithoutRequired}
+        defaultValues={{
+          translationsRequiredStatusId: 1,
+          translationLanguageIds: [1, 2],
+        }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    const statusSelect = await screen.findByRole('combobox', {
+      name: /^Translations required$/i,
+    });
+    await user.click(statusSelect);
+    await user.click(await screen.findByText('Not required'));
+
+    await waitFor(() => {
+      expect(formRef!.getValues('translationsRequiredStatusId')).toBe(3);
+      expect(formRef!.getValues('translationLanguageIds')).toEqual([1, 2]);
+    });
   });
 });

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.test.tsx
@@ -16,6 +16,30 @@ beforeAll(() => {
   }
 });
 
+const mockTranslationRequiredStatuses = [
+  {
+    id: 1,
+    name: 'pending',
+    displayName: 'Pending review',
+    label: 'Pending review',
+    value: 1,
+  },
+  {
+    id: 2,
+    name: 'required',
+    displayName: 'Required',
+    label: 'Required',
+    value: 2,
+  },
+  {
+    id: 3,
+    name: 'not_required',
+    displayName: 'Not required',
+    label: 'Not required',
+    value: 3,
+  },
+];
+
 const mockLookups = {
   isLoading: false,
   hasError: false,
@@ -33,22 +57,7 @@ const mockLookups = {
     { id: 1, name: 'French', displayName: 'French' },
     { id: 2, name: 'Spanish', displayName: 'Spanish' },
   ],
-  translationRequiredStatuses: [
-    {
-      id: 1,
-      name: 'Not required',
-      displayName: 'Not required',
-      label: 'Not required',
-      value: 1,
-    },
-    {
-      id: 2,
-      name: 'Required',
-      displayName: 'Required',
-      label: 'Required',
-      value: 2,
-    },
-  ],
+  translationRequiredStatuses: mockTranslationRequiredStatuses,
   governmentRepresentatives: [],
   newsReleaseDistributions: [{ value: '1', label: 'Internal' }],
   premierRequested: [],
@@ -63,12 +72,17 @@ const mockLookups = {
 function ActivityReleaseSectionHarness({
   readOnly,
   canEditFieldScope,
+  defaultValues,
 }: {
   readOnly: boolean;
   canEditFieldScope?: (s: string) => boolean;
+  defaultValues?: Partial<ActivityFormData>;
 }) {
   const form = useForm<ActivityFormData>({
-    defaultValues: getDefaultFormValues() as ActivityFormData,
+    defaultValues: {
+      ...(getDefaultFormValues() as ActivityFormData),
+      ...defaultValues,
+    },
   });
 
   return (
@@ -105,6 +119,7 @@ describe('ActivityReleaseSection permissions', () => {
       <ActivityReleaseSectionHarness
         readOnly={false}
         canEditFieldScope={(s: string) => s !== 'translations'}
+        defaultValues={{ translationsRequiredStatusId: 2 }}
       />
     );
 
@@ -112,5 +127,33 @@ describe('ActivityReleaseSection permissions', () => {
       /Select translation languages/i
     );
     expect(input).toBeDisabled();
+  });
+});
+
+describe('ActivityReleaseSection translation languages visibility', () => {
+  it('hides translation languages when status is not Required', () => {
+    render(
+      <ActivityReleaseSectionHarness
+        readOnly={false}
+        defaultValues={{ translationsRequiredStatusId: 1 }}
+      />
+    );
+
+    expect(
+      screen.queryByPlaceholderText(/Select translation languages/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows translation languages when status is Required', async () => {
+    render(
+      <ActivityReleaseSectionHarness
+        readOnly={false}
+        defaultValues={{ translationsRequiredStatusId: 2 }}
+      />
+    );
+
+    expect(
+      await screen.findByPlaceholderText(/Select translation languages/i)
+    ).toBeInTheDocument();
   });
 });

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -259,7 +259,10 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
               onValueChange={(value) => {
                 const nextStatusId = optionalSelectIdValue(value);
                 setActivityFormFieldValue(form, field.name, nextStatusId);
-                if (nextStatusId !== requiredTranslationStatusId) {
+                if (
+                  requiredTranslationStatusId != null &&
+                  nextStatusId !== requiredTranslationStatusId
+                ) {
                   setActivityFormFieldValue(form, 'translationLanguageIds', []);
                 }
               }}

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -1,7 +1,6 @@
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useMemo } from 'react';
 
-import { TRANSLATION_REQUIRED_LOOKUP_NAME } from '@corpcal/shared';
 import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
 import {
@@ -35,6 +34,7 @@ import {
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
 import { setActivityFormFieldValue } from '@/lib/activity-form-set-field';
+import { resolveTranslationRequiredStatusId } from '@/lib/activity-form-translation-required';
 import type { OptionItem } from '@/schemas/types';
 
 import { useActivityEdit } from '../activity-edit-context';
@@ -52,13 +52,6 @@ type ActivityReleaseSectionProps = {
     displayName?: string;
   }>;
 };
-
-function resolveTranslationRequiredStatusId(
-  statuses: TranslationRequiredStatusLookupItem[],
-  lookupName: string
-): number | undefined {
-  return statuses.find((status) => status.name === lookupName)?.id;
-}
 
 /**
  * Isolated so `useWatch('translationsRequiredStatusId')` only re-renders this
@@ -166,11 +159,7 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
   const translationsScope = useActivityFieldScopeControl('translations');
 
   const requiredTranslationStatusId = useMemo(
-    () =>
-      resolveTranslationRequiredStatusId(
-        translationRequiredStatuses,
-        TRANSLATION_REQUIRED_LOOKUP_NAME
-      ),
+    () => resolveTranslationRequiredStatusId(translationRequiredStatuses),
     [translationRequiredStatuses]
   );
 

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReleaseSection.tsx
@@ -1,5 +1,7 @@
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useMemo } from 'react';
 
+import { TRANSLATION_REQUIRED_LOOKUP_NAME } from '@corpcal/shared';
 import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
 import {
@@ -51,6 +53,108 @@ type ActivityReleaseSectionProps = {
   }>;
 };
 
+function resolveTranslationRequiredStatusId(
+  statuses: TranslationRequiredStatusLookupItem[],
+  lookupName: string
+): number | undefined {
+  return statuses.find((status) => status.name === lookupName)?.id;
+}
+
+/**
+ * Isolated so `useWatch('translationsRequiredStatusId')` only re-renders this
+ * subtree when that field changes, not the entire release section.
+ */
+function TranslationLanguagesField({
+  requiredTranslationStatusId,
+  translationLanguageComboboxOptions,
+}: {
+  requiredTranslationStatusId: number | undefined;
+  translationLanguageComboboxOptions: OptionItem[];
+}) {
+  const form = useFormContext<ActivityFormData>();
+  const translationsScope = useActivityFieldScopeControl('translations');
+  const translationsAnchorRef = useComboboxAnchor();
+  const translationsRequiredStatusId = useWatch({
+    control: form.control,
+    name: 'translationsRequiredStatusId',
+  });
+
+  const showLanguages =
+    requiredTranslationStatusId != null &&
+    translationsRequiredStatusId === requiredTranslationStatusId;
+
+  if (!showLanguages) {
+    return null;
+  }
+
+  return (
+    <FormField
+      control={form.control}
+      name="translationLanguageIds"
+      render={({ field }) => {
+        const selectedOptions = translationLanguageComboboxOptions.filter((o) =>
+          (field.value ?? []).includes(Number(o.value))
+        );
+        return (
+          <FormItem>
+            <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
+            <ActivityFieldScopePermissionTooltip scope="translations">
+              <FormControl data-field={field.name}>
+                <Combobox
+                  items={translationLanguageComboboxOptions}
+                  multiple
+                  value={selectedOptions}
+                  onValueChange={(selected) =>
+                    setActivityFormFieldValue(
+                      form,
+                      field.name,
+                      selected.map((o) => Number(o.value))
+                    )
+                  }
+                  itemToStringValue={(o) => o.label}
+                  readOnly={
+                    translationsScope.readOnly &&
+                    !translationsScope.fieldScopeDisabled
+                  }
+                  disabled={translationsScope.fieldScopeDisabled}
+                >
+                  <ComboboxChips ref={translationsAnchorRef} className="w-full">
+                    <ComboboxValue>
+                      {(values: OptionItem[]) => (
+                        <>
+                          {values.map((option) => (
+                            <ComboboxChip key={option.value}>
+                              {option.label}
+                            </ComboboxChip>
+                          ))}
+                          <ComboboxChipsInput placeholder="Select translation languages" />
+                        </>
+                      )}
+                    </ComboboxValue>
+                  </ComboboxChips>
+                  <ComboboxContent anchor={translationsAnchorRef}>
+                    <ComboboxEmpty>
+                      No translation languages found.
+                    </ComboboxEmpty>
+                    <ComboboxList>
+                      {(option: OptionItem) => (
+                        <ComboboxItem key={option.value} value={option}>
+                          {option.label}
+                        </ComboboxItem>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
+              </FormControl>
+            </ActivityFieldScopePermissionTooltip>
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}
+
 export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
   newsReleaseDistributionOptions,
   newsReleaseOriginOptions,
@@ -60,7 +164,15 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
   const form = useFormContext<ActivityFormData>();
   const { readOnly } = useActivityEdit();
   const translationsScope = useActivityFieldScopeControl('translations');
-  const translationsAnchorRef = useComboboxAnchor();
+
+  const requiredTranslationStatusId = useMemo(
+    () =>
+      resolveTranslationRequiredStatusId(
+        translationRequiredStatuses,
+        TRANSLATION_REQUIRED_LOOKUP_NAME
+      ),
+    [translationRequiredStatuses]
+  );
 
   const translationLanguageComboboxOptions: OptionItem[] =
     translationLanguageOptions.map((l) => ({
@@ -155,13 +267,13 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
                 String(s.id)
               )}
               value={optionalIdSelectDisplayValue(field.value)}
-              onValueChange={(value) =>
-                setActivityFormFieldValue(
-                  form,
-                  field.name,
-                  optionalSelectIdValue(value)
-                )
-              }
+              onValueChange={(value) => {
+                const nextStatusId = optionalSelectIdValue(value);
+                setActivityFormFieldValue(form, field.name, nextStatusId);
+                if (nextStatusId !== requiredTranslationStatusId) {
+                  setActivityFormFieldValue(form, 'translationLanguageIds', []);
+                }
+              }}
             >
               <ActivityFieldScopePermissionTooltip scope="translations">
                 <FormControl data-field={field.name}>
@@ -188,72 +300,9 @@ export const ActivityReleaseSection: React.FC<ActivityReleaseSectionProps> = ({
         )}
       />
 
-      <FormField
-        control={form.control}
-        name="translationLanguageIds"
-        render={({ field }) => {
-          const selectedOptions = translationLanguageComboboxOptions.filter(
-            (o) => (field.value ?? []).includes(Number(o.value))
-          );
-          return (
-            <FormItem>
-              <FormLabel>{getActivityFieldLabel(field.name)}</FormLabel>
-              <ActivityFieldScopePermissionTooltip scope="translations">
-                <FormControl data-field={field.name}>
-                  <Combobox
-                    items={translationLanguageComboboxOptions}
-                    multiple
-                    value={selectedOptions}
-                    onValueChange={(selected) =>
-                      setActivityFormFieldValue(
-                        form,
-                        field.name,
-                        selected.map((o) => Number(o.value))
-                      )
-                    }
-                    itemToStringValue={(o) => o.label}
-                    readOnly={
-                      translationsScope.readOnly &&
-                      !translationsScope.fieldScopeDisabled
-                    }
-                    disabled={translationsScope.fieldScopeDisabled}
-                  >
-                    <ComboboxChips
-                      ref={translationsAnchorRef}
-                      className="w-full"
-                    >
-                      <ComboboxValue>
-                        {(values: OptionItem[]) => (
-                          <>
-                            {values.map((option) => (
-                              <ComboboxChip key={option.value}>
-                                {option.label}
-                              </ComboboxChip>
-                            ))}
-                            <ComboboxChipsInput placeholder="Select translation languages" />
-                          </>
-                        )}
-                      </ComboboxValue>
-                    </ComboboxChips>
-                    <ComboboxContent anchor={translationsAnchorRef}>
-                      <ComboboxEmpty>
-                        No translation languages found.
-                      </ComboboxEmpty>
-                      <ComboboxList>
-                        {(option: OptionItem) => (
-                          <ComboboxItem key={option.value} value={option}>
-                            {option.label}
-                          </ComboboxItem>
-                        )}
-                      </ComboboxList>
-                    </ComboboxContent>
-                  </Combobox>
-                </FormControl>
-              </ActivityFieldScopePermissionTooltip>
-              <FormMessage />
-            </FormItem>
-          );
-        }}
+      <TranslationLanguagesField
+        requiredTranslationStatusId={requiredTranslationStatusId}
+        translationLanguageComboboxOptions={translationLanguageComboboxOptions}
       />
     </ActivityFormSection>
   );

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReportsSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReportsSection.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { ActivityFormData } from '@corpcal/shared/schemas';
+import { getDefaultFormValues } from '@/lib/activity-form-defaults';
+import { buildPayloadForUpdate } from '@/lib/activity-form-payload';
+
+import { ActivityEditProvider } from '../activity-edit-context';
+import { ActivityReportsSection } from './ActivityReportsSection';
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => undefined;
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+});
+
+vi.mock('@/components/ui/rich-text-field', () =>
+  import('@/test-utils/rich-text-field-mock').then((m) => ({
+    RichTextField: m.RichTextFieldMock,
+  }))
+);
+
+vi.mock('@/hooks/useLookAheadSectionRows', () => ({
+  useLookAheadSectionRows: () => ({
+    rows: [
+      {
+        sectionId: 'events',
+        order: 1,
+        lookAheadKey: 'events',
+        uiLabel: 'Events',
+        legendColor: '#000000',
+      },
+    ],
+    isLoading: false,
+    hasConfig: true,
+  }),
+  rowsToSectionOptions: (
+    rows: Array<{ lookAheadKey: string | null; uiLabel: string }>
+  ) =>
+    rows
+      .filter((row) => row.lookAheadKey != null)
+      .map((row) => ({
+        value: row.lookAheadKey as string,
+        label: row.uiLabel,
+      })),
+}));
+
+vi.mock('@/hooks/useLookups', () => ({
+  useReports: () => ({ data: [], isLoading: false }),
+}));
+
+function ActivityReportsSectionHarness({
+  defaultValues,
+  onFormReady,
+}: {
+  defaultValues?: Partial<ActivityFormData>;
+  onFormReady?: (form: ReturnType<typeof useForm<ActivityFormData>>) => void;
+}) {
+  const form = useForm<ActivityFormData>({
+    defaultValues: {
+      ...(getDefaultFormValues() as ActivityFormData),
+      ...defaultValues,
+    },
+  });
+
+  onFormReady?.(form);
+
+  return (
+    <FormProvider {...form}>
+      <ActivityEditProvider
+        value={{
+          readOnly: false,
+          canViewFieldScope: (scope) => scope === 'lookAhead',
+          canEditFieldScope: () => true,
+        }}
+      >
+        <ActivityReportsSection />
+      </ActivityEditProvider>
+    </FormProvider>
+  );
+}
+
+function getLookAheadSectionNoneRadio(): HTMLElement {
+  const radio = document.getElementById('lookAhead-section-none');
+  if (!radio) {
+    throw new Error('Expected look-ahead section None radio');
+  }
+  return radio;
+}
+
+describe('ActivityReportsSection look ahead section', () => {
+  it('renders a None option for look-ahead section', () => {
+    render(<ActivityReportsSectionHarness />);
+
+    expect(getLookAheadSectionNoneRadio()).toBeInTheDocument();
+    expect(screen.getByLabelText('Events')).toBeInTheDocument();
+  });
+
+  it('clears lookAheadSection when None is selected', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivityReportsSectionHarness
+        defaultValues={{ lookAheadSection: 'events' }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    await user.click(getLookAheadSectionNoneRadio());
+
+    expect(formRef?.getValues('lookAheadSection')).toBeUndefined();
+  });
+
+  it('maps cleared lookAheadSection to null in update payloads', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivityReportsSectionHarness
+        defaultValues={{ lookAheadSection: 'events' }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    await user.click(getLookAheadSectionNoneRadio());
+
+    const formValues = formRef!.getValues();
+    const payload = buildPayloadForUpdate(formValues, formValues);
+
+    expect(payload.lookAheadSection).toBeNull();
+  });
+});

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivityReportsSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivityReportsSection.tsx
@@ -14,7 +14,10 @@ import { FormSectionDivider } from '@/components/ui/form-section-divider';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { RichTextField } from '@/components/ui/rich-text-field';
-import { lookAheadStatusOptions } from '@/constants/form-options';
+import {
+  lookAheadSectionNoneOption,
+  lookAheadStatusOptions,
+} from '@/constants/form-options';
 import {
   rowsToSectionOptions,
   useLookAheadSectionRows,
@@ -152,6 +155,18 @@ export const ActivityReportsSection: React.FC = () => {
                       value={optionalRadioDisplayValue(field.value)}
                       className="flex flex-row flex-wrap gap-x-4 gap-y-2"
                     >
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value={lookAheadSectionNoneOption.value}
+                          id="lookAhead-section-none"
+                        />
+                        <Label
+                          htmlFor="lookAhead-section-none"
+                          className="cursor-pointer font-normal"
+                        >
+                          {lookAheadSectionNoneOption.label}
+                        </Label>
+                      </div>
                       {lookAheadSectionOptions.map((option) => (
                         <div
                           key={option.value}

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.test.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { ActivityFormData } from '@corpcal/shared/schemas';
+import { getDefaultFormValues } from '@/lib/activity-form-defaults';
+
+import { ActivityEditProvider } from '../activity-edit-context';
+import { ActivitySharingSection } from './ActivitySharingSection';
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => undefined;
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+});
+
+vi.mock('@/hooks/useLeadTeamOptions', () => ({
+  useLeadTeamOptions: () => ({
+    data: [{ id: 5, name: 'Comms Team', displayName: 'Comms Team' }],
+  }),
+}));
+
+function ActivitySharingSectionHarness({
+  readOnly = false,
+  defaultValues,
+  onFormReady,
+}: {
+  readOnly?: boolean;
+  defaultValues?: Partial<ActivityFormData>;
+  onFormReady?: (form: ReturnType<typeof useForm<ActivityFormData>>) => void;
+}) {
+  const form = useForm<ActivityFormData>({
+    defaultValues: {
+      ...(getDefaultFormValues() as ActivityFormData),
+      leadTeamId: 5,
+      ...defaultValues,
+    },
+  });
+
+  onFormReady?.(form);
+
+  return (
+    <FormProvider {...form}>
+      <ActivityEditProvider
+        value={{
+          readOnly,
+          canViewFieldScope: () => true,
+          canEditFieldScope: () => true,
+        }}
+      >
+        <ActivitySharingSection sharedWithTeams={[]} quickShareGroups={[]} />
+      </ActivityEditProvider>
+    </FormProvider>
+  );
+}
+
+describe('ActivitySharingSection visibility switch', () => {
+  it('maps the switch to team visibility when checked', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivitySharingSectionHarness
+        defaultValues={{ visibility: 'global' }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    const restrictSwitch = screen.getByRole('switch', {
+      name: /Restrict access/i,
+    });
+    expect(restrictSwitch).not.toBeChecked();
+    expect(
+      screen.getByText(/This activity is visible to all calendar users/i)
+    ).toBeInTheDocument();
+
+    await user.click(restrictSwitch);
+
+    expect(restrictSwitch).toBeChecked();
+    expect(formRef?.getValues('visibility')).toBe('team');
+    expect(
+      screen.getByText(
+        /This activity is visible only to Comms Team, shares, and exec/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('maps the switch to global visibility when unchecked', async () => {
+    const user = userEvent.setup();
+    let formRef: ReturnType<typeof useForm<ActivityFormData>> | undefined;
+
+    render(
+      <ActivitySharingSectionHarness
+        defaultValues={{ visibility: 'team' }}
+        onFormReady={(form) => {
+          formRef = form;
+        }}
+      />
+    );
+
+    const restrictSwitch = screen.getByRole('switch', {
+      name: /Restrict access/i,
+    });
+    expect(restrictSwitch).toBeChecked();
+
+    await user.click(restrictSwitch);
+
+    expect(restrictSwitch).not.toBeChecked();
+    expect(formRef?.getValues('visibility')).toBe('global');
+  });
+});

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
@@ -122,6 +122,8 @@ type ActivitySharingSectionProps = {
   quickShareGroups: QuickShareGroupLookup[];
 };
 
+const RESTRICT_ACCESS_SWITCH_ID = 'activity-visibility-restrict-access';
+
 export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
   sharedWithTeams,
   quickShareGroups,
@@ -174,6 +176,7 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
               <div className="flex flex-row items-start space-y-0 space-x-3">
                 <FormControl data-field={field.name}>
                   <Switch
+                    id={RESTRICT_ACCESS_SWITCH_ID}
                     checked={isRestricted}
                     readOnly={readOnly}
                     onCheckedChange={(checked) => {
@@ -186,7 +189,7 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">
-                  <FormLabel>
+                  <FormLabel htmlFor={RESTRICT_ACCESS_SWITCH_ID}>
                     <>
                       {getActivityFieldLabel(field.name)}
                       <Popover>

--- a/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
+++ b/calendar-ui/src/components/activity/ActivityFormSections/ActivitySharingSection.tsx
@@ -1,14 +1,9 @@
-import { CheckIcon } from 'lucide-react';
-import { useFormContext } from 'react-hook-form';
+import { CheckIcon, Globe, Lock } from 'lucide-react';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useMemo, type FC } from 'react';
 
-import {
-  DEFAULT_VISIBILITY,
-  VISIBILITY,
-  type Visibility,
-} from '@corpcal/shared/constants/constants';
+import { DEFAULT_VISIBILITY } from '@corpcal/shared/constants/constants';
 import type { ActivityFormData } from '@corpcal/shared/schemas';
-import { FormSelect, FormSelectTrigger } from '@/components/app/form-select';
 import {
   Combobox,
   ComboboxChip,
@@ -36,7 +31,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useLeadTeamOptions } from '@/hooks/useLeadTeamOptions';
 import { getActivityFieldLabel } from '@/lib/activity-form-labels';
 import { ACTIVITY_FORM_SECTION_LABELS } from '@/lib/activity-form-section-labels';
 import { setActivityFormFieldValue } from '@/lib/activity-form-set-field';
@@ -133,6 +129,14 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
   const { readOnly } = useActivityEdit();
   const form = useFormContext<ActivityFormData>();
   const sharedWithAnchorRef = useComboboxAnchor();
+  const leadTeamId = useWatch({ control: form.control, name: 'leadTeamId' });
+  const { data: leadTeamOptions = [] } = useLeadTeamOptions(true);
+
+  const leadTeamName = useMemo(() => {
+    if (leadTeamId == null) return 'lead team';
+    const team = leadTeamOptions.find((t) => t.id === leadTeamId);
+    return team?.displayName ?? team?.name ?? 'lead team';
+  }, [leadTeamId, leadTeamOptions]);
 
   const sharedWithTeamOptions = useMemo<OptionItem[]>(
     () =>
@@ -162,69 +166,85 @@ export const ActivitySharingSection: FC<ActivitySharingSectionProps> = ({
       <FormField
         control={form.control}
         name="visibility"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>
-              <>
-                {getActivityFieldLabel(field.name)}
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <InfoIconButton aria-label="About visibility" />
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-80 max-w-[calc(100vw-2rem)] text-sm"
-                    align="start"
-                  >
-                    <p className="mb-2">
-                      Sets who can see and view the activity details in
-                      Corporate Calendar:
-                    </p>
-                    <ul className="list-disc space-y-1 pl-4">
-                      <li>
-                        restrict to only your team (and those you share with)
-                      </li>
-                      <li>leave unchecked to make visible for everyone</li>
-                    </ul>
-                    <p className="mt-2">
-                      GCPE executive, Strategic Communications and Cabinet
-                      Priorities staff, and Calendar admin can always view
-                      and/or edit all activities.
-                    </p>
-                    <p className="mt-2">
-                      Does not affect inclusion in the Look Ahead report.
-                    </p>
-                  </PopoverContent>
-                </Popover>
-              </>
-            </FormLabel>
-            <FormSelect
-              readOnly={readOnly}
-              onValueChange={(value) => {
-                const visibility: Visibility = (
-                  VISIBILITY as readonly string[]
-                ).includes(value)
-                  ? (value as Visibility)
-                  : DEFAULT_VISIBILITY;
-                setActivityFormFieldValue(form, field.name, visibility);
-              }}
-              value={field.value || DEFAULT_VISIBILITY}
-            >
-              <FormControl data-field={field.name}>
-                <FormSelectTrigger readOnly={readOnly}>
-                  <SelectValue placeholder="Select visibility" />
-                </FormSelectTrigger>
-              </FormControl>
-              <SelectContent>
-                <SelectItem value="global">Everyone</SelectItem>
-                <SelectItem value="team">My team only</SelectItem>
-              </SelectContent>
-            </FormSelect>
-            <FormDescription>
-              Activities are always visible to exec and admins.
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
+        render={({ field }) => {
+          const isRestricted = (field.value ?? DEFAULT_VISIBILITY) === 'team';
+
+          return (
+            <FormItem className="space-y-2">
+              <div className="flex flex-row items-start space-y-0 space-x-3">
+                <FormControl data-field={field.name}>
+                  <Switch
+                    checked={isRestricted}
+                    readOnly={readOnly}
+                    onCheckedChange={(checked) => {
+                      setActivityFormFieldValue(
+                        form,
+                        field.name,
+                        checked === true ? 'team' : 'global'
+                      );
+                    }}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>
+                    <>
+                      {getActivityFieldLabel(field.name)}
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <InfoIconButton aria-label="About access restriction" />
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="w-80 max-w-[calc(100vw-2rem)] text-sm"
+                          align="start"
+                        >
+                          <p className="mb-2">
+                            Controls who can view this activity in Corporate
+                            Calendar:
+                          </p>
+                          <ul className="list-disc space-y-1 pl-4">
+                            <li>
+                              <strong>On:</strong> only the lead team and teams
+                              selected in Share with can view the activity (plus
+                              roles below).
+                            </li>
+                            <li>
+                              <strong>Off:</strong> visible to everyone.
+                            </li>
+                          </ul>
+                          <p className="mt-2">
+                            GCPE executive, Strategic Communications, Cabinet
+                            Priorities, and Calendar admin roles can always view
+                            all activities regardless of this setting.
+                          </p>
+                          <p className="mt-2">
+                            Does not affect inclusion in the Look Ahead report.
+                          </p>
+                        </PopoverContent>
+                      </Popover>
+                    </>
+                  </FormLabel>
+                </div>
+              </div>
+              <p className="text-muted-foreground flex items-start gap-2 text-sm">
+                {isRestricted ? (
+                  <>
+                    <Lock className="mt-0.5 size-4 shrink-0" aria-hidden />
+                    <span>
+                      This activity is visible only to {leadTeamName}, shares,
+                      and exec.
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <Globe className="mt-0.5 size-4 shrink-0" aria-hidden />
+                    <span>This activity is visible to all calendar users.</span>
+                  </>
+                )}
+              </p>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
 
       <FormField

--- a/calendar-ui/src/components/activity/activities/CloneActivityModal.tsx
+++ b/calendar-ui/src/components/activity/activities/CloneActivityModal.tsx
@@ -59,15 +59,6 @@ function resolveNotConfirmedStatusId<
   return firstByDisplay?.id;
 }
 
-const SECTION_LABELS: Record<CloneAdvancedSection, string> = {
-  overview: ACTIVITY_FORM_SECTION_LABELS.overview,
-  comms: ACTIVITY_FORM_SECTION_LABELS.comms,
-  reports: ACTIVITY_FORM_SECTION_LABELS.reports,
-  schedule: ACTIVITY_FORM_SECTION_LABELS.schedule,
-  event: ACTIVITY_FORM_SECTION_LABELS.event,
-  sharing: ACTIVITY_FORM_SECTION_LABELS.sharing,
-};
-
 /**
  * Map each clone advanced field path to the field-level scope that governs
  * edit permission. Unlisted paths are always allowed (no scope gating).
@@ -570,7 +561,7 @@ export function CloneActivityModal({
                     return (
                       <div key={section} className="space-y-2">
                         <p className="text-xs font-semibold tracking-wide uppercase">
-                          {SECTION_LABELS[section]}
+                          {ACTIVITY_FORM_SECTION_LABELS[section]}
                         </p>
                         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                           {paths.map((path) => {

--- a/calendar-ui/src/constants/form-options.ts
+++ b/calendar-ui/src/constants/form-options.ts
@@ -27,10 +27,13 @@ export const lookAheadStatusOptions = LOOK_AHEAD_STATUS.map((value) => ({
 /** RadioGroup value when no look-ahead section is selected (clears DB column). */
 export const LOOK_AHEAD_SECTION_NONE_RADIO_VALUE = '';
 
+/** Clear option label for look-ahead section radios (no LA/Exec bucket). */
+export const LOOK_AHEAD_SECTION_NONE_LABEL = 'None';
+
 /** First option for look-ahead section radios — excludes activity from LA/Exec buckets. */
 export const lookAheadSectionNoneOption = {
   value: LOOK_AHEAD_SECTION_NONE_RADIO_VALUE,
-  label: getLookAheadStatusLabel('none'),
+  label: LOOK_AHEAD_SECTION_NONE_LABEL,
 } as const;
 
 /**

--- a/calendar-ui/src/constants/form-options.ts
+++ b/calendar-ui/src/constants/form-options.ts
@@ -24,6 +24,15 @@ export const lookAheadStatusOptions = LOOK_AHEAD_STATUS.map((value) => ({
   label: getLookAheadStatusLabel(value),
 }));
 
+/** RadioGroup value when no look-ahead section is selected (clears DB column). */
+export const LOOK_AHEAD_SECTION_NONE_RADIO_VALUE = '';
+
+/** First option for look-ahead section radios — excludes activity from LA/Exec buckets. */
+export const lookAheadSectionNoneOption = {
+  value: LOOK_AHEAD_SECTION_NONE_RADIO_VALUE,
+  label: getLookAheadStatusLabel('none'),
+} as const;
+
 /**
  * Look Ahead Section options now live in `useLookAheadSectionRows` (config-driven).
  * Use that hook (and `rowsToSectionOptions` / `getLookAheadSectionLabelFromRows`)

--- a/calendar-ui/src/lib/activity-form-payload.test.ts
+++ b/calendar-ui/src/lib/activity-form-payload.test.ts
@@ -71,6 +71,19 @@ describe('buildPayloadForCreate', () => {
     expect(payload.notes).not.toBe('');
     expect(payload.significance).not.toBe(EMPTY_RICH_TEXT_DOC);
   });
+
+  it('strips orphan translationLanguageIds when status is not required', () => {
+    const formValues = minimalForm({
+      translationsRequiredStatusId: 1,
+      translationLanguageIds: [1, 2],
+    });
+
+    const payload = buildPayloadForCreate(formValues, formValues, {
+      requiredTranslationStatusId: 2,
+    });
+
+    expect(payload.translationLanguageIds).toBeUndefined();
+  });
 });
 
 describe('buildPayloadForUpdate', () => {
@@ -98,5 +111,18 @@ describe('buildPayloadForUpdate', () => {
     expect(payload.schedulingNotes).toBeNull();
     expect(payload.strategy).toBeNull();
     expect(payload.significance).toBeNull();
+  });
+
+  it('strips orphan translationLanguageIds when status is not required', () => {
+    const formValues = minimalForm({
+      translationsRequiredStatusId: 3,
+      translationLanguageIds: [1],
+    });
+
+    const payload = buildPayloadForUpdate(formValues, formValues, {
+      requiredTranslationStatusId: 2,
+    });
+
+    expect(payload.translationLanguageIds).toBeUndefined();
   });
 });

--- a/calendar-ui/src/lib/activity-form-payload.test.ts
+++ b/calendar-ui/src/lib/activity-form-payload.test.ts
@@ -40,6 +40,22 @@ describe('buildMarkReviewedOnlyPayload', () => {
 });
 
 describe('buildPayloadForCreate', () => {
+  it('maps cleared lookAheadSection to null for API', () => {
+    const formValues = minimalForm({ lookAheadSection: undefined });
+
+    const payload = buildPayloadForCreate(formValues, formValues);
+
+    expect(payload.lookAheadSection).toBeNull();
+  });
+
+  it('preserves lookAheadSection when a section is selected', () => {
+    const formValues = minimalForm({ lookAheadSection: 'events' });
+
+    const payload = buildPayloadForCreate(formValues, formValues);
+
+    expect(payload.lookAheadSection).toBe('events');
+  });
+
   it('strips UI sentinels from optional fields before sending to API', () => {
     const formValues = minimalForm({
       notes: '',
@@ -58,6 +74,16 @@ describe('buildPayloadForCreate', () => {
 });
 
 describe('buildPayloadForUpdate', () => {
+  it('maps cleared lookAheadSection to null so PATCH clears the DB column', () => {
+    const formValues = minimalForm({
+      lookAheadSection: undefined,
+    });
+
+    const payload = buildPayloadForUpdate(formValues, formValues);
+
+    expect(payload.lookAheadSection).toBeNull();
+  });
+
   it('strips UI sentinels from optional fields before sending to API', () => {
     const formValues = minimalForm({
       notes: '',

--- a/calendar-ui/src/lib/activity-form-payload.ts
+++ b/calendar-ui/src/lib/activity-form-payload.ts
@@ -26,6 +26,7 @@ function buildPayloadFromPrepared(
     endDate: prepared.endDate ?? null,
     startTime: prepared.startTime ?? null,
     endTime: prepared.endTime ?? null,
+    lookAheadSection: prepared.lookAheadSection ?? null,
     categoryIds: toUndefinedIfEmpty(preparedFormValues.categoryIds),
     tagIds: toUndefinedIfEmpty(preparedFormValues.tagIds),
     commsMaterialIds: toUndefinedIfEmpty(preparedFormValues.commsMaterialIds),

--- a/calendar-ui/src/lib/activity-form-payload.ts
+++ b/calendar-ui/src/lib/activity-form-payload.ts
@@ -9,7 +9,12 @@ function toUndefinedIfEmpty<T>(arr: T[] | undefined): T[] | undefined {
   return arr;
 }
 
-export type CreatePayloadOptions = {
+export type ActivityFormPayloadOptions = {
+  /** Lookup ID for translation_required_statuses.name === 'required'. */
+  requiredTranslationStatusId?: number;
+};
+
+export type CreatePayloadOptions = ActivityFormPayloadOptions & {
   markAsReviewed?: boolean;
 };
 
@@ -52,17 +57,27 @@ export function buildPayloadForCreate(
   formValues: ActivityFormData,
   options?: CreatePayloadOptions
 ): Record<string, unknown> {
+  const { requiredTranslationStatusId, ...createOptions } = options ?? {};
   return buildPayloadFromPrepared(
-    prepareActivityFormDataForSubmit(data),
-    prepareActivityFormDataForSubmit(formValues),
-    options
+    prepareForSubmit(data, requiredTranslationStatusId),
+    prepareForSubmit(formValues, requiredTranslationStatusId),
+    createOptions
   );
 }
 
-export type UpdatePayloadOptions = {
+export type UpdatePayloadOptions = ActivityFormPayloadOptions & {
   markAsReviewed?: boolean;
   markAsCompleted?: boolean;
 };
+
+function prepareForSubmit(
+  data: ActivityFormData,
+  requiredTranslationStatusId: number | undefined
+): ActivityFormData {
+  return prepareActivityFormDataForSubmit(data, {
+    requiredTranslationStatusId,
+  });
+}
 
 /**
  * Builds the request payload for updating an activity from form values.
@@ -74,12 +89,16 @@ export function buildPayloadForUpdate(
   formValues: ActivityFormData,
   options?: UpdatePayloadOptions
 ): Record<string, unknown> {
-  const prepared = prepareActivityFormDataForSubmit(data);
-  const preparedFormValues = prepareActivityFormDataForSubmit(formValues);
+  const { requiredTranslationStatusId, markAsReviewed, markAsCompleted } =
+    options ?? {};
+  const prepared = prepareForSubmit(data, requiredTranslationStatusId);
+  const preparedFormValues = prepareForSubmit(
+    formValues,
+    requiredTranslationStatusId
+  );
   const normalizedReportSettings = normalizeReportSettings(
     preparedFormValues.reportSettings
   );
-  const { markAsReviewed, markAsCompleted } = options ?? {};
   const payload: Record<string, unknown> = {
     ...buildPayloadFromPrepared(prepared, preparedFormValues),
     reportSettings: normalizedReportSettings,

--- a/calendar-ui/src/lib/activity-form-section-labels.ts
+++ b/calendar-ui/src/lib/activity-form-section-labels.ts
@@ -1,29 +1,9 @@
 /**
- * Section IDs for the activity form. Matches the logical grouping of fields.
+ * Re-exported from `@corpcal/shared`. Section registry: `activity-form-sections.ts`.
+ * See `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md` when changing form layout.
  */
-export type ActivityFormSectionId =
-  | 'overview'
-  | 'comms'
-  | 'newsRelease'
-  | 'reports'
-  | 'schedule'
-  | 'event'
-  | 'sharing'
-  | 'venue';
-
-/**
- * User-facing labels for activity form sections. Single source of truth for section titles.
- */
-export const ACTIVITY_FORM_SECTION_LABELS: Record<
-  ActivityFormSectionId,
-  string
-> = {
-  overview: 'Overview',
-  comms: 'Comms',
-  newsRelease: 'Release',
-  reports: 'Reports',
-  schedule: 'Schedule',
-  event: 'Event',
-  sharing: 'Sharing',
-  venue: 'Venue',
-};
+export {
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_LABELS,
+  type ActivityFormSectionId,
+} from '@corpcal/shared';

--- a/calendar-ui/src/lib/activity-form-translation-required.ts
+++ b/calendar-ui/src/lib/activity-form-translation-required.ts
@@ -1,0 +1,9 @@
+import { TRANSLATION_REQUIRED_LOOKUP_NAME } from '@corpcal/shared';
+import type { TranslationRequiredStatusLookupItem } from '@corpcal/shared/api/types';
+
+export function resolveTranslationRequiredStatusId(
+  statuses: TranslationRequiredStatusLookupItem[],
+  lookupName: string = TRANSLATION_REQUIRED_LOOKUP_NAME
+): number | undefined {
+  return statuses.find((status) => status.name === lookupName)?.id;
+}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -75,6 +75,7 @@ import {
   buildPayloadForUpdate,
   type UpdatePayloadOptions,
 } from '../lib/activity-form-payload';
+import { resolveTranslationRequiredStatusId } from '../lib/activity-form-translation-required';
 import { computeFormChanges } from '../lib/activity-history-format';
 import { showActivityMutationSuccessToast } from '../lib/activity-mutation-success-toast';
 import { resolveActivityToastDisplayId } from '../lib/activity-toast-options';
@@ -135,6 +136,11 @@ export function ActivityPage({
       getFieldLabel: getActivityFieldLabel,
       schema: createActivityRequestSchema,
     });
+  const requiredTranslationStatusId = useMemo(
+    () =>
+      resolveTranslationRequiredStatusId(lookups.translationRequiredStatuses),
+    [lookups.translationRequiredStatuses]
+  );
   const canReviewActivities = hasPermission(PERMISSIONS.ACTIVITIES.REVIEW);
   const reviewerChangedPaths = useMemo<ReadonlySet<string>>(() => {
     const paths = canReviewActivities
@@ -551,10 +557,10 @@ export function ActivityPage({
         } else {
           const opts: UpdatePayloadOptions =
             mode.kind === 'reviewWithSave'
-              ? { markAsReviewed: true }
+              ? { markAsReviewed: true, requiredTranslationStatusId }
               : mode.kind === 'completeWithSave'
-                ? { markAsCompleted: true }
-                : {};
+                ? { markAsCompleted: true, requiredTranslationStatusId }
+                : { requiredTranslationStatusId };
           submitData = {
             ...buildPayloadForUpdate(
               mode.validatedData,
@@ -618,6 +624,7 @@ export function ActivityPage({
       canViewActivity,
       applyExternalLockReleased,
       navigate,
+      requiredTranslationStatusId,
     ]
   );
 

--- a/calendar-ui/src/pages/CreateActivityForm.tsx
+++ b/calendar-ui/src/pages/CreateActivityForm.tsx
@@ -1,7 +1,7 @@
 import { ErrorBoundary } from 'react-error-boundary';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { useState, type FC } from 'react';
+import { useMemo, useState, type FC } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared/auth';
 import {
@@ -27,6 +27,7 @@ import { useCreateActivity } from '../hooks/useCalendar';
 import { getActivityFieldLabel } from '../lib/activity-form-labels';
 import { getActivityFormBackTarget } from '../lib/activity-form-navigation-state';
 import { buildPayloadForCreate } from '../lib/activity-form-payload';
+import { resolveTranslationRequiredStatusId } from '../lib/activity-form-translation-required';
 import { showActivityMutationSuccessToast } from '../lib/activity-mutation-success-toast';
 import { resolveActivityToastDisplayId } from '../lib/activity-toast-options';
 import {
@@ -79,6 +80,12 @@ export const CreateActivityForm: FC = () => {
       schema: createActivityRequestSchema,
     });
 
+  const requiredTranslationStatusId = useMemo(
+    () =>
+      resolveTranslationRequiredStatusId(lookups.translationRequiredStatuses),
+    [lookups.translationRequiredStatuses]
+  );
+
   const handleCancel = () => {
     void form.reset();
     void navigate(listOrBackPath);
@@ -100,6 +107,7 @@ export const CreateActivityForm: FC = () => {
       const formValues = form.getValues();
       const submitData = buildPayloadForCreate(validatedData, formValues, {
         markAsReviewed: canReviewActivities ? markAsReviewed : undefined,
+        requiredTranslationStatusId,
       });
       const payload = {
         ...submitData,

--- a/packages/shared/docs/ACTIVITY_FORM_SECTIONS.md
+++ b/packages/shared/docs/ACTIVITY_FORM_SECTIONS.md
@@ -1,0 +1,50 @@
+# Activity form sections
+
+Canonical section order, labels, and field membership live in:
+
+`packages/shared/src/activity-form-sections.ts`
+
+The activity form UI is composed in `calendar-ui/src/components/activity/ActivityFormBody.tsx` using one component per section under `ActivityFormSections/`.
+
+## When you change the form
+
+1. **Update the registry** — add/move/remove the top-level `ActivityFormData` key under the correct section in `ACTIVITY_FORM_SECTION_FIELDS`. Adjust `ACTIVITY_FORM_SECTION_IDS` and `ACTIVITY_FORM_SECTION_LABELS` if you add or rename a section.
+2. **Update the section component** — render the field in the matching `Activity*Section.tsx` file.
+3. **Update `ActivityFormBody`** — if section order or column layout changes.
+4. **Review-exempt** — if the field should be admin-configurable, ensure it is listed in the registry and **not** in `ACTIVITY_REVIEW_EXEMPT_CODE_KEYS` (`review-exempt-settings.ts`). The admin UI grouping is derived automatically.
+5. **Clone modal** — optional advanced fields are derived from the registry minus exclusions in `clone-activity.schema.ts` (`CLONE_NEVER_COPIED_FIELD_KEYS`, etc.). Add clone-specific exclusions there; do not duplicate section lists.
+6. **Run tests** — `npm test -- activity-form-sections` in `packages/shared`.
+
+## Derived consumers (do not duplicate section lists)
+
+| Consumer                              | Source                                                      |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Review-exempt Settings combobox       | `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS`              |
+| Clone modal “More options” checkboxes | `CLONE_ADVANCED_SECTIONS` / `CLONE_ADVANCED_FIELD_GROUPS`   |
+| Section headings in form components   | `ACTIVITY_FORM_SECTION_LABELS` (re-exported in calendar-ui) |
+
+## Section order (current)
+
+| Column | Sections                                       |
+| ------ | ---------------------------------------------- |
+| Left   | Overview → Comms                               |
+| Right  | Reports → Schedule → Release → Event → Sharing |
+
+## Notes
+
+- **`newsReleaseId`** — still on `ActivityFormData` but not rendered in the form; listed under Release for review-exempt configurability only. Excluded from clone advanced options in `clone-activity.schema.ts`.
+- **Nested paths** (e.g. `venueAddress.city`) are not listed here; clone/review use top-level keys (`venueAddress`) where applicable.
+- **Code-exempt review fields** (`ACTIVITY_REVIEW_EXEMPT_CODE_KEYS`) remain in the registry but are filtered out of the admin Settings UI.
+
+## Keys intentionally omitted from the registry
+
+These top-level `ActivityFormData` keys are listed in `ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS` and must not appear in any section. A compile-time and runtime test in `activity-form-sections.test.ts` fails if a schema key is missing from both the registry and this list.
+
+| Key                    | Reason                                                     |
+| ---------------------- | ---------------------------------------------------------- |
+| `activityStatusId`     | Backend-owned status; excluded from review diff            |
+| `markAsReviewed`       | Create/clone workflow flag, not a form section field       |
+| `markAsCompleted`      | Complete workflow flag, not a form section field           |
+| `activityHistoryNotes` | Audit/history note on create or clone, not the main form   |
+| `commsContactLeadId`   | UI convenience; submitted as `commsContacts` with `isLead` |
+| `leadMinistryId`       | Derived from lead team ministry                            |

--- a/packages/shared/src/activity-form-sections.test.ts
+++ b/packages/shared/src/activity-form-sections.test.ts
@@ -12,30 +12,12 @@ import {
   ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS,
   ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS,
 } from './review-exempt-settings';
-import {
-  createActivityRequestSchema,
-  type ActivityFormData,
-} from './schemas/activity.schema';
+import { createActivityRequestSchema } from './schemas/activity.schema';
 import {
   CLONE_ADVANCED_FIELD_GROUPS,
   CLONE_ADVANCED_FIELD_PATHS,
   CLONE_ADVANCED_SECTIONS,
 } from './schemas/clone-activity.schema';
-
-type RegistryFieldKey = {
-  [Section in (typeof ACTIVITY_FORM_SECTION_IDS)[number]]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
-}[(typeof ACTIVITY_FORM_SECTION_IDS)[number]];
-
-type UnaccountedActivityFormKey = Exclude<
-  keyof ActivityFormData,
-  | RegistryFieldKey
-  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
->;
-
-/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
-const _registryCompleteness: UnaccountedActivityFormKey extends never
-  ? true
-  : UnaccountedActivityFormKey = true;
 
 describe('activity-form-sections', () => {
   it('uses unique field keys across sections', () => {
@@ -145,5 +127,3 @@ describe('activity-form-sections', () => {
     );
   });
 });
-
-void _registryCompleteness;

--- a/packages/shared/src/activity-form-sections.test.ts
+++ b/packages/shared/src/activity-form-sections.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS,
+  getActivityFormSectionFieldKeys,
+  getActivityFormSectionFieldKeySet,
+} from './activity-form-sections';
+import {
+  ACTIVITY_REVIEW_EXEMPT_CODE_KEYS,
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS,
+  ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS,
+} from './review-exempt-settings';
+import {
+  createActivityRequestSchema,
+  type ActivityFormData,
+} from './schemas/activity.schema';
+import {
+  CLONE_ADVANCED_FIELD_GROUPS,
+  CLONE_ADVANCED_FIELD_PATHS,
+  CLONE_ADVANCED_SECTIONS,
+} from './schemas/clone-activity.schema';
+
+type RegistryFieldKey = {
+  [Section in (typeof ACTIVITY_FORM_SECTION_IDS)[number]]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
+}[(typeof ACTIVITY_FORM_SECTION_IDS)[number]];
+
+type UnaccountedActivityFormKey = Exclude<
+  keyof ActivityFormData,
+  | RegistryFieldKey
+  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
+>;
+
+/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
+const _registryCompleteness: UnaccountedActivityFormKey extends never
+  ? true
+  : UnaccountedActivityFormKey = true;
+
+describe('activity-form-sections', () => {
+  it('uses unique field keys across sections', () => {
+    const keys = getActivityFormSectionFieldKeys();
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('accounts for every ActivityFormData key via registry or omitted list', () => {
+    const registryKeys = getActivityFormSectionFieldKeySet();
+    const omittedKeys = new Set(
+      ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS.map(String)
+    );
+    const schemaKeys = Object.keys(createActivityRequestSchema.shape);
+
+    expect(registryKeys.size + omittedKeys.size).toBe(schemaKeys.length);
+    for (const key of schemaKeys) {
+      expect(registryKeys.has(key) || omittedKeys.has(key)).toBe(true);
+    }
+    for (const key of registryKeys) {
+      expect(omittedKeys.has(key)).toBe(false);
+    }
+  });
+
+  it('derives review-exempt sections in form order with Release after Schedule', () => {
+    const sectionIds = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.map(
+      (s) => s.id
+    );
+    expect(sectionIds).toEqual([
+      'overview',
+      'comms',
+      'reports',
+      'schedule',
+      'newsRelease',
+      'event',
+      'sharing',
+    ]);
+  });
+
+  it('places release fields under newsRelease, not comms', () => {
+    const commsKeys =
+      ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.find((s) => s.id === 'comms')
+        ?.keys ?? [];
+    const releaseKeys =
+      ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS.find(
+        (s) => s.id === 'newsRelease'
+      )?.keys ?? [];
+
+    expect(commsKeys).toEqual([
+      'commsContacts',
+      'strategy',
+      'commsMaterialIds',
+    ]);
+    expect(releaseKeys).toEqual([
+      'newsReleaseId',
+      'newsReleaseOriginId',
+      'newsReleaseDistributionId',
+      'translationsRequiredStatusId',
+      'translationLanguageIds',
+    ]);
+  });
+
+  it('derives review-exempt keys from registry minus code-exempt keys', () => {
+    const expected = ACTIVITY_FORM_SECTION_IDS.flatMap((id) =>
+      ACTIVITY_FORM_SECTION_FIELDS[id].filter(
+        (key) => !ACTIVITY_REVIEW_EXEMPT_CODE_KEYS.has(String(key))
+      )
+    ).map(String);
+    expect([...ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS]).toEqual(expected);
+  });
+
+  it('derives clone advanced field groups from registry minus clone exclusions', () => {
+    expect(CLONE_ADVANCED_SECTIONS).toEqual([
+      'overview',
+      'comms',
+      'reports',
+      'schedule',
+      'newsRelease',
+      'event',
+      'sharing',
+    ]);
+    expect(CLONE_ADVANCED_FIELD_GROUPS).toEqual({
+      overview: [
+        'tagIds',
+        'leadOrgId',
+        'leadOrgName',
+        'significance',
+        'isIssue',
+        'isConfidential',
+        'notes',
+      ],
+      comms: ['strategy', 'commsMaterialIds'],
+      reports: ['reportSettings'],
+      schedule: ['schedulingNotes'],
+      newsRelease: ['newsReleaseOriginId', 'newsReleaseDistributionId'],
+      event: [
+        'venueStatusId',
+        'venueAddress',
+        'premierRequestedId',
+        'representatives',
+        'eventPlanners',
+      ],
+      sharing: ['visibility', 'sharedWithTeamIds'],
+    });
+    expect(CLONE_ADVANCED_FIELD_PATHS).not.toContain('newsReleaseId');
+    expect(CLONE_ADVANCED_FIELD_PATHS).not.toContain(
+      'translationsRequiredStatusId'
+    );
+  });
+});
+
+void _registryCompleteness;

--- a/packages/shared/src/activity-form-sections.ts
+++ b/packages/shared/src/activity-form-sections.ts
@@ -1,0 +1,131 @@
+import type { ActivityFormData } from './schemas/activity.schema';
+
+/**
+ * Canonical activity form section registry.
+ *
+ * Single source of truth for section order, labels, and top-level field membership.
+ * Mirrors `ActivityFormBody` in calendar-ui and the `Activity*Section` components.
+ *
+ * Downstream consumers derive their groupings from here:
+ * - Review-exempt admin UI — `ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS` in
+ *   `review-exempt-settings.ts` (filters out code-exempt keys).
+ * - Clone modal advanced options — `CLONE_ADVANCED_*` in `clone-activity.schema.ts`
+ *   (filters out clone-specific exclusions).
+ *
+ * When the form changes, update this file first, then the matching section component
+ * in `calendar-ui/src/components/activity/ActivityFormSections/`. See
+ * `packages/shared/docs/ACTIVITY_FORM_SECTIONS.md`.
+ */
+
+/** Section order as rendered in the activity form (left column, then right). */
+export const ACTIVITY_FORM_SECTION_IDS = [
+  'overview',
+  'comms',
+  'reports',
+  'schedule',
+  'newsRelease',
+  'event',
+  'sharing',
+] as const;
+
+export type ActivityFormSectionId = (typeof ACTIVITY_FORM_SECTION_IDS)[number];
+
+/** User-facing section titles. */
+export const ACTIVITY_FORM_SECTION_LABELS: Record<
+  ActivityFormSectionId,
+  string
+> = {
+  overview: 'Overview',
+  comms: 'Comms',
+  reports: 'Reports',
+  schedule: 'Schedule',
+  newsRelease: 'Release',
+  event: 'Event',
+  sharing: 'Sharing',
+};
+
+/**
+ * Top-level `ActivityFormData` keys owned by each section.
+ * Include code-exempt or clone-excluded keys here for completeness; consumers filter.
+ */
+export const ACTIVITY_FORM_SECTION_FIELDS: Record<
+  ActivityFormSectionId,
+  readonly (keyof ActivityFormData)[]
+> = {
+  overview: [
+    'title',
+    'categoryIds',
+    'tagIds',
+    'leadTeamId',
+    'leadOrgId',
+    'leadOrgName',
+    'significance',
+    'isIssue',
+    'isConfidential',
+    'summary',
+    'notes',
+    'pitchRequiredStatusId',
+    'pitchDate',
+  ],
+  comms: ['commsContacts', 'strategy', 'commsMaterialIds'],
+  reports: [
+    'reportSettings',
+    'executiveSummary',
+    'lookAheadStatus',
+    'lookAheadSection',
+  ],
+  schedule: [
+    'startDate',
+    'endDate',
+    'startTime',
+    'endTime',
+    'isAllDay',
+    'dateStatusId',
+    'timeStatusId',
+    'schedulingNotes',
+  ],
+  newsRelease: [
+    'newsReleaseId',
+    'newsReleaseOriginId',
+    'newsReleaseDistributionId',
+    'translationsRequiredStatusId',
+    'translationLanguageIds',
+  ],
+  event: [
+    'venueStatusId',
+    'venueAddress',
+    'premierRequestedId',
+    'representatives',
+    'eventPlanners',
+  ],
+  sharing: ['visibility', 'sharedWithTeamIds'],
+};
+
+/**
+ * Top-level `ActivityFormData` keys intentionally omitted from the section registry.
+ * System-owned, derived, or UI-only convenience fields — not grouped in the form.
+ */
+export const ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS = [
+  'activityStatusId',
+  'markAsCompleted',
+  'markAsReviewed',
+  'activityHistoryNotes',
+  'commsContactLeadId',
+  'leadMinistryId',
+] as const satisfies readonly (keyof ActivityFormData)[];
+
+/** Flat list of all section field keys in section order (each key appears at most once). */
+export function getActivityFormSectionFieldKeys(): readonly string[] {
+  const keys: string[] = [];
+  for (const id of ACTIVITY_FORM_SECTION_IDS) {
+    for (const key of ACTIVITY_FORM_SECTION_FIELDS[id]) {
+      keys.push(String(key));
+    }
+  }
+  return keys;
+}
+
+/** Set of all keys listed in {@link ACTIVITY_FORM_SECTION_FIELDS}. */
+export function getActivityFormSectionFieldKeySet(): ReadonlySet<string> {
+  return new Set(getActivityFormSectionFieldKeys());
+}

--- a/packages/shared/src/activity-form-sections.ts
+++ b/packages/shared/src/activity-form-sections.ts
@@ -48,10 +48,7 @@ export const ACTIVITY_FORM_SECTION_LABELS: Record<
  * Top-level `ActivityFormData` keys owned by each section.
  * Include code-exempt or clone-excluded keys here for completeness; consumers filter.
  */
-export const ACTIVITY_FORM_SECTION_FIELDS: Record<
-  ActivityFormSectionId,
-  readonly (keyof ActivityFormData)[]
-> = {
+export const ACTIVITY_FORM_SECTION_FIELDS = {
   overview: [
     'title',
     'categoryIds',
@@ -99,7 +96,10 @@ export const ACTIVITY_FORM_SECTION_FIELDS: Record<
     'eventPlanners',
   ],
   sharing: ['visibility', 'sharedWithTeamIds'],
-};
+} as const satisfies Record<
+  ActivityFormSectionId,
+  readonly (keyof ActivityFormData)[]
+>;
 
 /**
  * Top-level `ActivityFormData` keys intentionally omitted from the section registry.
@@ -113,6 +113,24 @@ export const ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS = [
   'commsContactLeadId',
   'leadMinistryId',
 ] as const satisfies readonly (keyof ActivityFormData)[];
+
+type ActivityFormSectionFieldKey = {
+  [Section in ActivityFormSectionId]: (typeof ACTIVITY_FORM_SECTION_FIELDS)[Section][number];
+}[ActivityFormSectionId];
+
+type UnaccountedActivityFormDataKey = Exclude<
+  keyof ActivityFormData,
+  | ActivityFormSectionFieldKey
+  | (typeof ACTIVITY_FORM_SECTION_REGISTRY_OMITTED_KEYS)[number]
+>;
+
+/** Compile-time guard: registry + omitted keys must cover all ActivityFormData keys. */
+type AssertRegistryComplete = UnaccountedActivityFormDataKey extends never
+  ? true
+  : UnaccountedActivityFormDataKey;
+
+const _assertRegistryComplete: AssertRegistryComplete = true;
+void _assertRegistryComplete;
 
 /** Flat list of all section field keys in section order (each key appears at most once). */
 export function getActivityFormSectionFieldKeys(): readonly string[] {

--- a/packages/shared/src/constants/constants.ts
+++ b/packages/shared/src/constants/constants.ts
@@ -198,6 +198,11 @@ export const DEFAULT_VISIBILITY = 'global' as const;
  */
 export const PITCH_TRANSLATION_PENDING_LOOKUP_NAME = 'pending' as const;
 
+/**
+ * Lookup `name` for translation_required_statuses when translations are mandatory.
+ */
+export const TRANSLATION_REQUIRED_LOOKUP_NAME = 'required' as const;
+
 // ============================================================================
 // Auth Constants
 // ============================================================================

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './activities';
 export * from './activity-filter-state';
 export * from './activity-completion';
+export * from './activity-form-sections';
 export * from './datetime';
 export * from './filters/activityFilterStateToQueryParams';
 export * from './filters/activity-filter-active';

--- a/packages/shared/src/review-exempt-settings.ts
+++ b/packages/shared/src/review-exempt-settings.ts
@@ -1,4 +1,16 @@
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+  ACTIVITY_FORM_SECTION_LABELS,
+  type ActivityFormSectionId,
+} from './activity-form-sections';
 import type { ActivityFormData } from './schemas/activity.schema';
+
+export type ReviewExemptConfigurableSection = {
+  readonly id: ActivityFormSectionId;
+  readonly title: string;
+  readonly keys: readonly (keyof ActivityFormData)[];
+};
 
 /**
  * `application_settings.key` for JSON array of admin-configurable review-exempt
@@ -34,76 +46,17 @@ export const ACTIVITY_REVIEW_EXEMPT_CODE_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Admin UI + server allowlist, grouped to mirror {@link ActivityFormBody} section
- * order (left: Overview, Comms; right: Reports, Schedule, Event, Sharing).
- * Keep in sync when form sections or top-level field sets change.
+ * Admin UI + server allowlist, grouped from {@link ACTIVITY_FORM_SECTION_FIELDS}.
+ * Omits {@link ACTIVITY_REVIEW_EXEMPT_CODE_KEYS}. See `docs/ACTIVITY_FORM_SECTIONS.md`.
  */
-export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS = [
-  {
-    id: 'overview' as const,
-    title: 'Overview',
-    keys: [
-      'title',
-      'categoryIds',
-      'tagIds',
-      'leadTeamId',
-      'leadOrgId',
-      'significance',
-      'isIssue',
-      'isConfidential',
-      'notes',
-      'pitchRequiredStatusId',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'comms' as const,
-    title: 'Comms',
-    keys: [
-      'commsContacts',
-      'strategy',
-      'commsMaterialIds',
-      'newsReleaseId',
-      'newsReleaseOriginId',
-      'newsReleaseDistributionId',
-      'translationsRequiredStatusId',
-      'translationLanguageIds',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'reports' as const,
-    title: 'Reports',
-    keys: [
-      'reportSettings',
-      'executiveSummary',
-      'lookAheadStatus',
-      'lookAheadSection',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'schedule' as const,
-    title: 'Schedule',
-    keys: ['schedulingNotes'] as const satisfies ReadonlyArray<
-      keyof ActivityFormData
-    >,
-  },
-  {
-    id: 'event' as const,
-    title: 'Event',
-    keys: [
-      'venueAddress',
-      'premierRequestedId',
-      'representatives',
-      'eventPlanners',
-    ] as const satisfies ReadonlyArray<keyof ActivityFormData>,
-  },
-  {
-    id: 'sharing' as const,
-    title: 'Sharing',
-    keys: ['visibility', 'sharedWithTeamIds'] as const satisfies ReadonlyArray<
-      keyof ActivityFormData
-    >,
-  },
-] as const;
+export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS: readonly ReviewExemptConfigurableSection[] =
+  ACTIVITY_FORM_SECTION_IDS.map((id) => ({
+    id,
+    title: ACTIVITY_FORM_SECTION_LABELS[id],
+    keys: ACTIVITY_FORM_SECTION_FIELDS[id].filter(
+      (key) => !ACTIVITY_REVIEW_EXEMPT_CODE_KEYS.has(String(key))
+    ),
+  })).filter((section) => section.keys.length > 0);
 
 const CONFIGURABLE_FLAT: string[] = [];
 for (const s of ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_SECTIONS) {
@@ -118,11 +71,6 @@ export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEY_SET: ReadonlySet<string> =
 /** Flat allowlist in stable order (section order) for zod/validation. */
 export const ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS: readonly string[] =
   CONFIGURABLE_FLAT;
-
-const ZOD_ENUM = ACTIVITY_REVIEW_EXEMPT_CONFIGURABLE_KEYS as [
-  string,
-  ...string[],
-];
 
 /**
  * Merges code-exempt keys with allowlisted configurable keys (typically from DB).

--- a/packages/shared/src/schemas/clone-activity.schema.ts
+++ b/packages/shared/src/schemas/clone-activity.schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+import {
+  ACTIVITY_FORM_SECTION_FIELDS,
+  ACTIVITY_FORM_SECTION_IDS,
+} from '../activity-form-sections';
 import type { ActivityFormData } from './activity.schema';
 
 /**
@@ -102,69 +106,6 @@ export const CLONE_SYSTEM_FIELD_KEYS = [
 export type CloneSystemFieldKey = (typeof CLONE_SYSTEM_FIELD_KEYS)[number];
 
 /**
- * Section identifiers used to group the advanced field list in the clone
- * modal. These match the form section labels used elsewhere in the UI.
- */
-export const CLONE_ADVANCED_SECTIONS = [
-  'overview',
-  'comms',
-  'reports',
-  'schedule',
-  'event',
-  'sharing',
-] as const;
-
-export type CloneAdvancedSection = (typeof CLONE_ADVANCED_SECTIONS)[number];
-
-/**
- * Advanced field inventory for the clone modal, grouped by form section.
- * Each entry is a top-level `ActivityFormData` key (or dotted path) that
- * the user can toggle on/off before confirming the clone.
- *
- * Keys are excluded when they:
- * - appear in `CLONE_MODAL_SCHEDULE_FIELD_KEYS` (handled in the modal)
- * - appear in `CLONE_NEVER_COPIED_FIELD_KEYS` (never carried over)
- * - appear in `CLONE_SYSTEM_FIELD_KEYS` (owned by the server)
- * - are required on create (title, categoryIds, leadTeamId, summary,
- *   commsContacts) — always copied or re-entered, never optional
- */
-export const CLONE_ADVANCED_FIELD_GROUPS: Record<
-  CloneAdvancedSection,
-  readonly string[]
-> = {
-  overview: [
-    'leadOrgId',
-    'isConfidential',
-    'isIssue',
-    'significance',
-    'notes',
-    'tagIds',
-  ],
-  comms: [
-    'strategy',
-    'commsMaterialIds',
-    'newsReleaseOriginId',
-    'newsReleaseDistributionId',
-  ],
-  reports: ['reportSettings'],
-  schedule: ['schedulingNotes'],
-  event: [
-    'premierRequestedId',
-    'representatives',
-    'venueStatusId',
-    'venueAddress',
-    'eventPlanners',
-  ],
-  sharing: ['visibility', 'sharedWithTeamIds'],
-} as const;
-
-/** Flat list of all advanced field paths a user may toggle. */
-export const CLONE_ADVANCED_FIELD_PATHS: readonly string[] =
-  CLONE_ADVANCED_SECTIONS.flatMap(
-    (section) => CLONE_ADVANCED_FIELD_GROUPS[section]
-  );
-
-/**
  * Fields that are always copied on clone (required on create, and not in the
  * modal). The server applies these regardless of `includeFieldPaths`.
  */
@@ -177,6 +118,53 @@ export const CLONE_ALWAYS_COPIED_FIELD_KEYS = [
 
 export type CloneAlwaysCopiedFieldKey =
   (typeof CLONE_ALWAYS_COPIED_FIELD_KEYS)[number];
+
+/**
+ * Top-level keys excluded from the clone modal advanced field list.
+ * Section membership comes from {@link ACTIVITY_FORM_SECTION_FIELDS}; see
+ * `docs/ACTIVITY_FORM_SECTIONS.md`.
+ */
+const CLONE_ADVANCED_FIELD_EXCLUSIONS = new Set<string>([
+  ...CLONE_MODAL_SCHEDULE_FIELD_KEYS,
+  ...CLONE_NEVER_COPIED_FIELD_KEYS,
+  ...CLONE_ALWAYS_COPIED_FIELD_KEYS,
+  ...CLONE_SYSTEM_FIELD_KEYS,
+  'title',
+  'newsReleaseId', // on schema only; not rendered or cloneable in UI
+]);
+
+function isCloneAdvancedField(key: keyof ActivityFormData): boolean {
+  return !CLONE_ADVANCED_FIELD_EXCLUSIONS.has(String(key));
+}
+
+/** Sections that have at least one clone-advanced field after exclusions. */
+export const CLONE_ADVANCED_SECTIONS = ACTIVITY_FORM_SECTION_IDS.filter((id) =>
+  ACTIVITY_FORM_SECTION_FIELDS[id].some(isCloneAdvancedField)
+);
+
+export type CloneAdvancedSection = (typeof CLONE_ADVANCED_SECTIONS)[number];
+
+function buildCloneAdvancedFieldGroups(): Record<
+  CloneAdvancedSection,
+  readonly string[]
+> {
+  const groups = {} as Record<CloneAdvancedSection, readonly string[]>;
+  for (const id of CLONE_ADVANCED_SECTIONS) {
+    groups[id] = ACTIVITY_FORM_SECTION_FIELDS[id]
+      .filter(isCloneAdvancedField)
+      .map(String);
+  }
+  return groups;
+}
+
+/** Advanced field inventory for the clone modal, grouped by form section. */
+export const CLONE_ADVANCED_FIELD_GROUPS = buildCloneAdvancedFieldGroups();
+
+/** Flat list of all advanced field paths a user may toggle. */
+export const CLONE_ADVANCED_FIELD_PATHS: readonly string[] =
+  CLONE_ADVANCED_SECTIONS.flatMap(
+    (section) => CLONE_ADVANCED_FIELD_GROUPS[section]
+  );
 
 /**
  * Allowed values the server will accept in `includeFieldPaths`. Anything

--- a/packages/shared/src/utils/activity-field-labels.ts
+++ b/packages/shared/src/utils/activity-field-labels.ts
@@ -68,7 +68,7 @@ export const ACTIVITY_FIELD_LABELS: Partial<
   commsMaterialIds: 'Comms materials',
   translationLanguageIds: 'Translation languages',
   sharedWithTeamIds: 'Share with',
-  visibility: 'Visibility',
+  visibility: 'Restrict access',
   notes: 'Notes',
   strategy: 'Strategy',
   isIssue: 'Issue',

--- a/packages/shared/src/utils/activity-form-canonicalize.spec.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.spec.ts
@@ -156,6 +156,17 @@ describe('prepareActivityFormDataForSubmit', () => {
     expect(prepared.translationLanguageIds).toEqual([1, 2]);
   });
 
+  it('preserves translationLanguageIds when required status lookup is unresolved', () => {
+    const prepared = prepareActivityFormDataForSubmit(
+      minimalForm({
+        translationsRequiredStatusId: 2,
+        translationLanguageIds: [1, 2],
+      })
+    );
+
+    expect(prepared.translationLanguageIds).toEqual([1, 2]);
+  });
+
   it('preserves non-empty optional field values', () => {
     const prepared = prepareActivityFormDataForSubmit(
       minimalForm({

--- a/packages/shared/src/utils/activity-form-canonicalize.spec.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.spec.ts
@@ -121,6 +121,15 @@ describe('prepareActivityFormDataForSubmit', () => {
     expect(prepared.strategy).toBeNull();
     expect(prepared.significance).toBeNull();
     expect(prepared.executiveSummary).toBeNull();
+    expect(prepared.lookAheadSection).toBeNull();
+  });
+
+  it('preserves lookAheadSection when a section key is set', () => {
+    const prepared = prepareActivityFormDataForSubmit(
+      minimalForm({ lookAheadSection: 'events' })
+    );
+
+    expect(prepared.lookAheadSection).toBe('events');
   });
 
   it('preserves non-empty optional field values', () => {

--- a/packages/shared/src/utils/activity-form-canonicalize.spec.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.spec.ts
@@ -132,6 +132,30 @@ describe('prepareActivityFormDataForSubmit', () => {
     expect(prepared.lookAheadSection).toBe('events');
   });
 
+  it('clears translationLanguageIds when status is not required', () => {
+    const prepared = prepareActivityFormDataForSubmit(
+      minimalForm({
+        translationsRequiredStatusId: 1,
+        translationLanguageIds: [1, 2],
+      }),
+      { requiredTranslationStatusId: 2 }
+    );
+
+    expect(prepared.translationLanguageIds).toEqual([]);
+  });
+
+  it('preserves translationLanguageIds when status is required', () => {
+    const prepared = prepareActivityFormDataForSubmit(
+      minimalForm({
+        translationsRequiredStatusId: 2,
+        translationLanguageIds: [1, 2],
+      }),
+      { requiredTranslationStatusId: 2 }
+    );
+
+    expect(prepared.translationLanguageIds).toEqual([1, 2]);
+  });
+
   it('preserves non-empty optional field values', () => {
     const prepared = prepareActivityFormDataForSubmit(
       minimalForm({

--- a/packages/shared/src/utils/activity-form-canonicalize.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.ts
@@ -128,10 +128,10 @@ export function stripTranslationLanguagesWhenNotRequired(
   data: ActivityFormData,
   requiredTranslationStatusId: number | undefined
 ): ActivityFormData {
-  if (
-    requiredTranslationStatusId != null &&
-    data.translationsRequiredStatusId === requiredTranslationStatusId
-  ) {
+  if (requiredTranslationStatusId == null) {
+    return data;
+  }
+  if (data.translationsRequiredStatusId === requiredTranslationStatusId) {
     return data;
   }
   if (!data.translationLanguageIds?.length) {

--- a/packages/shared/src/utils/activity-form-canonicalize.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.ts
@@ -112,6 +112,34 @@ export function canonicalizeActivityFormData(
   };
 }
 
+export type PrepareActivityFormDataOptions = {
+  /**
+   * Lookup ID for `translation_required_statuses.name === 'required'`.
+   * When set, {@link translationLanguageIds} are cleared unless status matches.
+   */
+  requiredTranslationStatusId?: number;
+};
+
+/**
+ * Removes translation language IDs when translations are not required for the
+ * current status (hidden in the release section UI).
+ */
+export function stripTranslationLanguagesWhenNotRequired(
+  data: ActivityFormData,
+  requiredTranslationStatusId: number | undefined
+): ActivityFormData {
+  if (
+    requiredTranslationStatusId != null &&
+    data.translationsRequiredStatusId === requiredTranslationStatusId
+  ) {
+    return data;
+  }
+  if (!data.translationLanguageIds?.length) {
+    return data;
+  }
+  return { ...data, translationLanguageIds: [] };
+}
+
 /**
  * Normalizes hydrated form values for create/update API payloads.
  *
@@ -121,9 +149,14 @@ export function canonicalizeActivityFormData(
  * fields to `null` for the request body.
  */
 export function prepareActivityFormDataForSubmit(
-  data: ActivityFormData
+  data: ActivityFormData,
+  options?: PrepareActivityFormDataOptions
 ): ActivityFormData {
-  const c = canonicalizeActivityFormData(data);
+  const stripped = stripTranslationLanguagesWhenNotRequired(
+    data,
+    options?.requiredTranslationStatusId
+  );
+  const c = canonicalizeActivityFormData(stripped);
   return {
     ...c,
     notes: c.notes ?? null,

--- a/packages/shared/src/utils/activity-form-canonicalize.ts
+++ b/packages/shared/src/utils/activity-form-canonicalize.ts
@@ -131,5 +131,6 @@ export function prepareActivityFormDataForSubmit(
     strategy: c.strategy ?? null,
     significance: c.significance ?? null,
     executiveSummary: c.executiveSummary ?? null,
+    lookAheadSection: c.lookAheadSection ?? null,
   };
 }


### PR DESCRIPTION
# PR: refactor/CORPCAL-254-activity-form-polish-b

## Summary

Polishes the activity create/edit form (CORPCAL-254): centralizes section metadata in shared, and improves Look Ahead, translation, and visibility UX. Submit payloads now strip orphan translation language IDs when translations are not required.

Updates Visibility select field to a switch (as discussed/designed with team), including dynamic support text.

## Important

- Shared package/types changed — run `npm run build:packages` before calendar-ui/calendar-service dev or CI.
- `calendar-service/src/lookups/lookups.controller.spec.ts` is an unrelated lint fix (removed unnecessary `as any`).

Clearer visibility text (includes info popover for more detail)
<img width="1231" height="384" alt="Screenshot 2026-06-12 at 4 24 25 PM" src="https://github.com/user-attachments/assets/dff53945-7dd6-463f-bca6-e14a8b9ba844" />

Add Look Ahead section `None` allowing users to remove activity from LA report (legacy functionality parity and real world use requirement)
<img width="1022" height="225" alt="Screenshot 2026-06-12 at 4 23 53 PM" src="https://github.com/user-attachments/assets/37ff14b5-d82c-4951-bf62-b6c57ed986c7" />

Conditional disclosure of Translation languages (languages are stripped on save if status !== required)
<img width="1214" height="220" alt="Screenshot 2026-06-12 at 4 25 44 PM" src="https://github.com/user-attachments/assets/d69d5409-1b54-4233-a988-35706d1b63f9" />
<img width="1213" height="319" alt="Screenshot 2026-06-12 at 4 25 51 PM" src="https://github.com/user-attachments/assets/98226d4d-55db-4ecf-b230-9d0e00f7b2bc" />

## Changes

1. **Shared section registry:** single source for section order, labels, and field membership.
   - Added `activity-form-sections.ts`; review-exempt and clone modal derive from it.
   - Added `ACTIVITY_FORM_SECTIONS.md` and unit tests.

2. **Look Ahead section:** explicit **None** radio clears `lookAheadSection` (maps to `null` on save).

3. **Release / translations:** language picker hidden unless status is **Required**; submit strips `translationLanguageIds` when status is not required.

4. **Sharing / visibility:** dropdown replaced with **Restrict access** switch and contextual copy (lead team name, lock/globe icons).

5. **Tests:** coverage for release translations, reports None, sharing switch, payload stripping, and section registry.

## Testing

- `npm run lint:staged` (pre-commit)
- Vitest related tests via lint-staged for `calendar-ui` and `packages/shared`
- Manual: create/edit activity — toggle restrict access, clear Look Ahead section, change translation status
