### PR TITLE
fix(teams): expose adEmail on team member contract to fix email colum…

### DIFF
--- a/calendar-service/API.md
+++ b/calendar-service/API.md
@@ -288,6 +288,47 @@ Permanently deletes an activity from the database.
 
 ---
 
+## Teams Endpoints
+
+### Get Team By ID
+
+**GET** `/teams/:id`
+
+Returns a team detail object including active members.
+
+**Response:** `200 OK`
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 5,
+    "name": "Team One",
+    "displayName": "Team One",
+    "abbreviation": "T1",
+    "description": null,
+    "sortOrder": 0,
+    "isActive": true,
+    "roleId": null,
+    "memberCount": 1,
+    "ministryId": 1,
+    "ministryName": "Premier",
+    "members": [
+      {
+        "userId": 10,
+        "userName": "User Ten",
+        "role": "owner",
+        "adEmail": "user10@example.com"
+      }
+    ]
+  }
+}
+```
+
+**Member fields:** `adEmail` is nullable and may be `null` when no email is present.
+
+---
+
 ## Lookups Endpoints
 
 Reference data for dropdowns and filters. All responses follow the format: `{ "success": true, "data": [...] }`

--- a/calendar-service/src/common/test-utils.ts
+++ b/calendar-service/src/common/test-utils.ts
@@ -133,8 +133,8 @@ export const createMockTeamDetail = (
 ): TeamDetail => ({
   ...createMockTeamListItem(),
   members: [
-    { userId: 1, userName: 'User One', role: 'owner' },
-    { userId: 2, userName: 'User Two', role: 'member' },
+    { userId: 1, userName: 'User One', role: 'owner', adEmail: null },
+    { userId: 2, userName: 'User Two', role: 'member', adEmail: null },
   ],
   ...overrides,
 });

--- a/calendar-service/src/teams/teams.controller.spec.ts
+++ b/calendar-service/src/teams/teams.controller.spec.ts
@@ -91,12 +91,23 @@ describe('TeamsController', () => {
 
   describe('findOne', () => {
     it('should return team detail by ID', async () => {
-      const team = createMockTeamDetail({ id: 5 });
+      const team = createMockTeamDetail({
+        id: 5,
+        members: [
+          {
+            userId: 10,
+            userName: 'User Ten',
+            role: 'owner',
+            adEmail: 'user10@example.com',
+          },
+        ],
+      });
       mockTeamsService.findOne.mockResolvedValue(team);
 
       const result = await controller.findOne(5);
 
       expect(result).toEqual({ success: true, data: team });
+      expect(result.data?.members[0]?.adEmail).toBe('user10@example.com');
       expect(mockTeamsService.findOne).toHaveBeenCalledWith(5);
       expect(mockTeamsService.findOne).toHaveBeenCalledTimes(1);
     });

--- a/calendar-service/src/teams/teams.service.spec.ts
+++ b/calendar-service/src/teams/teams.service.spec.ts
@@ -226,7 +226,12 @@ describe('TeamsService', () => {
       };
       const memberRows = [{ userId: 10, role: 'owner' }];
       const userRows = [
-        { id: 10, adDisplayName: 'User Ten', adUsername: 'user10' },
+        {
+          id: 10,
+          adDisplayName: 'User Ten',
+          adUsername: 'user10',
+          adEmail: 'user10@example.com',
+        },
       ];
       const ministryNameRows = [{ displayName: 'Premier' }];
 
@@ -252,6 +257,7 @@ describe('TeamsService', () => {
         userId: 10,
         userName: 'User Ten',
         role: 'owner',
+        adEmail: 'user10@example.com',
       });
     });
   });

--- a/calendar-service/src/teams/teams.service.ts
+++ b/calendar-service/src/teams/teams.service.ts
@@ -316,16 +316,12 @@ export class TeamsService {
               id: users.id,
               adDisplayName: users.adDisplayName,
               adUsername: users.adUsername,
+              adEmail: users.adEmail,
             })
             .from(users)
             .where(inArray(users.id, userIds))
         : [];
-    const userMap = new Map(
-      userRows.map((u) => [
-        u.id,
-        u.adDisplayName || u.adUsername || `User ${u.id}`,
-      ])
-    );
+    const userMap = new Map(userRows.map((u) => [u.id, u]));
 
     let ministryName: string | null = null;
     if (t.ministryId != null) {
@@ -341,11 +337,15 @@ export class TeamsService {
       ...t,
       ministryName,
       memberCount: memberRows.length,
-      members: memberRows.map((m) => ({
-        userId: m.userId,
-        userName: userMap.get(m.userId) ?? `User ${m.userId}`,
-        role: m.role,
-      })),
+      members: memberRows.map((m) => {
+        const u = userMap.get(m.userId);
+        return {
+          userId: m.userId,
+          userName: u?.adDisplayName || u?.adUsername || `User ${m.userId}`,
+          role: m.role,
+          adEmail: u?.adEmail ?? null,
+        };
+      }),
     };
   }
 

--- a/calendar-ui/src/api/usersApi.ts
+++ b/calendar-ui/src/api/usersApi.ts
@@ -130,6 +130,23 @@ export async function fetchUserActivities(
   return response.data.data;
 }
 
+export interface UserActivityCountItem {
+  userId: number;
+  activityCount: number;
+}
+
+export async function fetchUserActivityCounts(
+  userIds: number[]
+): Promise<UserActivityCountItem[]> {
+  const unique = [...new Set(userIds)];
+  if (unique.length === 0) return [];
+  const response = await api.get<{
+    success: boolean;
+    data: UserActivityCountItem[];
+  }>('/users/activity-counts', { params: { userIds: unique.join(',') } });
+  return response.data.data;
+}
+
 export async function transferActivities(
   sourceUserId: number,
   body: TransferActivitiesBody

--- a/calendar-ui/src/components/teams/AddTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/AddTeamMemberModal.tsx
@@ -1,0 +1,35 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface AddTeamMemberModalProps {
+  open: boolean;
+  teamId: number;
+  existingMemberIds: number[];
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+export default function AddTeamMemberModal({
+  open,
+  onClose,
+}: AddTeamMemberModalProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add team member</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-slate-500">Coming soon.</p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -1,0 +1,42 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface RemovableTeamMember {
+  userId: number;
+  userName: string;
+  adEmail?: string | null;
+}
+
+interface RemoveTeamMemberModalProps {
+  open: boolean;
+  teamId: number;
+  teamName: string;
+  member: RemovableTeamMember | null;
+  onClose: () => void;
+  onRemoved: () => void;
+}
+
+export default function RemoveTeamMemberModal({
+  open,
+  onClose,
+}: RemoveTeamMemberModalProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove team member</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-slate-500">Coming soon.</p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/calendar-ui/src/pages/TeamDetails.tsx
+++ b/calendar-ui/src/pages/TeamDetails.tsx
@@ -1,0 +1,320 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Edit, Loader2 } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useState } from 'react';
+
+import { PERMISSIONS } from '@corpcal/shared';
+import { fetchTeamById } from '@/api/teamsApi';
+import { fetchUserActivityCounts } from '@/api/usersApi';
+import { PageContainer } from '@/components/layout';
+import AddTeamMemberModal from '@/components/teams/AddTeamMemberModal';
+import RemoveTeamMemberModal from '@/components/teams/RemoveTeamMemberModal';
+import { TeamEditModal } from '@/components/teams/TeamEditModal';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/useAuth';
+
+interface RemovableTeamMember {
+  userId: number;
+  userName: string;
+  adEmail?: string | null;
+}
+
+export function TeamDetails() {
+  const params = useParams();
+  const navigate = useNavigate();
+  const id = params.id ? parseInt(params.id, 10) : NaN;
+
+  const { data: team, isLoading } = useQuery({
+    queryKey: ['team', id],
+    queryFn: () => fetchTeamById(id),
+    enabled: !Number.isNaN(id),
+  });
+
+  const teamMembers = team?.members ?? [];
+  const memberIds = teamMembers.map((member) => member.userId);
+  const {
+    data: memberActivityCounts,
+    isLoading: isMemberActivityCountsLoading,
+    isFetching: isMemberActivityCountsFetching,
+    isError: isMemberActivityCountsError,
+  } = useQuery({
+    queryKey: ['users', 'activity-counts', memberIds],
+    queryFn: async () => {
+      const rows = await fetchUserActivityCounts(memberIds);
+      return new Map<number, number>(
+        rows.map((row) => [row.userId, Number(row.activityCount) || 0])
+      );
+    },
+    enabled: !Number.isNaN(id) && memberIds.length > 0,
+    staleTime: 30_000,
+  });
+
+  const queryClient = useQueryClient();
+  const [showEditTeam, setShowEditTeam] = useState(false);
+  const [showAddMember, setShowAddMember] = useState(false);
+  const [memberToRemove, setMemberToRemove] =
+    useState<RemovableTeamMember | null>(null);
+  const [memberSearch, setMemberSearch] = useState('');
+  const { hasPermission } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (!team) {
+    return (
+      <div className="py-12 text-center text-slate-500">Team not found</div>
+    );
+  }
+
+  const handleBack = () => {
+    void navigate('/users?tab=teams');
+  };
+
+  return (
+    <>
+      <PageContainer variant="narrow" className="space-y-6">
+        <div className="flex items-center justify-start">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleBack}
+            className="shrink-0 gap-2"
+          >
+            <ArrowLeft className="size-4" aria-hidden />
+            Go back
+          </Button>
+        </div>
+
+        <div>
+          <div className="flex items-start gap-4">
+            <div>
+              <h2 className="text-2xl leading-tight font-semibold">
+                {team.displayName ?? team.name}
+              </h2>
+              {team.description && (
+                <div className="mt-1 text-sm text-slate-600">
+                  {team.description}
+                </div>
+              )}
+            </div>
+
+            <div className="ms-auto">
+              {/* Edit button placed inline with heading to match UserDetailPage */}
+              {hasPermission(PERMISSIONS.TEAMS.EDIT) ? (
+                <div className="ml-0.5">
+                  <Button
+                    size="sm"
+                    onClick={() => setShowEditTeam(true)}
+                    className="focus-visible:ring-primary/30 inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 focus-visible:ring-2"
+                    aria-label="Edit team"
+                  >
+                    <Edit className="h-4 w-4" aria-hidden />
+                    Edit
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid max-w-3xl grid-cols-2 gap-4">
+            <div>
+              <h3 className="text-sm font-medium text-slate-600">Name</h3>
+              <p className="text-slate-900">{team.name}</p>
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-slate-600">
+                Abbreviation
+              </h3>
+              <p className="text-slate-900">{team.abbreviation ?? '-'}</p>
+            </div>
+            <div className="col-span-2">
+              <h3 className="text-sm font-medium text-slate-600">
+                Description
+              </h3>
+              <p className="text-slate-900">{team.description ?? '-'}</p>
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-slate-600">Ministry</h3>
+              <p className="text-slate-900">{team.ministryName ?? '-'}</p>
+            </div>
+            <div className="col-span-2">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-medium text-slate-600">
+                  Team members
+                </h3>
+                <div>
+                  {hasPermission(PERMISSIONS.USERS.EDIT) ? (
+                    <Button size="sm" onClick={() => setShowAddMember(true)}>
+                      + Add member
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-3 flex items-center justify-between gap-3">
+                <Input
+                  placeholder="Search"
+                  value={memberSearch}
+                  onChange={(e) => setMemberSearch(e.target.value)}
+                  className="max-w-sm"
+                />
+              </div>
+
+              <div className="mt-3 overflow-x-auto rounded-md border">
+                <table className="w-full text-left">
+                  <thead className="bg-slate-50 text-sm text-slate-600">
+                    <tr>
+                      <th className="px-3 py-2">Name</th>
+                      <th className="px-3 py-2">Email</th>
+                      <th className="px-3 py-2">Role</th>
+                      <th className="px-3 py-2">Teams</th>
+                      <th className="px-3 py-2">Activities</th>
+                      <th className="px-3 py-2">Status</th>
+                      <th className="px-3 py-2">Last updated</th>
+                      <th className="px-3 py-2"> </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {team.members && team.members.length > 0 ? (
+                      team.members
+                        .filter((m) => {
+                          if (!memberSearch) return true;
+                          const q = memberSearch.toLowerCase();
+                          const name = (m.userName ?? '').toLowerCase();
+                          const email = (m.adEmail ?? '').toLowerCase();
+                          return name.includes(q) || email.includes(q);
+                        })
+                        .map((m) => (
+                          <tr key={m.userId} className="border-t">
+                            <td className="px-3 py-2">
+                              {m.userName ?? `User ${m.userId}`}
+                            </td>
+                            <td className="px-3 py-2 text-slate-500">
+                              {m.adEmail ?? ''}
+                            </td>
+                            <td className="px-3 py-2">
+                              <span className="rounded-md border px-2 py-1 text-sm text-slate-600">
+                                {m.role}
+                              </span>
+                            </td>
+                            <td className="px-3 py-2 text-slate-500">
+                              {team.displayName ?? team.name}
+                            </td>
+                            <td className="px-3 py-2 text-slate-500">
+                              {(() => {
+                                if (
+                                  isMemberActivityCountsLoading ||
+                                  isMemberActivityCountsFetching
+                                ) {
+                                  return '...';
+                                }
+                                if (isMemberActivityCountsError) return '-';
+                                return String(
+                                  memberActivityCounts?.get(m.userId) ?? 0
+                                );
+                              })()}
+                            </td>
+                            <td className="px-3 py-2">
+                              <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-sm text-green-800">
+                                Active
+                              </span>
+                            </td>
+                            <td className="px-3 py-2 text-slate-500">-</td>
+                            <td className="px-3 py-2">
+                              {hasPermission(PERMISSIONS.USERS.EDIT) ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() =>
+                                    setMemberToRemove({
+                                      userId: m.userId,
+                                      userName:
+                                        m.userName ?? `User ${m.userId}`,
+                                    })
+                                  }
+                                >
+                                  Remove
+                                </Button>
+                              ) : null}
+                            </td>
+                          </tr>
+                        ))
+                    ) : (
+                      <tr>
+                        <td
+                          colSpan={8}
+                          className="px-3 py-6 text-center text-slate-500"
+                        >
+                          No members
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </PageContainer>
+      <TeamEditModal
+        team={
+          team
+            ? {
+                id: team.id,
+                name: team.name,
+                displayName: team.displayName ?? null,
+                abbreviation: team.abbreviation ?? '',
+                description: team.description ?? null,
+                sortOrder: team.sortOrder,
+                isActive: team.isActive,
+                roleId: null,
+                memberCount: team.members ? team.members.length : 0,
+                ministryId: team.ministryId ?? null,
+                ministryName: team.ministryName ?? null,
+              }
+            : null
+        }
+        open={showEditTeam}
+        onClose={() => setShowEditTeam(false)}
+        onSaved={() => {
+          setShowEditTeam(false);
+          if (!Number.isNaN(id)) {
+            void queryClient.invalidateQueries({ queryKey: ['team', id] });
+          }
+        }}
+      />
+      <AddTeamMemberModal
+        open={showAddMember}
+        teamId={team.id}
+        existingMemberIds={
+          team.members ? team.members.map((m) => m.userId) : []
+        }
+        onClose={() => setShowAddMember(false)}
+        onAdded={() => {
+          setShowAddMember(false);
+          void queryClient.invalidateQueries({ queryKey: ['team', id] });
+        }}
+      />
+      <RemoveTeamMemberModal
+        open={!!memberToRemove}
+        teamId={team.id}
+        teamName={team.displayName ?? team.name}
+        member={memberToRemove}
+        onClose={() => setMemberToRemove(null)}
+        onRemoved={() => {
+          setMemberToRemove(null);
+          void queryClient.invalidateQueries({ queryKey: ['team', id] });
+        }}
+      />
+    </>
+  );
+}
+
+export default TeamDetails;

--- a/packages/shared/src/schemas/team.schema.spec.ts
+++ b/packages/shared/src/schemas/team.schema.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createTeamBodySchema,
   teamListItemSchema,
+  teamMemberSchema,
   updateTeamBodySchema,
 } from './team.schema';
 
@@ -45,6 +46,37 @@ describe('teamListItemSchema', () => {
     expect(result.displayName).toBeNull();
     expect(result.description).toBeNull();
     expect(result.ministryId).toBeNull();
+  });
+});
+
+describe('teamMemberSchema', () => {
+  it('accepts member with email', () => {
+    const result = teamMemberSchema.parse({
+      userId: 1,
+      userName: 'User One',
+      role: 'owner',
+      adEmail: 'user@example.com',
+    });
+    expect(result.adEmail).toBe('user@example.com');
+  });
+
+  it('accepts member with null email', () => {
+    const result = teamMemberSchema.parse({
+      userId: 2,
+      userName: 'User Two',
+      role: 'member',
+      adEmail: null,
+    });
+    expect(result.adEmail).toBeNull();
+  });
+
+  it('rejects member missing adEmail', () => {
+    const result = teamMemberSchema.safeParse({
+      userId: 3,
+      userName: 'User Three',
+      role: 'member',
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/shared/src/schemas/team.schema.ts
+++ b/packages/shared/src/schemas/team.schema.ts
@@ -50,6 +50,7 @@ export const teamMemberSchema = z.object({
   userId: z.number().int(),
   userName: z.string(),
   role: z.string(),
+  adEmail: z.string().nullable(),
 });
 
 export type TeamMember = z.infer<typeof teamMemberSchema>;


### PR DESCRIPTION
This should be merged in after the team details view PR.

add adEmail (nullable) to teamMemberSchema in shared include adEmail in teams.service findOne member mapping remove (m as any).adEmail casts from TeamDetails — now fully typed add fetchUserActivityCounts to usersApi and stub AddTeamMemberModal / RemoveTeamMemberModal to unblock pre-existing broken build on main update test-utils mock and teams controller/service specs to assert adEmail document GET /teams/:id member shape with adEmail in API.md