### PR TITLE
feat(teams): redesign Team Details UI and harden Team modal validation

### DIFF
--- a/calendar-ui/src/components/teams/TeamEditModal.test.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.test.tsx
@@ -7,19 +7,26 @@ import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
 
 import { TeamEditModal } from './TeamEditModal';
 
-const { mockToast, mockCreateTeam, mockUpdateTeam, mockFetchTeamById } =
-  vi.hoisted(() => ({
-    mockToast: { success: vi.fn(), error: vi.fn() },
-    mockCreateTeam: vi.fn(),
-    mockUpdateTeam: vi.fn(),
-    mockFetchTeamById: vi.fn(),
-  }));
+const {
+  mockToast,
+  mockCreateTeam,
+  mockUpdateTeam,
+  mockFetchTeamById,
+  mockFetchTeamsList,
+} = vi.hoisted(() => ({
+  mockToast: { success: vi.fn(), error: vi.fn() },
+  mockCreateTeam: vi.fn(),
+  mockUpdateTeam: vi.fn(),
+  mockFetchTeamById: vi.fn(),
+  mockFetchTeamsList: vi.fn(),
+}));
 
 vi.mock('sonner', () => ({ toast: mockToast }));
 
 vi.mock('@/api/teamsApi', () => ({
   createTeam: (...args: unknown[]) => mockCreateTeam(...args),
   fetchTeamById: (id: number) => mockFetchTeamById(id),
+  fetchTeamsList: (...args: unknown[]) => mockFetchTeamsList(...args),
   updateTeam: (...args: unknown[]) => mockUpdateTeam(...args),
 }));
 
@@ -99,6 +106,7 @@ const mockTeamDetail: TeamDetail = {
 describe('TeamEditModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchTeamsList.mockResolvedValue([]);
     mockCreateTeam.mockResolvedValue({
       id: 1,
       name: 'New Team',
@@ -153,6 +161,67 @@ describe('TeamEditModal', () => {
     });
   });
 
+  describe('abbreviation uniqueness', () => {
+    it('shows validation and blocks submit when abbreviation matches another team', async () => {
+      mockFetchTeamsList.mockResolvedValue([
+        {
+          id: 99,
+          name: 'Another Team',
+          displayName: 'Another Team',
+          abbreviation: 'TT',
+          description: null,
+          sortOrder: 0,
+          isActive: true,
+          roleId: null,
+          memberCount: 0,
+          ministryId: null,
+          ministryName: null,
+        },
+      ]);
+
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.type(screen.getByLabelText(/name \*/i), 'Test Team');
+      await user.type(screen.getByLabelText(/^abbreviation \*/i), 'TT');
+
+      expect(
+        await screen.findByText(/abbreviation is already used by another team/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
+    });
+
+    it('maps backend duplicate abbreviation conflict to inline validation', async () => {
+      mockCreateTeam.mockRejectedValue({
+        message: 'Conflict',
+        response: {
+          status: 409,
+          data: { message: 'Abbreviation already exists' },
+        },
+      });
+
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.type(screen.getByLabelText(/name \*/i), 'Test Team');
+      await user.type(screen.getByLabelText(/^abbreviation \*/i), 'TT');
+
+      const createButton = screen.getByRole('button', { name: /create/i });
+      await waitFor(() => expect(createButton).toBeEnabled(), {
+        timeout: 5000,
+      });
+      fireEvent.submit(createButton.closest('form') as HTMLFormElement);
+
+      expect(
+        await screen.findByText(/abbreviation is already used by another team/i)
+      ).toBeInTheDocument();
+      expect(mockToast.error).not.toHaveBeenCalledWith('Conflict', {
+        id: 'team-created',
+      });
+      expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
+    });
+  });
+
   describe('update success toast', () => {
     it('calls toast.success with id team-updated-{id} when update succeeds', async () => {
       mockFetchTeamById.mockResolvedValue({
@@ -169,7 +238,7 @@ describe('TeamEditModal', () => {
       renderEditModal(mockTeamListItem);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing Team');
+        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing');
       });
 
       await user.clear(screen.getByLabelText(/name \*/i));
@@ -196,7 +265,7 @@ describe('TeamEditModal', () => {
       renderEditModal(mockTeamListItem);
 
       await waitFor(() => {
-        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing Team');
+        expect(screen.getByLabelText(/name \*/i)).toHaveValue('Existing');
       });
 
       await user.click(screen.getByRole('button', { name: /update/i }));

--- a/calendar-ui/src/components/teams/TeamEditModal.test.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
+import { ApiError } from '@/api/errors';
 
 import { TeamEditModal } from './TeamEditModal';
 
@@ -154,7 +155,7 @@ describe('TeamEditModal', () => {
       fireEvent.submit(createButton.closest('form') as HTMLFormElement);
 
       await waitFor(() => {
-        expect(mockToast.error).toHaveBeenCalledWith('Failed to create', {
+        expect(mockToast.error).toHaveBeenCalledWith('Failed to create team', {
           id: 'team-created',
         });
       });
@@ -192,13 +193,16 @@ describe('TeamEditModal', () => {
     });
 
     it('maps backend duplicate abbreviation conflict to inline validation', async () => {
-      mockCreateTeam.mockRejectedValue({
-        message: 'Conflict',
-        response: {
+      mockCreateTeam.mockRejectedValue(
+        new ApiError({
           status: 409,
-          data: { message: 'Abbreviation already exists' },
-        },
-      });
+          title: 'Conflict',
+          detail: 'Abbreviation already exists',
+          type: 'https://example.com/errors/conflict',
+          instance: '/teams',
+          correlationId: 'test-123',
+        })
+      );
 
       const user = userEvent.setup();
       renderModal();
@@ -215,9 +219,6 @@ describe('TeamEditModal', () => {
       expect(
         await screen.findByText(/abbreviation is already used by another team/i)
       ).toBeInTheDocument();
-      expect(mockToast.error).not.toHaveBeenCalledWith('Conflict', {
-        id: 'team-created',
-      });
       expect(screen.getByRole('button', { name: /create/i })).toBeDisabled();
     });
   });
@@ -271,7 +272,7 @@ describe('TeamEditModal', () => {
       await user.click(screen.getByRole('button', { name: /update/i }));
 
       await waitFor(() => {
-        expect(mockToast.error).toHaveBeenCalledWith('Server error', {
+        expect(mockToast.error).toHaveBeenCalledWith('Failed to update team', {
           id: 'team-updated-5',
         });
       });

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
+import { ApiError } from '@/api/errors';
 import { fetchMinistries } from '@/api/lookupsApi';
 import {
   createTeam,
@@ -60,18 +61,12 @@ export function TeamEditModal({
   const [isActive, setIsActive] = useState(true);
   const [ministryId, setMinistryId] = useState<string | null>(null);
 
-  const isDuplicateAbbreviationError = (
-    err: Error & {
-      response?: {
-        status?: number;
-        data?: { message?: string; error?: string };
-      };
-    }
-  ) => {
-    const status = err.response?.status;
-    const rawMessage =
-      `${err.message ?? ''} ${err.response?.data?.message ?? ''} ${err.response?.data?.error ?? ''}`.toLowerCase();
-    return status === 409 && rawMessage.includes('abbreviation');
+  const isDuplicateAbbreviationError = (error: unknown): boolean => {
+    return (
+      error instanceof ApiError &&
+      error.status === 409 &&
+      error.detail.toLowerCase().includes('abbreviation')
+    );
   };
 
   const { data: detail, isLoading: isLoadingDetail } =
@@ -134,21 +129,14 @@ export function TeamEditModal({
       onSaved();
       onClose();
     },
-    onError: (
-      err: Error & {
-        response?: {
-          status?: number;
-          data?: { message?: string; error?: string };
-        };
-      }
-    ) => {
+    onError: (err: unknown) => {
       if (isDuplicateAbbreviationError(err)) {
         setHasServerAbbreviationConflict(true);
         return;
       }
-      toast.error(err.message || 'Failed to create team', {
-        id: 'team-created',
-      });
+      const message =
+        err instanceof ApiError ? err.detail : 'Failed to create team';
+      toast.error(message, { id: 'team-created' });
     },
   });
 
@@ -166,20 +154,14 @@ export function TeamEditModal({
       onSaved();
       onClose();
     },
-    onError: (
-      err: Error & {
-        response?: {
-          status?: number;
-          data?: { message?: string; error?: string };
-        };
-      },
-      variables
-    ) => {
+    onError: (err: unknown, variables) => {
       if (isDuplicateAbbreviationError(err)) {
         setHasServerAbbreviationConflict(true);
         return;
       }
-      toast.error(err.message || 'Failed to update team', {
+      const message =
+        err instanceof ApiError ? err.detail : 'Failed to update team';
+      toast.error(message, {
         id: variables ? `team-updated-${variables.id}` : undefined,
       });
     },

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -71,7 +71,7 @@ export function TeamEditModal({
     const status = err.response?.status;
     const rawMessage =
       `${err.message ?? ''} ${err.response?.data?.message ?? ''} ${err.response?.data?.error ?? ''}`.toLowerCase();
-    return status === 409 || rawMessage.includes('abbreviation');
+    return status === 409 && rawMessage.includes('abbreviation');
   };
 
   const { data: detail, isLoading: isLoadingDetail } =

--- a/calendar-ui/src/components/teams/TeamEditModal.tsx
+++ b/calendar-ui/src/components/teams/TeamEditModal.tsx
@@ -5,7 +5,12 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { TeamDetail, TeamListItem } from '@corpcal/shared/api/types';
 import { fetchMinistries } from '@/api/lookupsApi';
-import { createTeam, fetchTeamById, updateTeam } from '@/api/teamsApi';
+import {
+  createTeam,
+  fetchTeamById,
+  fetchTeamsList,
+  updateTeam,
+} from '@/api/teamsApi';
 import { Button } from '@/components/ui/button';
 import {
   Combobox,
@@ -23,6 +28,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { InfoIconButton } from '@/components/ui/info-icon-button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -45,12 +51,28 @@ export function TeamEditModal({
 }: TeamEditModalProps) {
   const isCreate = team === null;
   const queryClient = useQueryClient();
-  const [name, setName] = useState('');
   const [abbreviation, setAbbreviation] = useState('');
   const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
   const [abbrevManuallyEdited, setAbbrevManuallyEdited] = useState(false);
+  const [hasServerAbbreviationConflict, setHasServerAbbreviationConflict] =
+    useState(false);
   const [isActive, setIsActive] = useState(true);
   const [ministryId, setMinistryId] = useState<string | null>(null);
+
+  const isDuplicateAbbreviationError = (
+    err: Error & {
+      response?: {
+        status?: number;
+        data?: { message?: string; error?: string };
+      };
+    }
+  ) => {
+    const status = err.response?.status;
+    const rawMessage =
+      `${err.message ?? ''} ${err.response?.data?.message ?? ''} ${err.response?.data?.error ?? ''}`.toLowerCase();
+    return status === 409 || rawMessage.includes('abbreviation');
+  };
 
   const { data: detail, isLoading: isLoadingDetail } =
     useQuery<TeamDetail | null>({
@@ -65,6 +87,13 @@ export function TeamEditModal({
     enabled: open,
   });
 
+  const { data: allTeams = [] } = useQuery<TeamListItem[]>({
+    queryKey: lookupQueryKeys.teamsList(true),
+    queryFn: () => fetchTeamsList(false),
+    enabled: open,
+    staleTime: 30_000,
+  });
+
   const ministryOptions = useMemo(
     () =>
       ministries.map((m) => ({
@@ -77,16 +106,18 @@ export function TeamEditModal({
   useEffect(() => {
     if (!open) return;
     if (isCreate) {
-      setName('');
       setAbbreviation('');
       setDisplayName('');
+      setDescription('');
+      setHasServerAbbreviationConflict(false);
       setIsActive(true);
       setMinistryId(null);
       setAbbrevManuallyEdited(false);
     } else if (detail) {
-      setName(detail.name);
       setAbbreviation(detail.abbreviation);
       setDisplayName(detail.displayName ?? '');
+      setDescription(detail.description ?? '');
+      setHasServerAbbreviationConflict(false);
       setIsActive(detail.isActive);
       setMinistryId(
         detail.ministryId != null ? String(detail.ministryId) : null
@@ -103,7 +134,18 @@ export function TeamEditModal({
       onSaved();
       onClose();
     },
-    onError: (err: Error) => {
+    onError: (
+      err: Error & {
+        response?: {
+          status?: number;
+          data?: { message?: string; error?: string };
+        };
+      }
+    ) => {
+      if (isDuplicateAbbreviationError(err)) {
+        setHasServerAbbreviationConflict(true);
+        return;
+      }
       toast.error(err.message || 'Failed to create team', {
         id: 'team-created',
       });
@@ -124,7 +166,19 @@ export function TeamEditModal({
       onSaved();
       onClose();
     },
-    onError: (err: Error, variables) => {
+    onError: (
+      err: Error & {
+        response?: {
+          status?: number;
+          data?: { message?: string; error?: string };
+        };
+      },
+      variables
+    ) => {
+      if (isDuplicateAbbreviationError(err)) {
+        setHasServerAbbreviationConflict(true);
+        return;
+      }
       toast.error(err.message || 'Failed to update team', {
         id: variables ? `team-updated-${variables.id}` : undefined,
       });
@@ -136,12 +190,19 @@ export function TeamEditModal({
     const trimmedDisplay = displayName.trim();
     const trimmedAbbrev = abbreviation.trim().replace(/\s+/g, '');
     const missingFields: string[] = [];
-    if (!trimmedDisplay) missingFields.push(isCreate ? 'Name' : 'Display');
+    if (!trimmedDisplay) missingFields.push('Name');
     if (!trimmedAbbrev) missingFields.push('Abbreviation');
 
     if (missingFields.length > 0) {
       const detail = `Required fields missing: ${missingFields.join(', ')}`;
       toast.error('Submission failed', { description: detail, duration: 6000 });
+      return;
+    }
+    if (hasAbbreviationConflict) {
+      toast.error('Submission failed', {
+        description: 'Abbreviation must be unique across all teams.',
+        duration: 6000,
+      });
       return;
     }
     if (isCreate) {
@@ -150,17 +211,19 @@ export function TeamEditModal({
         name: nameForCreate,
         abbreviation: trimmedAbbrev,
         displayName: trimmedDisplay || undefined,
+        description: description.trim() || undefined,
         isActive,
         ministryId: ministryId != null ? parseInt(ministryId, 10) : undefined,
       });
     } else if (team) {
-      const nameForUpdate = name && name.trim() ? name.trim() : trimmedDisplay;
+      const nameForUpdate = trimmedDisplay;
       updateMutation.mutate({
         id: team.id,
         body: {
           name: nameForUpdate,
           abbreviation: trimmedAbbrev,
           displayName: trimmedDisplay || undefined,
+          description: description.trim() || undefined,
           isActive,
           ministryId: ministryId != null ? parseInt(ministryId, 10) : null,
         },
@@ -175,8 +238,24 @@ export function TeamEditModal({
   const isLoading = !isCreate && isLoadingDetail;
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
   const displayValid = displayName.trim().length > 0;
-  const abbreviationValid = abbreviation.trim().replace(/\s+/g, '').length > 0;
-  const isFormValid = displayValid && abbreviationValid;
+  const normalizedAbbreviation = abbreviation
+    .trim()
+    .replace(/\s+/g, '')
+    .toLowerCase();
+  const abbreviationValid = normalizedAbbreviation.length > 0;
+  const abbreviationConflict =
+    abbreviationValid &&
+    allTeams.some((existingTeam) => {
+      const existingAbbreviation =
+        existingTeam.abbreviation?.trim().toLowerCase() ?? '';
+      if (!existingAbbreviation) return false;
+      if (team && existingTeam.id === team.id) return false;
+      return existingAbbreviation === normalizedAbbreviation;
+    });
+  const hasAbbreviationConflict =
+    abbreviationConflict || hasServerAbbreviationConflict;
+  const isFormValid =
+    displayValid && abbreviationValid && !hasAbbreviationConflict;
   const dialogContentRef = useRef<HTMLDivElement | null>(null);
 
   return (
@@ -200,28 +279,8 @@ export function TeamEditModal({
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              {!isCreate && (
-                <Label htmlFor="team-name">
-                  Name{' '}
-                  <span
-                    className="text-required-field-indicator font-semibold"
-                    aria-hidden
-                  >
-                    *
-                  </span>
-                </Label>
-              )}
-              <Input
-                id="team-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Programmatic name (hidden in create flow)"
-                className={isCreate ? 'sr-only' : undefined}
-                aria-hidden={isCreate}
-                required={!isCreate}
-              />
               <Label htmlFor="team-display-name">
-                {isCreate ? 'Name' : 'Display'}{' '}
+                Name{' '}
                 <span
                   className="text-required-field-indicator font-semibold"
                   aria-hidden
@@ -238,7 +297,10 @@ export function TeamEditModal({
               />
             </div>
             <div className="space-y-2">
-              <Label>Ministry (optional)</Label>
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="team-ministry">Ministry</Label>
+                <InfoIconButton aria-label="Ministry is optional" />
+              </div>
               <Combobox
                 items={ministryOptions}
                 value={selectedMinistry}
@@ -250,13 +312,17 @@ export function TeamEditModal({
                     const m = ministries.find((mm) => String(mm.id) === newId);
                     const abb = m?.abbreviation ? String(m.abbreviation) : '';
                     if (!abbrevManuallyEdited || !abbreviation) {
+                      setHasServerAbbreviationConflict(false);
                       setAbbreviation(abb);
                     }
                   }
                 }}
                 itemToStringValue={(o: OptionItem) => o.label}
               >
-                <ComboboxInput placeholder="Select ministry..." />
+                <ComboboxInput
+                  id="team-ministry"
+                  placeholder="Select ministry..."
+                />
                 <ComboboxContent container={dialogContentRef}>
                   <ComboboxEmpty>No ministries found.</ComboboxEmpty>
                   <ComboboxList>
@@ -283,6 +349,7 @@ export function TeamEditModal({
                 id="team-abbreviation"
                 value={abbreviation}
                 onChange={(e) => {
+                  setHasServerAbbreviationConflict(false);
                   setAbbreviation(e.target.value);
                   setAbbrevManuallyEdited(true);
                 }}
@@ -298,6 +365,20 @@ export function TeamEditModal({
                 Short code (max 6 characters) used in activity IDs for
                 non-ministry teams.
               </p>
+              {hasAbbreviationConflict ? (
+                <p className="text-destructive text-xs">
+                  Abbreviation is already used by another team.
+                </p>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="team-description">Description</Label>
+              <Input
+                id="team-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Description"
+              />
             </div>
             <div className="flex items-center gap-2">
               <Switch

--- a/calendar-ui/src/pages/TeamDetails.tsx
+++ b/calendar-ui/src/pages/TeamDetails.tsx
@@ -51,7 +51,7 @@ export function TeamDetails() {
   });
 
   const { data: teamUsers = [] } = useQuery({
-    queryKey: ['users', { teamIds: [id] }],
+    queryKey: ['users', 'team-members', id, memberIds],
     queryFn: () => fetchUsers({ teamIds: [id] }),
     enabled: !Number.isNaN(id),
     staleTime: 30_000,
@@ -60,11 +60,7 @@ export function TeamDetails() {
   const userLastUpdatedById = useMemo(
     () =>
       new Map<number, string | null>(
-        teamUsers.map((u) => [
-          u.id,
-          (u as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ??
-            null,
-        ])
+        teamUsers.map((u) => [u.id, u.lastUpdatedDateTime ?? null])
       ),
     [teamUsers]
   );
@@ -152,7 +148,7 @@ export function TeamDetails() {
                 {team.displayName ?? team.name}
               </h2>
               {hasPermission(PERMISSIONS.TEAMS.EDIT) ? (
-                <div className="absolute top-1 right-80">
+                <div className="absolute top-1 right-0">
                   <Button
                     size="sm"
                     onClick={() => setShowEditTeam(true)}

--- a/calendar-ui/src/pages/TeamDetails.tsx
+++ b/calendar-ui/src/pages/TeamDetails.tsx
@@ -65,6 +65,16 @@ export function TeamDetails() {
     [teamUsers]
   );
 
+  const userIsActiveById = useMemo(
+    () => new Map<number, boolean>(teamUsers.map((u) => [u.id, u.isActive])),
+    [teamUsers]
+  );
+
+  const userById = useMemo(
+    () => new Map(teamUsers.map((u) => [u.id, u])),
+    [teamUsers]
+  );
+
   const queryClient = useQueryClient();
   const [showEditTeam, setShowEditTeam] = useState(false);
   const [showAddMember, setShowAddMember] = useState(false);
@@ -112,7 +122,7 @@ export function TeamDetails() {
     if (!memberSearch) return true;
     const q = memberSearch.toLowerCase();
     const name = (m.userName ?? '').toLowerCase();
-    const email = ((m as any).adEmail ?? '').toLowerCase();
+    const email = (userById.get(m.userId)?.adEmail ?? '').toLowerCase();
     return name.includes(q) || email.includes(q);
   });
 
@@ -283,7 +293,7 @@ export function TeamDetails() {
                           {m.userName ?? `User ${m.userId}`}
                         </td>
                         <td className="px-3 py-2 text-slate-700">
-                          {(m as any).adEmail ?? ''}
+                          {userById.get(m.userId)?.adEmail ?? '-'}
                         </td>
                         <td className="px-3 py-2">
                           <span className="rounded-md border px-2 py-1 text-sm text-slate-700">
@@ -310,8 +320,16 @@ export function TeamDetails() {
                           })()}
                         </td>
                         <td className="px-3 py-2">
-                          <span className="rounded bg-green-100 px-2 py-0.5 text-xs text-green-800">
-                            Active
+                          <span
+                            className={`rounded px-2 py-0.5 text-xs font-medium ${
+                              userIsActiveById.get(m.userId)
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-slate-100 text-slate-700'
+                            }`}
+                          >
+                            {userIsActiveById.get(m.userId)
+                              ? 'Active'
+                              : 'Inactive'}
                           </span>
                         </td>
                         <td className="px-3 py-2 text-slate-700">

--- a/calendar-ui/src/pages/TeamDetails.tsx
+++ b/calendar-ui/src/pages/TeamDetails.tsx
@@ -1,11 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Edit, Loader2 } from 'lucide-react';
+import { ArrowLeft, Edit, Loader2, Search } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { PERMISSIONS } from '@corpcal/shared';
 import { fetchTeamById } from '@/api/teamsApi';
-import { fetchUserActivityCounts } from '@/api/usersApi';
+import { fetchUserActivityCounts, fetchUsers } from '@/api/usersApi';
 import { PageContainer } from '@/components/layout';
 import AddTeamMemberModal from '@/components/teams/AddTeamMemberModal';
 import RemoveTeamMemberModal from '@/components/teams/RemoveTeamMemberModal';
@@ -50,6 +50,25 @@ export function TeamDetails() {
     staleTime: 30_000,
   });
 
+  const { data: teamUsers = [] } = useQuery({
+    queryKey: ['users', { teamIds: [id] }],
+    queryFn: () => fetchUsers({ teamIds: [id] }),
+    enabled: !Number.isNaN(id),
+    staleTime: 30_000,
+  });
+
+  const userLastUpdatedById = useMemo(
+    () =>
+      new Map<number, string | null>(
+        teamUsers.map((u) => [
+          u.id,
+          (u as { lastUpdatedDateTime?: string | null }).lastUpdatedDateTime ??
+            null,
+        ])
+      ),
+    [teamUsers]
+  );
+
   const queryClient = useQueryClient();
   const [showEditTeam, setShowEditTeam] = useState(false);
   const [showAddMember, setShowAddMember] = useState(false);
@@ -76,6 +95,31 @@ export function TeamDetails() {
     void navigate('/users?tab=teams');
   };
 
+  const formatMemberLastUpdated = (member: any) => {
+    const raw =
+      userLastUpdatedById.get(member.userId) ??
+      member.updatedAt ??
+      member.lastUpdatedAt ??
+      member.modifiedAt ??
+      member.userUpdatedAt;
+    if (!raw) return '-';
+    const parsed = new Date(String(raw));
+    if (Number.isNaN(parsed.getTime())) return '-';
+    return parsed.toLocaleDateString('en-CA', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const filteredMembers = teamMembers.filter((m) => {
+    if (!memberSearch) return true;
+    const q = memberSearch.toLowerCase();
+    const name = (m.userName ?? '').toLowerCase();
+    const email = ((m as any).adEmail ?? '').toLowerCase();
+    return name.includes(q) || email.includes(q);
+  });
+
   return (
     <>
       <PageContainer variant="narrow" className="space-y-6">
@@ -92,23 +136,23 @@ export function TeamDetails() {
           </Button>
         </div>
 
-        <div>
-          <div className="flex items-start gap-4">
-            <div>
-              <h2 className="text-2xl leading-tight font-semibold">
+        <div className="space-y-6">
+          <div className="ml-2 max-w-3xl">
+            <div className="relative">
+              <h2
+                className="mb-2 pr-28 text-slate-900"
+                style={{
+                  fontFamily: 'var(--Font-family-Base, "BC Sans")',
+                  fontSize: 'var(--Font-size-800, 32px)',
+                  fontStyle: 'normal',
+                  fontWeight: 700,
+                  lineHeight: 'var(--Line-height-800, 40px)',
+                }}
+              >
                 {team.displayName ?? team.name}
               </h2>
-              {team.description && (
-                <div className="mt-1 text-sm text-slate-600">
-                  {team.description}
-                </div>
-              )}
-            </div>
-
-            <div className="ms-auto">
-              {/* Edit button placed inline with heading to match UserDetailPage */}
               {hasPermission(PERMISSIONS.TEAMS.EDIT) ? (
-                <div className="ml-0.5">
+                <div className="absolute top-1 right-80">
                   <Button
                     size="sm"
                     onClick={() => setShowEditTeam(true)}
@@ -121,146 +165,193 @@ export function TeamDetails() {
                 </div>
               ) : null}
             </div>
+
+            <div className="space-y-1.5">
+              {team.abbreviation ? (
+                <p
+                  className="text-slate-900"
+                  style={{
+                    fontFamily:
+                      'var(--Typescale-Body-2-font-family, "BC Sans")',
+                    fontSize: 'var(--Typescale-Body-2-font-size, 16px)',
+                    fontStyle: 'normal',
+                    fontWeight: 400,
+                    lineHeight: 'var(--Typescale-Body-2-line-height, 22px)',
+                  }}
+                >
+                  {team.abbreviation}
+                </p>
+              ) : null}
+              {team.ministryName ? (
+                <p
+                  className="text-slate-800"
+                  style={{
+                    fontFamily:
+                      'var(--Typescale-Body-2-font-family, "BC Sans")',
+                    fontSize: 'var(--Typescale-Body-2-font-size, 16px)',
+                    fontStyle: 'normal',
+                    fontWeight: 400,
+                    lineHeight: 'var(--Typescale-Body-2-line-height, 22px)',
+                  }}
+                >
+                  {team.ministryName}
+                </p>
+              ) : null}
+              {team.description ? (
+                <p
+                  className="text-slate-800"
+                  style={{
+                    fontFamily:
+                      'var(--Typescale-Body-2-font-family, "BC Sans")',
+                    fontSize: 'var(--Typescale-Body-2-font-size, 16px)',
+                    fontStyle: 'normal',
+                    fontWeight: 400,
+                    lineHeight: 'var(--Typescale-Body-2-line-height, 22px)',
+                  }}
+                >
+                  {team.description}
+                </p>
+              ) : null}
+              <div className="pt-2">
+                <span
+                  className={`inline-flex rounded-full px-2 py-0.5 text-sm font-medium ${
+                    team.isActive
+                      ? 'bg-green-600 text-white'
+                      : 'bg-slate-400 text-white'
+                  }`}
+                >
+                  {team.isActive ? 'Active' : 'Inactive'}
+                </span>
+              </div>
+            </div>
           </div>
 
-          <div className="grid max-w-3xl grid-cols-2 gap-4">
-            <div>
-              <h3 className="text-sm font-medium text-slate-600">Name</h3>
-              <p className="text-slate-900">{team.name}</p>
-            </div>
-            <div>
-              <h3 className="text-sm font-medium text-slate-600">
-                Abbreviation
+          <div className="max-w-5xl">
+            <div className="flex items-center justify-between">
+              <h3
+                style={{
+                  color: 'var(--NeutralForeground1-Rest, #000000)',
+                  fontFamily: 'var(--Typescale-Title-3-font-family, "BC Sans")',
+                  fontSize: 'var(--Typescale-Title-3-font-size, 24px)',
+                  fontStyle: 'normal',
+                  fontWeight: 700,
+                  lineHeight: 'var(--Typescale-Title-3-line-height, 32px)',
+                }}
+              >
+                Team members
               </h3>
-              <p className="text-slate-900">{team.abbreviation ?? '-'}</p>
+              {hasPermission(PERMISSIONS.USERS.EDIT) ? (
+                <Button size="sm" onClick={() => setShowAddMember(true)}>
+                  + Add member
+                </Button>
+              ) : null}
             </div>
-            <div className="col-span-2">
-              <h3 className="text-sm font-medium text-slate-600">
-                Description
-              </h3>
-              <p className="text-slate-900">{team.description ?? '-'}</p>
-            </div>
-            <div>
-              <h3 className="text-sm font-medium text-slate-600">Ministry</h3>
-              <p className="text-slate-900">{team.ministryName ?? '-'}</p>
-            </div>
-            <div className="col-span-2">
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-medium text-slate-600">
-                  Team members
-                </h3>
-                <div>
-                  {hasPermission(PERMISSIONS.USERS.EDIT) ? (
-                    <Button size="sm" onClick={() => setShowAddMember(true)}>
-                      + Add member
-                    </Button>
-                  ) : null}
-                </div>
-              </div>
 
-              <div className="mt-3 flex items-center justify-between gap-3">
+            <div className="mt-3 space-y-3">
+              <div className="relative max-w-sm">
+                <Search
+                  className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400"
+                  aria-hidden
+                />
                 <Input
                   placeholder="Search"
                   value={memberSearch}
                   onChange={(e) => setMemberSearch(e.target.value)}
-                  className="max-w-sm"
+                  className="pl-9"
                 />
               </div>
+              <p className="text-slate-700">
+                Showing {filteredMembers.length} users
+              </p>
+            </div>
 
-              <div className="mt-3 overflow-x-auto rounded-md border">
-                <table className="w-full text-left">
-                  <thead className="bg-slate-50 text-sm text-slate-600">
-                    <tr>
-                      <th className="px-3 py-2">Name</th>
-                      <th className="px-3 py-2">Email</th>
-                      <th className="px-3 py-2">Role</th>
-                      <th className="px-3 py-2">Teams</th>
-                      <th className="px-3 py-2">Activities</th>
-                      <th className="px-3 py-2">Status</th>
-                      <th className="px-3 py-2">Last updated</th>
-                      <th className="px-3 py-2"> </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {team.members && team.members.length > 0 ? (
-                      team.members
-                        .filter((m) => {
-                          if (!memberSearch) return true;
-                          const q = memberSearch.toLowerCase();
-                          const name = (m.userName ?? '').toLowerCase();
-                          const email = (
-                            (m as any).adEmail ?? ''
-                          ).toLowerCase();
-                          return name.includes(q) || email.includes(q);
-                        })
-                        .map((m) => (
-                          <tr key={m.userId} className="border-t">
-                            <td className="px-3 py-2">
-                              {m.userName ?? `User ${m.userId}`}
-                            </td>
-                            <td className="px-3 py-2 text-slate-500">
-                              {(m as any).adEmail ?? ''}
-                            </td>
-                            <td className="px-3 py-2">
-                              <span className="rounded-md border px-2 py-1 text-sm text-slate-600">
-                                {m.role}
-                              </span>
-                            </td>
-                            <td className="px-3 py-2 text-slate-500">
-                              {team.displayName ?? team.name}
-                            </td>
-                            <td className="px-3 py-2 text-slate-500">
-                              {(() => {
-                                if (
-                                  isMemberActivityCountsLoading ||
-                                  isMemberActivityCountsFetching
-                                ) {
-                                  return '...';
-                                }
-                                if (isMemberActivityCountsError) return '-';
-                                return String(
-                                  memberActivityCounts?.get(m.userId) ?? 0
-                                );
-                              })()}
-                            </td>
-                            <td className="px-3 py-2">
-                              <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-sm text-green-800">
-                                Active
-                              </span>
-                            </td>
-                            <td className="px-3 py-2 text-slate-500">-</td>
-                            <td className="px-3 py-2">
-                              {hasPermission(PERMISSIONS.USERS.EDIT) ? (
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() =>
-                                    setMemberToRemove({
-                                      userId: m.userId,
-                                      userName:
-                                        m.userName ?? `User ${m.userId}`,
-                                    })
-                                  }
-                                >
-                                  Remove
-                                </Button>
-                              ) : null}
-                            </td>
-                          </tr>
-                        ))
-                    ) : (
-                      <tr>
-                        <td
-                          colSpan={8}
-                          className="px-3 py-6 text-center text-slate-500"
-                        >
-                          No members
+            <div className="mt-3 overflow-x-auto rounded-md border">
+              <table className="w-full text-left">
+                <thead className="bg-slate-50 text-sm text-slate-700">
+                  <tr>
+                    <th className="px-3 py-2">Name</th>
+                    <th className="px-3 py-2">Email</th>
+                    <th className="px-3 py-2">Role</th>
+                    <th className="px-3 py-2">Teams</th>
+                    <th className="px-3 py-2">Activities</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Last updated</th>
+                    <th className="px-3 py-2"> </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredMembers.length > 0 ? (
+                    filteredMembers.map((m) => (
+                      <tr key={m.userId} className="border-t">
+                        <td className="px-3 py-2">
+                          {m.userName ?? `User ${m.userId}`}
+                        </td>
+                        <td className="px-3 py-2 text-slate-700">
+                          {(m as any).adEmail ?? ''}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className="rounded-md border px-2 py-1 text-sm text-slate-700">
+                            {m.role}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className="rounded-md bg-slate-100 px-2 py-1 text-sm text-slate-700">
+                            {team.displayName ?? team.name}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-slate-700">
+                          {(() => {
+                            if (
+                              isMemberActivityCountsLoading ||
+                              isMemberActivityCountsFetching
+                            ) {
+                              return '...';
+                            }
+                            if (isMemberActivityCountsError) return '-';
+                            return `${String(
+                              memberActivityCounts?.get(m.userId) ?? 0
+                            )} active`;
+                          })()}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className="rounded bg-green-100 px-2 py-0.5 text-xs text-green-800">
+                            Active
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-slate-700">
+                          {formatMemberLastUpdated(m)}
+                        </td>
+                        <td className="px-3 py-2">
+                          {hasPermission(PERMISSIONS.USERS.EDIT) ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="focus-visible:ring-primary/30 inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 focus-visible:ring-2"
+                              onClick={() =>
+                                setMemberToRemove({
+                                  userId: m.userId,
+                                  userName: m.userName ?? `User ${m.userId}`,
+                                })
+                              }
+                            >
+                              Remove
+                            </Button>
+                          ) : null}
                         </td>
                       </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
+                    ))
+                  ) : (
+                    <tr>
+                      <td
+                        colSpan={8}
+                        className="px-3 py-6 text-center text-slate-500"
+                      >
+                        No members
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
             </div>
           </div>
         </div>


### PR DESCRIPTION
refactor Team Details header/layout to match design and stabilize Edit button positioning update Team members table styling (status/activity badges, search row, typography spacing) source Team members 'Last updated' from users list data (lastUpdatedDateTime) without backend changes update Team modal form UX: Name label, Ministry info icon, Description field restoration enforce unique team abbreviation on create/edit with inline validation map backend duplicate/conflict responses to the same inline abbreviation error extend TeamEditModal tests for uniqueness and conflict handling (all passing)