### PR TITLE
Feat/corpcal 158 report date range header

### DIFF
--- a/calendar-ui/src/components/reports/ReportAppliedDateRange.test.tsx
+++ b/calendar-ui/src/components/reports/ReportAppliedDateRange.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeReportActivityDateRange } from '@corpcal/shared/reports/normalizeReportActivityDateRange';
+
+import { ReportAppliedDateRange } from './ReportAppliedDateRange';
+
+const dateRange = normalizeReportActivityDateRange({
+  startDateFrom: '2026-01-01',
+  startDateTo: '2026-03-31',
+});
+
+describe('ReportAppliedDateRange', () => {
+  it('renders the formatted applied date range', () => {
+    render(<ReportAppliedDateRange dateRange={dateRange} />);
+
+    expect(
+      screen.getByLabelText('Applied date range: Jan 1 – Mar 31, 2026')
+    ).toBeTruthy();
+  });
+
+  it('renders nothing when date range is missing', () => {
+    const { container } = render(<ReportAppliedDateRange dateRange={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/calendar-ui/src/components/reports/ReportAppliedDateRange.tsx
+++ b/calendar-ui/src/components/reports/ReportAppliedDateRange.tsx
@@ -1,0 +1,23 @@
+import type { NormalizedReportDateRange } from '@corpcal/shared/reports/reportDateRange';
+import { formatDateRange } from '@/lib/datetime-utils';
+
+export interface ReportAppliedDateRangeProps {
+  dateRange: NormalizedReportDateRange | null;
+}
+
+export function ReportAppliedDateRange({
+  dateRange,
+}: ReportAppliedDateRangeProps) {
+  if (!dateRange) return null;
+
+  const label = formatDateRange(dateRange.start, dateRange.end);
+
+  return (
+    <p
+      className="text-foreground min-w-0 truncate text-base font-semibold"
+      aria-label={`Applied date range: ${label}`}
+    >
+      {label}
+    </p>
+  );
+}

--- a/calendar-ui/src/pages/ReportsPage.tsx
+++ b/calendar-ui/src/pages/ReportsPage.tsx
@@ -18,6 +18,7 @@ import { CustomReportPreviewSection } from '@/components/reports/CustomReportPre
 import { EditReportModal } from '@/components/reports/EditReportModal';
 import { LookAheadDayRangeTabs } from '@/components/reports/LookAheadDayRangeTabs';
 import { PrintReportPreview } from '@/components/reports/PrintReportPreview';
+import { ReportAppliedDateRange } from '@/components/reports/ReportAppliedDateRange';
 import { ReportFiltersBar } from '@/components/reports/ReportFiltersBar';
 import { ReportLargeRangeWarning } from '@/components/reports/ReportLargeRangeWarning';
 import { ReportMonthRangeTabs } from '@/components/reports/ReportMonthRangeTabs';
@@ -478,24 +479,31 @@ export function ReportsPage() {
               {activeReport === report.name &&
               usesReportPreviewShell(report.name) ? (
                 <div className="flex min-h-0 flex-col">
-                  <div className="border-border flex h-9 shrink-0 items-center justify-end gap-4 border-t">
-                    <ReportLargeRangeWarning
-                      showLargeRangeWarning={showLargeRangeWarning}
-                      wasClamped={wasDateRangeClamped}
+                  <div className="border-border flex h-9 shrink-0 items-center justify-between gap-4 border-t">
+                    <ReportAppliedDateRange
+                      dateRange={resolvedReportDateRange}
                     />
-                    {isFullscreenPrintPreview(report.name) ? (
-                      <label className="text-foreground flex shrink-0 cursor-pointer items-center gap-2 text-sm">
-                        <Checkbox
-                          checked={previewSheetWidthMode === 'print'}
-                          onCheckedChange={(checked) =>
-                            setPreviewSheetWidthMode(checked ? 'print' : 'full')
-                          }
-                          aria-label="Print width"
-                          className="border-input"
-                        />
-                        Print width
-                      </label>
-                    ) : null}
+                    <div className="flex shrink-0 items-center gap-4">
+                      <ReportLargeRangeWarning
+                        showLargeRangeWarning={showLargeRangeWarning}
+                        wasClamped={wasDateRangeClamped}
+                      />
+                      {isFullscreenPrintPreview(report.name) ? (
+                        <label className="text-foreground flex shrink-0 cursor-pointer items-center gap-2 text-sm">
+                          <Checkbox
+                            checked={previewSheetWidthMode === 'print'}
+                            onCheckedChange={(checked) =>
+                              setPreviewSheetWidthMode(
+                                checked ? 'print' : 'full'
+                              )
+                            }
+                            aria-label="Print width"
+                            className="border-input"
+                          />
+                          Print width
+                        </label>
+                      ) : null}
+                    </div>
                   </div>
                   {isPreviewLoading ? (
                     <ReportPreviewEmptyState


### PR DESCRIPTION
## Summary

Small UI feat to make the selected date range visible on the reports page.
<img width="1753" height="1290" alt="Screenshot 2026-06-30 at 11 11 06 AM" src="https://github.com/user-attachments/assets/c5986c7f-ee9b-424e-afa5-6f3d01ca61c4" />

## Changes

- add ReportAppliedDateRange component with formatted range label
- wire component into ReportsPage preview shell toolbar
- align toolbar with date left and warnings/print controls right
- add unit tests for label formatting and null date range