### PR TITLE
Fix/corpcal 000 snowplow config overlay

### DIFF
--- a/calendar-service/src/activities/activity-flags.controller.ts
+++ b/calendar-service/src/activities/activity-flags.controller.ts
@@ -54,9 +54,10 @@ export class ActivityFlagsController {
   @ApiOperation({
     summary: 'Assign (flag) an activity',
     description:
-      'Assigns a team member to an activity for follow-up. ' +
-      'At most one assignee per (activity, team) pair. ' +
-      'Replaces the existing flag if one exists. ' +
+      'Legacy single-assignee endpoint. Assigns one team member to an activity for follow-up. ' +
+      'Internally syncs the full assignee set for the given (activity, team) pair to exactly one assignee, ' +
+      'so calling this route will remove any other existing assignees for that team. ' +
+      'Prefer PUT /activities/:id/flags for multi-assignee updates. ' +
       "Requires activities.flag permission. The caller's teamId must be provided in the body.",
   })
   @ApiParam({ name: 'id', type: Number, description: 'Activity ID' })
@@ -99,6 +100,8 @@ export class ActivityFlagsController {
     description:
       'Sets the full assignee list for the given (activity, team) pair. ' +
       'Adds missing assignees and removes assignees not present in the provided list. ' +
+      'This is the preferred multi-assignee endpoint. ' +
+      'By contrast, the legacy PUT /activities/:id/flag route overwrites the full set to a single assignee and can remove other assignees for that team. ' +
       'Requires activities.flag permission and a teamId the caller belongs to.',
   })
   @ApiParam({ name: 'id', type: Number, description: 'Activity ID' })

--- a/calendar-service/src/activities/activity-flags.controller.ts
+++ b/calendar-service/src/activities/activity-flags.controller.ts
@@ -117,14 +117,18 @@ export class ActivityFlagsController {
     @Body(new ZodValidationPipe(upsertActivityFlagsRequestSchema))
     body: UpsertActivityFlagsRequest,
     @CurrentUser() user: AuthUser
-  ): Promise<{ success: boolean }> {
+  ): Promise<{
+    success: boolean;
+    addedAssigneeIds: number[];
+    removedAssigneeIds: number[];
+  }> {
     if (!user.teamIds.includes(body.teamId)) {
       throw new ForbiddenException(
         'You are not a member of the specified team'
       );
     }
 
-    await this.flagsService.syncFlags(
+    const delta = await this.flagsService.syncFlags(
       activityId,
       body.teamId,
       body.assigneeIds,
@@ -132,7 +136,7 @@ export class ActivityFlagsController {
       body.note
     );
     this.gateway.broadcastActivityUpdated(activityId);
-    return { success: true };
+    return { success: true, ...delta };
   }
 
   @ApiOperation({

--- a/calendar-service/src/activities/activity-flags.controller.ts
+++ b/calendar-service/src/activities/activity-flags.controller.ts
@@ -21,7 +21,9 @@ import { createZodDto } from 'nestjs-zod';
 import type { AuthUser } from '@corpcal/shared';
 import {
   upsertActivityFlagRequestSchema,
+  upsertActivityFlagsRequestSchema,
   type UpsertActivityFlagRequest,
+  type UpsertActivityFlagsRequest,
 } from '@corpcal/shared/schemas';
 
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -33,6 +35,10 @@ import { ActivityFlagsService } from './services/activity-flags.service';
 
 class UpsertActivityFlagDto extends createZodDto(
   upsertActivityFlagRequestSchema
+) {}
+
+class UpsertActivityFlagsDto extends createZodDto(
+  upsertActivityFlagsRequestSchema
 ) {}
 
 @ApiTags('activities')
@@ -89,9 +95,88 @@ export class ActivityFlagsController {
   }
 
   @ApiOperation({
-    summary: 'Remove (unflag) an activity',
+    summary: 'Sync reviewer assignees for an activity',
     description:
-      'Removes the flag for the given team. Any authenticated team member can unflag.',
+      'Sets the full assignee list for the given (activity, team) pair. ' +
+      'Adds missing assignees and removes assignees not present in the provided list. ' +
+      'Requires activities.flag permission and a teamId the caller belongs to.',
+  })
+  @ApiParam({ name: 'id', type: Number, description: 'Activity ID' })
+  @ApiBody({ type: UpsertActivityFlagsDto })
+  @ApiResponse({ status: 200, description: 'Flags synced successfully' })
+  @ApiResponse({
+    status: 403,
+    description: 'No team with flag permission or assignee not on team',
+  })
+  @ApiResponse({ status: 404, description: 'Activity not found' })
+  @RequirePermission('activities.flag')
+  @Put(':id/flags')
+  @HttpCode(HttpStatus.OK)
+  async syncFlags(
+    @Param('id', ParseIntPipe) activityId: number,
+    @Body(new ZodValidationPipe(upsertActivityFlagsRequestSchema))
+    body: UpsertActivityFlagsRequest,
+    @CurrentUser() user: AuthUser
+  ): Promise<{ success: boolean }> {
+    if (!user.teamIds.includes(body.teamId)) {
+      throw new ForbiddenException(
+        'You are not a member of the specified team'
+      );
+    }
+
+    await this.flagsService.syncFlags(
+      activityId,
+      body.teamId,
+      body.assigneeIds,
+      user.id,
+      body.note
+    );
+    this.gateway.broadcastActivityUpdated(activityId);
+    return { success: true };
+  }
+
+  @ApiOperation({
+    summary: 'Remove one assignee flag from an activity',
+    description:
+      'Removes one assignee from the flag set for the given (activity, team) pair. ' +
+      'Any authenticated team member can unflag.',
+  })
+  @ApiParam({ name: 'id', type: Number, description: 'Activity ID' })
+  @ApiParam({ name: 'teamId', type: Number, description: 'Team ID' })
+  @ApiParam({
+    name: 'assigneeId',
+    type: Number,
+    description: 'Assignee user ID',
+  })
+  @ApiResponse({ status: 200, description: 'Assignee flag removed' })
+  @Delete(':id/flag/:teamId/:assigneeId')
+  @HttpCode(HttpStatus.OK)
+  async removeAssigneeFlag(
+    @Param('id', ParseIntPipe) activityId: number,
+    @Param('teamId', ParseIntPipe) teamId: number,
+    @Param('assigneeId', ParseIntPipe) assigneeId: number,
+    @CurrentUser() user: AuthUser
+  ): Promise<{ success: boolean }> {
+    if (!user.teamIds.includes(teamId)) {
+      throw new ForbiddenException(
+        'You are not a member of the specified team'
+      );
+    }
+
+    await this.flagsService.removeAssigneeFlag(
+      activityId,
+      teamId,
+      assigneeId,
+      user.id
+    );
+    this.gateway.broadcastActivityUpdated(activityId);
+    return { success: true };
+  }
+
+  @ApiOperation({
+    summary: 'Remove all assignee flags for a team',
+    description:
+      'Removes all assignee flags for the given team. Any authenticated team member can unflag.',
   })
   @ApiParam({ name: 'id', type: Number, description: 'Activity ID' })
   @ApiParam({ name: 'teamId', type: Number, description: 'Team ID' })

--- a/calendar-service/src/activities/services/activity-flags.service.spec.ts
+++ b/calendar-service/src/activities/services/activity-flags.service.spec.ts
@@ -13,14 +13,18 @@ describe('ActivityFlagsService', () => {
   };
 
   /**
-   * Build a chainable Drizzle-like mock where each method returns `this`
-   * except `limit`, which resolves to `resolveValue`.
+   * Build a chainable Drizzle-like mock.
+   *
+   * mode='limit': terminal call is limit().
+   * mode='where': terminal call is where().
    */
-  const makeChain = (resolveValue: unknown) => {
+  const makeChain = (
+    resolveValue: unknown,
+    mode: 'limit' | 'where' = 'limit'
+  ) => {
     const chain: Record<string, unknown> = {};
     const methods = [
       'from',
-      'where',
       'innerJoin',
       'leftJoin',
       'orderBy',
@@ -30,15 +34,19 @@ describe('ActivityFlagsService', () => {
     for (const m of methods) {
       chain[m] = vi.fn().mockReturnValue(chain);
     }
+    chain['where'] =
+      mode === 'where'
+        ? vi.fn().mockResolvedValue(resolveValue)
+        : vi.fn().mockReturnValue(chain);
     chain['limit'] = vi.fn().mockResolvedValue(resolveValue);
     return chain;
   };
 
-  /** Builds a mock db.insert() chain that resolves onConflictDoUpdate to undefined. */
+  /** Builds a mock db.insert() chain for syncFlags insert path. */
   const makeInsertChain = () => {
     const chain: Record<string, unknown> = {};
     chain['values'] = vi.fn().mockReturnValue(chain);
-    chain['onConflictDoUpdate'] = vi.fn().mockResolvedValue(undefined);
+    chain['onConflictDoNothing'] = vi.fn().mockResolvedValue(undefined);
     return chain;
   };
 
@@ -75,12 +83,12 @@ describe('ActivityFlagsService', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // upsertFlag
+  // upsertFlag / syncFlags
   // ---------------------------------------------------------------------------
   describe('upsertFlag', () => {
     it('throws NotFoundException when activity does not exist', async () => {
       // select() is called multiple times; first call (activity lookup) returns []
-      mockDb.select.mockReturnValue(makeChain([]));
+      mockDb.select.mockReturnValue(makeChain([], 'limit'));
 
       await expect(service.upsertFlag(999, 1, 2, 3)).rejects.toThrow(
         NotFoundException
@@ -92,9 +100,9 @@ describe('ActivityFlagsService', () => {
       mockDb.select.mockImplementation(() => {
         callCount++;
         // 1st call: activity exists
-        if (callCount === 1) return makeChain([{ id: 1 }]);
+        if (callCount === 1) return makeChain([{ id: 1 }], 'limit');
         // 2nd call: membership check → not found
-        return makeChain([]);
+        return makeChain([], 'where');
       });
 
       await expect(service.upsertFlag(1, 1, 99, 3)).rejects.toThrow(
@@ -102,14 +110,14 @@ describe('ActivityFlagsService', () => {
       );
     });
 
-    it('records flag_assigned with names for a fresh assignment', async () => {
+    it('records flag_assigned for a fresh assignment', async () => {
       let callCount = 0;
       mockDb.select.mockImplementation(() => {
         callCount++;
-        if (callCount === 1) return makeChain([{ id: 1 }]); // activity exists
-        if (callCount === 2) return makeChain([{ userId: 2 }]); // membership ok
-        if (callCount === 3) return makeChain([]); // no existing flag
-        return makeChain([{ name: 'Jane Smith' }]); // assignee name
+        if (callCount === 1) return makeChain([{ id: 1 }], 'limit'); // activity exists
+        if (callCount === 2)
+          return makeChain([{ userId: 2, name: 'Jane Smith' }], 'where'); // membership + name
+        return makeChain([], 'where'); // no existing flags
       });
       mockDb.insert.mockReturnValue(makeInsertChain());
 
@@ -123,16 +131,17 @@ describe('ActivityFlagsService', () => {
       );
     });
 
-    it('records flag_assigned with previous name for a reassignment', async () => {
+    it('records flag_assigned and flag_removed when replacing one assignee with another', async () => {
       let callCount = 0;
       mockDb.select.mockImplementation(() => {
         callCount++;
-        if (callCount === 1) return makeChain([{ id: 1 }]);
-        if (callCount === 2) return makeChain([{ userId: 2 }]);
-        if (callCount === 3) return makeChain([{ existingName: 'Old Person' }]); // existing flag
-        return makeChain([{ name: 'Jane Smith' }]); // new assignee name
+        if (callCount === 1) return makeChain([{ id: 1 }], 'limit');
+        if (callCount === 2)
+          return makeChain([{ userId: 2, name: 'Jane Smith' }], 'where');
+        return makeChain([{ assigneeId: 4, name: 'Old Person' }], 'where');
       });
       mockDb.insert.mockReturnValue(makeInsertChain());
+      mockDb.delete.mockReturnValue(makeDeleteChain());
 
       await service.upsertFlag(1, 1, 2, 3);
 
@@ -140,13 +149,13 @@ describe('ActivityFlagsService', () => {
         1,
         3,
         'flag_assigned',
-        [
-          {
-            field: 'flag.assigneeName',
-            oldValue: 'Old Person',
-            newValue: 'Jane Smith',
-          },
-        ]
+        [{ field: 'flag.assigneeName', oldValue: null, newValue: 'Jane Smith' }]
+      );
+      expect(mockHistoryService.recordChange).toHaveBeenCalledWith(
+        1,
+        3,
+        'flag_removed',
+        [{ field: 'flag.assigneeName', oldValue: 'Old Person', newValue: null }]
       );
     });
   });
@@ -155,13 +164,19 @@ describe('ActivityFlagsService', () => {
   // removeFlag
   // ---------------------------------------------------------------------------
   describe('removeFlag', () => {
-    it('records flag_removed with the assignee name', async () => {
+    it('records flag_removed for each assignee removed', async () => {
       let callCount = 0;
       mockDb.select.mockImplementation(() => {
         callCount++;
-        // 1st call: existing flag with assignee name
-        if (callCount === 1) return makeChain([{ name: 'Jane Smith' }]);
-        return makeChain([]);
+        if (callCount === 1)
+          return makeChain(
+            [
+              { assigneeId: 2, name: 'Jane Smith' },
+              { assigneeId: 4, name: 'John Doe' },
+            ],
+            'where'
+          );
+        return makeChain([], 'where');
       });
       mockDb.delete.mockReturnValue(makeDeleteChain());
 
@@ -173,15 +188,42 @@ describe('ActivityFlagsService', () => {
         'flag_removed',
         [{ field: 'flag.assigneeName', oldValue: 'Jane Smith', newValue: null }]
       );
+      expect(mockHistoryService.recordChange).toHaveBeenCalledWith(
+        1,
+        3,
+        'flag_removed',
+        [{ field: 'flag.assigneeName', oldValue: 'John Doe', newValue: null }]
+      );
     });
 
     it('is a no-op (no delete, no history) when no flag existed', async () => {
-      mockDb.select.mockReturnValue(makeChain([]));
+      mockDb.select.mockReturnValue(makeChain([], 'where'));
 
       await service.removeFlag(1, 1, 3);
 
       expect(mockDb.delete).not.toHaveBeenCalled();
       expect(mockHistoryService.recordChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // removeAssigneeFlag
+  // ---------------------------------------------------------------------------
+  describe('removeAssigneeFlag', () => {
+    it('removes one assignee and writes history entry', async () => {
+      mockDb.select.mockReturnValue(
+        makeChain([{ name: 'Jane Smith' }], 'limit')
+      );
+      mockDb.delete.mockReturnValue(makeDeleteChain());
+
+      await service.removeAssigneeFlag(1, 1, 2, 3);
+
+      expect(mockHistoryService.recordChange).toHaveBeenCalledWith(
+        1,
+        3,
+        'flag_removed',
+        [{ field: 'flag.assigneeName', oldValue: 'Jane Smith', newValue: null }]
+      );
     });
   });
 

--- a/calendar-service/src/activities/services/activity-flags.service.ts
+++ b/calendar-service/src/activities/services/activity-flags.service.ts
@@ -122,12 +122,13 @@ export class ActivityFlagsService {
 
     const existingAssigneeIds = existingFlags.map((row) => row.assigneeId);
     const existingAssigneeSet = new Set(existingAssigneeIds);
+    const desiredAssigneeSet = new Set(desiredAssigneeIds);
 
     const toAdd = desiredAssigneeIds.filter(
       (id) => !existingAssigneeSet.has(id)
     );
     const toRemove = existingAssigneeIds.filter(
-      (id) => !desiredAssigneeIds.includes(id)
+      (id) => !desiredAssigneeSet.has(id)
     );
 
     if (toAdd.length > 0) {

--- a/calendar-service/src/activities/services/activity-flags.service.ts
+++ b/calendar-service/src/activities/services/activity-flags.service.ts
@@ -30,9 +30,10 @@ export class ActivityFlagsService {
   ) {}
 
   /**
-   * Upsert the flag for the calling user's team on a given activity.
-   * Replaces any existing flag for that (activity, team) pair.
-   * The assignee must be a member of the same team.
+   * Legacy single-assignee API.
+   *
+   * Preserves prior behaviour by syncing the full assignee set to exactly one
+   * assignee for the provided (activity, team).
    */
   async upsertFlag(
     activityId: number,
@@ -41,7 +42,22 @@ export class ActivityFlagsService {
     assignedById: number,
     note?: string
   ): Promise<void> {
+    await this.syncFlags(activityId, teamId, [assigneeId], assignedById, note);
+  }
+
+  /**
+   * Syncs assignees for a given (activity, team) pair to exactly match
+   * the provided assignee list.
+   */
+  async syncFlags(
+    activityId: number,
+    teamId: number,
+    assigneeIds: number[],
+    assignedById: number,
+    note?: string
+  ): Promise<void> {
     const db = this.databaseService.db;
+    const desiredAssigneeIds = Array.from(new Set(assigneeIds));
 
     // Validate activity exists
     const [activity] = await db
@@ -53,29 +69,47 @@ export class ActivityFlagsService {
       throw new NotFoundException(`Activity ${activityId} not found`);
     }
 
-    // Validate assignee is a member of the team
-    const [membership] = await db
-      .select({ userId: userTeams.userId })
-      .from(userTeams)
-      .where(
-        and(
-          eq(userTeams.userId, assigneeId),
-          eq(userTeams.teamId, teamId),
-          eq(userTeams.isActive, true)
-        )
-      )
-      .limit(1);
+    // Validate all assignees are active members of the team
+    const assigneeMembershipRows =
+      desiredAssigneeIds.length === 0
+        ? []
+        : await db
+            .select({
+              userId: userTeams.userId,
+              name: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
+            })
+            .from(userTeams)
+            .innerJoin(users, eq(users.id, userTeams.userId))
+            .where(
+              and(
+                eq(userTeams.teamId, teamId),
+                eq(userTeams.isActive, true),
+                inArray(userTeams.userId, desiredAssigneeIds)
+              )
+            );
 
-    if (!membership) {
+    const membershipUserIdSet = new Set(
+      assigneeMembershipRows.map((m) => m.userId)
+    );
+    const invalidAssigneeIds = desiredAssigneeIds.filter(
+      (id) => !membershipUserIdSet.has(id)
+    );
+
+    if (invalidAssigneeIds.length > 0) {
       throw new ForbiddenException(
-        'Assignee is not an active member of this team'
+        'One or more assignees are not active members of this team'
       );
     }
 
-    // Look up existing assignee name before upsert
-    const [existingFlag] = await db
+    const assigneeNameById = new Map(
+      assigneeMembershipRows.map((row) => [row.userId, row.name] as const)
+    );
+
+    // Existing flags for this (activity, team) pair
+    const existingFlags = await db
       .select({
-        existingName: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
+        assigneeId: activityFlags.assigneeId,
+        name: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
       })
       .from(activityFlags)
       .innerJoin(users, eq(users.id, activityFlags.assigneeId))
@@ -84,52 +118,88 @@ export class ActivityFlagsService {
           eq(activityFlags.activityId, activityId),
           eq(activityFlags.teamId, teamId)
         )
-      )
-      .limit(1);
-    const previousAssigneeName = existingFlag?.existingName ?? null;
+      );
 
-    await db
-      .insert(activityFlags)
-      .values({
-        activityId,
-        teamId,
-        assigneeId,
-        assignedById,
-        note: note ?? null,
-        updatedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: [activityFlags.activityId, activityFlags.teamId],
-        set: {
-          assigneeId,
-          assignedById,
-          note: note ?? null,
-          updatedAt: new Date(),
-        },
-      });
+    const existingAssigneeIds = existingFlags.map((row) => row.assigneeId);
+    const existingAssigneeSet = new Set(existingAssigneeIds);
 
-    // Look up new assignee display name for history
-    const [assigneeUser] = await db
-      .select({
-        name: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
-      })
-      .from(users)
-      .where(eq(users.id, assigneeId))
-      .limit(1);
-    const assigneeName = assigneeUser?.name ?? String(assigneeId);
-
-    await this.activityHistoryService.recordChange(
-      activityId,
-      assignedById,
-      'flag_assigned',
-      [
-        {
-          field: 'flag.assigneeName',
-          oldValue: previousAssigneeName,
-          newValue: assigneeName,
-        },
-      ]
+    const toAdd = desiredAssigneeIds.filter(
+      (id) => !existingAssigneeSet.has(id)
     );
+    const toRemove = existingAssigneeIds.filter(
+      (id) => !desiredAssigneeIds.includes(id)
+    );
+
+    if (toAdd.length > 0) {
+      await db
+        .insert(activityFlags)
+        .values(
+          toAdd.map((assigneeId) => ({
+            activityId,
+            teamId,
+            assigneeId,
+            assignedById,
+            note: note ?? null,
+            updatedAt: new Date(),
+          }))
+        )
+        .onConflictDoNothing({
+          target: [
+            activityFlags.activityId,
+            activityFlags.teamId,
+            activityFlags.assigneeId,
+          ],
+        });
+    }
+
+    if (toRemove.length > 0) {
+      await db
+        .delete(activityFlags)
+        .where(
+          and(
+            eq(activityFlags.activityId, activityId),
+            eq(activityFlags.teamId, teamId),
+            inArray(activityFlags.assigneeId, toRemove)
+          )
+        );
+    }
+
+    for (const assigneeId of toAdd) {
+      const assigneeName =
+        assigneeNameById.get(assigneeId) ?? String(assigneeId);
+      await this.activityHistoryService.recordChange(
+        activityId,
+        assignedById,
+        'flag_assigned',
+        [
+          {
+            field: 'flag.assigneeName',
+            oldValue: null,
+            newValue: assigneeName,
+          },
+        ]
+      );
+    }
+
+    const existingNameById = new Map(
+      existingFlags.map((row) => [row.assigneeId, row.name] as const)
+    );
+    for (const assigneeId of toRemove) {
+      const assigneeName =
+        existingNameById.get(assigneeId) ?? String(assigneeId);
+      await this.activityHistoryService.recordChange(
+        activityId,
+        assignedById,
+        'flag_removed',
+        [
+          {
+            field: 'flag.assigneeName',
+            oldValue: assigneeName,
+            newValue: null,
+          },
+        ]
+      );
+    }
   }
 
   /**
@@ -143,7 +213,55 @@ export class ActivityFlagsService {
   ): Promise<void> {
     const db = this.databaseService.db;
 
-    // Look up existing assignee name before deleting
+    const existing = await db
+      .select({
+        assigneeId: activityFlags.assigneeId,
+        name: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
+      })
+      .from(activityFlags)
+      .innerJoin(users, eq(users.id, activityFlags.assigneeId))
+      .where(
+        and(
+          eq(activityFlags.activityId, activityId),
+          eq(activityFlags.teamId, teamId)
+        )
+      );
+
+    if (existing.length === 0) {
+      return;
+    }
+
+    await db
+      .delete(activityFlags)
+      .where(
+        and(
+          eq(activityFlags.activityId, activityId),
+          eq(activityFlags.teamId, teamId)
+        )
+      );
+
+    for (const row of existing) {
+      await this.activityHistoryService.recordChange(
+        activityId,
+        removedById,
+        'flag_removed',
+        [{ field: 'flag.assigneeName', oldValue: row.name, newValue: null }]
+      );
+    }
+  }
+
+  /**
+   * Remove a single assignee flag for a given (activity, team, assignee) tuple.
+   * No-op if the row does not exist.
+   */
+  async removeAssigneeFlag(
+    activityId: number,
+    teamId: number,
+    assigneeId: number,
+    removedById: number
+  ): Promise<void> {
+    const db = this.databaseService.db;
+
     const [existing] = await db
       .select({
         name: sql<string>`COALESCE(${users.adDisplayName}, ${users.adEmail})`,
@@ -153,7 +271,8 @@ export class ActivityFlagsService {
       .where(
         and(
           eq(activityFlags.activityId, activityId),
-          eq(activityFlags.teamId, teamId)
+          eq(activityFlags.teamId, teamId),
+          eq(activityFlags.assigneeId, assigneeId)
         )
       )
       .limit(1);
@@ -168,7 +287,8 @@ export class ActivityFlagsService {
       .where(
         and(
           eq(activityFlags.activityId, activityId),
-          eq(activityFlags.teamId, teamId)
+          eq(activityFlags.teamId, teamId),
+          eq(activityFlags.assigneeId, assigneeId)
         )
       );
 

--- a/calendar-service/src/activities/services/activity-flags.service.ts
+++ b/calendar-service/src/activities/services/activity-flags.service.ts
@@ -55,7 +55,7 @@ export class ActivityFlagsService {
     assigneeIds: number[],
     assignedById: number,
     note?: string
-  ): Promise<void> {
+  ): Promise<{ addedAssigneeIds: number[]; removedAssigneeIds: number[] }> {
     const db = this.databaseService.db;
     const desiredAssigneeIds = Array.from(new Set(assigneeIds));
 
@@ -200,6 +200,11 @@ export class ActivityFlagsService {
         ]
       );
     }
+
+    return {
+      addedAssigneeIds: toAdd,
+      removedAssigneeIds: toRemove,
+    };
   }
 
   /**

--- a/calendar-service/test/activities.e2e-spec.ts
+++ b/calendar-service/test/activities.e2e-spec.ts
@@ -359,6 +359,112 @@ describe('ActivitiesController (API integration)', () => {
     });
   });
 
+  describe('/activities/:id/flags and /activities/:id/flag/*', () => {
+    let flagTargetId: number;
+    let flagTeamId: number;
+    let assigneeIds: number[] = [];
+
+    beforeAll(async () => {
+      const meRes = await createAuthRequest(app, accessToken)
+        .get('/auth/me')
+        .expect(200);
+      const myTeamIds = (meRes.body?.teamIds as number[] | undefined) ?? [];
+      expect(myTeamIds.length).toBeGreaterThan(0);
+      flagTeamId = myTeamIds[0]!;
+
+      const teamRes = await createAuthRequest(app, accessToken)
+        .get(`/teams/${flagTeamId}`)
+        .expect(200);
+      const members = Array.isArray(teamRes.body?.data?.members)
+        ? teamRes.body.data.members
+        : [];
+      const teamMemberIds = Array.from(
+        new Set(
+          members
+            .map((m: any) => Number(m.userId))
+            .filter((id: number) => Number.isFinite(id))
+        )
+      );
+      expect(teamMemberIds.length).toBeGreaterThan(0);
+      assigneeIds = teamMemberIds.slice(0, 2);
+
+      const createRes = await createAuthRequest(app, accessToken)
+        .post('/activities')
+        .send(
+          createMockActivityRequest({
+            title: 'E2E Flags Multi Assignee',
+            leadTeamId: flagTeamId,
+            commsContacts: [{ userId: assigneeIds[0], isLead: true }],
+          })
+        )
+        .expect(201);
+      flagTargetId = createRes.body.data.id;
+    });
+
+    it('should sync assignees and return delta metadata', async () => {
+      const syncRes = await createAuthRequest(app, accessToken)
+        .put(`/activities/${flagTargetId}/flags`)
+        .send({ teamId: flagTeamId, assigneeIds })
+        .expect(200);
+
+      expect(syncRes.body).toHaveProperty('success', true);
+      expect(Array.isArray(syncRes.body.addedAssigneeIds)).toBe(true);
+      expect(syncRes.body.addedAssigneeIds).toEqual(
+        expect.arrayContaining(assigneeIds)
+      );
+      expect(syncRes.body.addedAssigneeIds).toHaveLength(assigneeIds.length);
+      expect(syncRes.body.removedAssigneeIds).toEqual([]);
+
+      const getRes = await createAuthRequest(app, accessToken)
+        .get(`/activities/${flagTargetId}`)
+        .expect(200);
+      const currentTeamAssignees = (getRes.body.data.flags ?? [])
+        .filter((f: any) => f.teamId === flagTeamId)
+        .map((f: any) => f.assigneeId);
+
+      expect(currentTeamAssignees).toEqual(expect.arrayContaining(assigneeIds));
+      expect(currentTeamAssignees).toHaveLength(assigneeIds.length);
+    });
+
+    it('should remove a single assignee via targeted delete route', async () => {
+      const assigneeIdToRemove = assigneeIds[0];
+
+      const deleteRes = await createAuthRequest(app, accessToken)
+        .delete(
+          `/activities/${flagTargetId}/flag/${flagTeamId}/${assigneeIdToRemove}`
+        )
+        .expect(200);
+      expect(deleteRes.body).toHaveProperty('success', true);
+
+      const getRes = await createAuthRequest(app, accessToken)
+        .get(`/activities/${flagTargetId}`)
+        .expect(200);
+      const currentTeamAssignees = (getRes.body.data.flags ?? [])
+        .filter((f: any) => f.teamId === flagTeamId)
+        .map((f: any) => f.assigneeId);
+
+      expect(currentTeamAssignees).not.toContain(assigneeIdToRemove);
+      expect(currentTeamAssignees.length).toBe(
+        Math.max(assigneeIds.length - 1, 0)
+      );
+    });
+
+    it('should remove all assignees for a team', async () => {
+      const deleteRes = await createAuthRequest(app, accessToken)
+        .delete(`/activities/${flagTargetId}/flag/${flagTeamId}`)
+        .expect(200);
+      expect(deleteRes.body).toHaveProperty('success', true);
+
+      const getRes = await createAuthRequest(app, accessToken)
+        .get(`/activities/${flagTargetId}`)
+        .expect(200);
+      const currentTeamAssignees = (getRes.body.data.flags ?? []).filter(
+        (f: any) => f.teamId === flagTeamId
+      );
+      expect(currentTeamAssignees).toHaveLength(0);
+    });
+  });
+
   describe('/activities/:id/soft-delete (DELETE)', () => {
     let softDeleteTargetId: number;
 

--- a/calendar-ui/src/api/flagsApi.ts
+++ b/calendar-ui/src/api/flagsApi.ts
@@ -1,4 +1,7 @@
-import type { UpsertActivityFlagRequest } from '@corpcal/shared/schemas';
+import type {
+  UpsertActivityFlagRequest,
+  UpsertActivityFlagsRequest,
+} from '@corpcal/shared/schemas';
 
 import api from './axios';
 
@@ -13,6 +16,27 @@ export async function upsertActivityFlag(
   await api.put(`/activities/${activityId}/flag`, body);
 }
 
+export interface SyncActivityFlagsResponse {
+  success: boolean;
+  addedAssigneeIds: number[];
+  removedAssigneeIds: number[];
+}
+
+/**
+ * Sync the full assignee set for an activity/team pair.
+ * PUT /activities/:id/flags
+ */
+export async function syncActivityFlags(
+  activityId: number,
+  body: UpsertActivityFlagsRequest
+): Promise<SyncActivityFlagsResponse> {
+  const response = await api.put<SyncActivityFlagsResponse>(
+    `/activities/${activityId}/flags`,
+    body
+  );
+  return response.data;
+}
+
 /**
  * Remove (unflag) an activity for the given team.
  * DELETE /activities/:id/flag/:teamId
@@ -22,4 +46,16 @@ export async function removeActivityFlag(
   teamId: number
 ): Promise<void> {
   await api.delete(`/activities/${activityId}/flag/${teamId}`);
+}
+
+/**
+ * Remove a single assignee flag for an activity/team pair.
+ * DELETE /activities/:id/flag/:teamId/:assigneeId
+ */
+export async function removeAssigneeActivityFlag(
+  activityId: number,
+  teamId: number,
+  assigneeId: number
+): Promise<void> {
+  await api.delete(`/activities/${activityId}/flag/${teamId}/${assigneeId}`);
 }

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -38,7 +38,11 @@ type ActivityPageHeaderProps = {
     assigneeNames?: string[]
   ) => void;
   /** Called when a non-flagging user removes their own assignment. */
-  onFlagUnassign?: (teamId: number, assigneeName?: string) => void;
+  onFlagUnassign?: (
+    teamId: number,
+    assigneeId: number,
+    assigneeName?: string
+  ) => void;
   isFlagPending?: boolean;
   isFavourite?: boolean;
   onFavouriteToggle?: () => void;
@@ -223,7 +227,11 @@ export function ActivityPageHeader({
               title={`Assigned to ${flaggedLabel} — click to unassign`}
               aria-label={`Assigned to ${flaggedLabel} — click to unassign`}
               onClick={() =>
-                onFlagUnassign(iconFlag.teamId, iconFlag.assigneeName)
+                onFlagUnassign(
+                  iconFlag.teamId,
+                  iconFlag.assigneeId,
+                  iconFlag.assigneeName
+                )
               }
               disabled={isFlagPending}
               className={iconButtonClassName}

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -21,6 +21,7 @@ import { formatDisplayValue } from '@/lib/formatDisplayValue';
 
 type ActivityPageHeaderProps = {
   displayId: string;
+  currentUserId?: number | null;
   title: string;
   categories: string[];
   leadMinistry?: string | null;
@@ -54,6 +55,7 @@ type ActivityPageHeaderProps = {
  */
 export function ActivityPageHeader({
   displayId,
+  currentUserId,
   title,
   categories,
   leadMinistry,
@@ -91,7 +93,10 @@ export function ActivityPageHeader({
   const visibleStackedFlags = stackedFlags.slice(0, 3);
   const overflowFlagCount = Math.max(stackedFlags.length - 3, 0);
   const isFlagged = sortedFlags.length > 0;
-  const iconFlag = sortedFlags[0] ?? null;
+  const currentUserFlag =
+    currentUserId == null
+      ? null
+      : (sortedFlags.find((flag) => flag.assigneeId === currentUserId) ?? null);
   const flaggedLabel = sortedFlags.map((f) => f.assigneeName).join(', ');
 
   const iconButtonClassName = 'shrink-0';
@@ -219,26 +224,26 @@ export function ActivityPageHeader({
               )}
             </Button>
           )}
-          {!canFlag && isFlagged && iconFlag && onFlagUnassign && (
+          {!canFlag && currentUserFlag && onFlagUnassign && (
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              title={`Assigned to ${flaggedLabel} — click to unassign`}
-              aria-label={`Assigned to ${flaggedLabel} — click to unassign`}
+              title={`Assigned to ${currentUserFlag.assigneeName} — click to unassign`}
+              aria-label={`Assigned to ${currentUserFlag.assigneeName} — click to unassign`}
               onClick={() =>
                 onFlagUnassign(
-                  iconFlag.teamId,
-                  iconFlag.assigneeId,
-                  iconFlag.assigneeName
+                  currentUserFlag.teamId,
+                  currentUserFlag.assigneeId,
+                  currentUserFlag.assigneeName
                 )
               }
               disabled={isFlagPending}
               className={iconButtonClassName}
             >
               <ActivityFlagIcon
-                assigneeName={iconFlag.assigneeName}
-                assigneeFlagColour={iconFlag.assigneeFlagColour}
+                assigneeName={currentUserFlag.assigneeName}
+                assigneeFlagColour={currentUserFlag.assigneeFlagColour}
               />
             </Button>
           )}

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -28,13 +28,13 @@ type ActivityPageHeaderProps = {
   /** Flags for activities assigned to the current user's teams. */
   flags?: ActivityFlagResponse[];
   canFlag?: boolean;
-  onFlagAssign?: (
+  onFlagSync?: (
     teamId: number,
-    assigneeId: number,
+    assigneeIds: number[],
     note?: string,
-    assigneeName?: string
+    assigneeNames?: string[]
   ) => void;
-  /** Called when the user removes the assignment. Available to all users, not just admins. */
+  /** Called when a non-flagging user removes their own assignment. */
   onFlagUnassign?: (teamId: number, assigneeName?: string) => void;
   isFlagPending?: boolean;
   isFavourite?: boolean;
@@ -56,7 +56,7 @@ export function ActivityPageHeader({
   onHistoryClick,
   flags,
   canFlag,
-  onFlagAssign,
+  onFlagSync,
   onFlagUnassign,
   isFlagPending,
   isFavourite,
@@ -80,11 +80,13 @@ export function ActivityPageHeader({
 
   const sortedFlags =
     flags == null ? [] : [...flags].sort((a, b) => a.teamId - b.teamId);
+  const stackedFlags = [...sortedFlags].reverse();
   const isFlagged = sortedFlags.length > 0;
-  const hasSingleFlag = sortedFlags.length === 1;
-  const currentFlag = hasSingleFlag ? sortedFlags[0] : null;
+  const iconFlag = sortedFlags[0] ?? null;
+  const flaggedLabel = sortedFlags.map((f) => f.assigneeName).join(', ');
 
-  const iconButtonClassName = 'shrink-0 shadow-none';
+  const iconButtonClassName = 'shrink-0';
+  const multiFlagButtonClassName = 'mr-3 h-10 shrink-0 px-2 pr-4';
   const headerActionIconClassName = 'text-muted-foreground size-4';
   const timestampClassName = 'text-muted-foreground text-xs sm:text-sm';
   const showActionButtons =
@@ -152,54 +154,72 @@ export function ActivityPageHeader({
 
       {showActionButtons && (
         <div className="col-start-2 row-start-4 flex items-center gap-2 self-center sm:col-start-2 sm:row-start-3 sm:mt-auto sm:self-end sm:justify-self-end">
-          {canFlag && onFlagAssign && onFlagUnassign && (
+          {canFlag && onFlagSync && (
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="icon"
               title={
                 isFlagged
-                  ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
+                  ? `Assigned to ${flaggedLabel} — click to edit`
                   : 'Assign activity'
               }
               aria-label={
                 isFlagged
-                  ? `Assigned to ${currentFlag?.assigneeName ?? 'teammate'} — click to reassign`
+                  ? `Assigned to ${flaggedLabel} — click to edit`
                   : 'Assign activity'
               }
               onClick={() => setAssignModalOpen(true)}
               disabled={isFlagPending}
-              className={iconButtonClassName}
+              className={
+                isFlagged ? multiFlagButtonClassName : iconButtonClassName
+              }
             >
-              <ActivityFlagIcon
-                assigneeName={isFlagged ? currentFlag?.assigneeName : null}
-                assigneeFlagColour={currentFlag?.assigneeFlagColour}
-              />
+              {isFlagged ? (
+                <span className="flex items-center pr-1.5">
+                  {stackedFlags.map((flag, index) => (
+                    <span
+                      key={`${flag.teamId}:${flag.assigneeId}`}
+                      className={index > 0 ? '-ml-1' : undefined}
+                    >
+                      <ActivityFlagIcon
+                        assigneeName={flag.assigneeName}
+                        assigneeFlagColour={flag.assigneeFlagColour}
+                      />
+                    </span>
+                  ))}
+                </span>
+              ) : (
+                <ActivityFlagIcon
+                  assigneeName={null}
+                  assigneeFlagColour={null}
+                />
+              )}
             </Button>
           )}
-          {!canFlag && isFlagged && currentFlag && onFlagUnassign && (
+          {!canFlag && isFlagged && iconFlag && onFlagUnassign && (
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="icon"
-              title={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
-              aria-label={`Assigned to ${currentFlag.assigneeName} — click to unassign`}
+              title={`Assigned to ${flaggedLabel} — click to unassign`}
+              aria-label={`Assigned to ${flaggedLabel} — click to unassign`}
               onClick={() =>
-                onFlagUnassign(currentFlag.teamId, currentFlag.assigneeName)
+                onFlagUnassign(iconFlag.teamId, iconFlag.assigneeName)
               }
               disabled={isFlagPending}
               className={iconButtonClassName}
             >
               <ActivityFlagIcon
-                assigneeName={currentFlag.assigneeName}
-                assigneeFlagColour={currentFlag.assigneeFlagColour}
+                assigneeName={iconFlag.assigneeName}
+                assigneeFlagColour={iconFlag.assigneeFlagColour}
               />
             </Button>
           )}
           {onFavouriteToggle && (
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="icon"
               title={isFavourite ? 'Remove from watchlist' : 'Add to watchlist'}
               onClick={onFavouriteToggle}
@@ -215,7 +235,7 @@ export function ActivityPageHeader({
           {onHistoryClick && (
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="icon"
               title="View history"
               onClick={onHistoryClick}
@@ -227,18 +247,14 @@ export function ActivityPageHeader({
         </div>
       )}
 
-      {canFlag && onFlagAssign && onFlagUnassign && (
+      {canFlag && onFlagSync && (
         <AssignActivityModal
           open={assignModalOpen}
           onOpenChange={setAssignModalOpen}
           flags={flags ?? []}
           isSubmitting={isFlagPending ?? false}
-          onAssign={(teamId, assigneeId, note, assigneeName) => {
-            onFlagAssign(teamId, assigneeId, note, assigneeName);
-            setAssignModalOpen(false);
-          }}
-          onUnassign={(teamId, assigneeName) => {
-            onFlagUnassign(teamId, assigneeName);
+          onSync={(teamId, assigneeIds, note, assigneeNames) => {
+            onFlagSync(teamId, assigneeIds, note, assigneeNames);
             setAssignModalOpen(false);
           }}
           displayId={displayId}

--- a/calendar-ui/src/components/activity/ActivityPageHeader.tsx
+++ b/calendar-ui/src/components/activity/ActivityPageHeader.tsx
@@ -2,7 +2,10 @@ import { History, Star } from 'lucide-react';
 import { useState, type ReactElement } from 'react';
 
 import type { ActivityFlagResponse } from '@corpcal/shared/api/types';
-import { ActivityFlagIcon } from '@/components/activity/activities/ActivityFlagIcon';
+import {
+  ActivityFlagIcon,
+  ActivityFlagOverflowIcon,
+} from '@/components/activity/activities/ActivityFlagIcon';
 import { AssignActivityModal } from '@/components/activity/activities/AssignActivityModal';
 import { Badge, getActivityStatusBadgeVariant } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -81,6 +84,8 @@ export function ActivityPageHeader({
   const sortedFlags =
     flags == null ? [] : [...flags].sort((a, b) => a.teamId - b.teamId);
   const stackedFlags = [...sortedFlags].reverse();
+  const visibleStackedFlags = stackedFlags.slice(0, 3);
+  const overflowFlagCount = Math.max(stackedFlags.length - 3, 0);
   const isFlagged = sortedFlags.length > 0;
   const iconFlag = sortedFlags[0] ?? null;
   const flaggedLabel = sortedFlags.map((f) => f.assigneeName).join(', ');
@@ -177,10 +182,11 @@ export function ActivityPageHeader({
             >
               {isFlagged ? (
                 <span className="flex items-center pr-1.5">
-                  {stackedFlags.map((flag, index) => (
+                  {visibleStackedFlags.map((flag, index) => (
                     <span
                       key={`${flag.teamId}:${flag.assigneeId}`}
-                      className={index > 0 ? '-ml-1' : undefined}
+                      className={index > 0 ? '-ml-0.5' : undefined}
+                      style={{ zIndex: index + 1 }}
                     >
                       <ActivityFlagIcon
                         assigneeName={flag.assigneeName}
@@ -188,6 +194,18 @@ export function ActivityPageHeader({
                       />
                     </span>
                   ))}
+                  {overflowFlagCount > 0 ? (
+                    <span
+                      className={
+                        visibleStackedFlags.length > 0 ? '-ml-0.5' : undefined
+                      }
+                      style={{ zIndex: visibleStackedFlags.length + 1 }}
+                    >
+                      <ActivityFlagOverflowIcon
+                        extraCount={overflowFlagCount}
+                      />
+                    </span>
+                  ) : null}
                 </span>
               ) : (
                 <ActivityFlagIcon

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   MapPin,
   NotebookText,
+  Star,
   Users,
 } from 'lucide-react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -32,6 +33,7 @@ import { DEFAULT_ACTIVITY_FILTER_STATE, PERMISSIONS } from '@corpcal/shared';
 import { SYSTEM_ROLES } from '@corpcal/shared/auth';
 import { sanitizeLegendSwatchHexColor } from '@corpcal/shared/schemas';
 import { contrastingBlackOrWhiteForegroundHex } from '@corpcal/shared/utils';
+import { ActivityFlagIcon } from '@/components/activity/activities/ActivityFlagIcon';
 import { ActivityFlagPopover } from '@/components/activity/activities/ActivityFlagPopover';
 import { ErrorState } from '@/components/shared';
 import {
@@ -230,12 +232,14 @@ function OverviewCell({
   row,
   canViewPitchStatus,
   canFlag,
+  isFavourite,
   onFlagSync,
   flagPending,
 }: {
   row: ActivityTableRow;
   canViewPitchStatus: boolean;
   canFlag?: boolean;
+  isFavourite?: boolean;
   onFlagSync?: (
     teamId: number,
     assigneeIds: number[],
@@ -248,19 +252,23 @@ function OverviewCell({
     row.pitchDate ??
     null;
   const displayIdText = row.displayId ?? String(row.id);
+  const assignedFlags = useMemo(() => {
+    const uniqueFlags = new Map<number, ActivityTableRow['flags'][number]>();
+    row.flags.forEach((flag) => {
+      if (!uniqueFlags.has(flag.assigneeId)) {
+        uniqueFlags.set(flag.assigneeId, flag);
+      }
+    });
+    return Array.from(uniqueFlags.values());
+  }, [row.flags]);
+  const hasAssignedUsers = assignedFlags.length > 0;
+  const assignedTooltip = assignedFlags
+    .map((flag) => flag.assigneeName)
+    .join(', ');
 
   return (
     <div>
       <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0 text-xs font-semibold text-slate-900">
-        {(canFlag || row.flags.length > 0) && onFlagSync && (
-          <ActivityFlagPopover
-            activityId={row.id}
-            flags={row.flags}
-            readOnly={!canFlag}
-            onSync={onFlagSync}
-            isPending={flagPending}
-          />
-        )}
         <span
           data-no-row-nav
           onClick={(e) => e.stopPropagation()}
@@ -275,6 +283,71 @@ function OverviewCell({
             {displayIdText}
           </CopyableText>
         </span>
+        {isFavourite && (
+          <span
+            title="Added to watch list"
+            aria-label="Added to watch list"
+            className="inline-flex"
+          >
+            <Star
+              className="size-5 text-amber-500"
+              fill="currentColor"
+              aria-hidden
+            />
+          </span>
+        )}
+        {hasAssignedUsers && canFlag && onFlagSync ? (
+          <ActivityFlagPopover
+            activityId={row.id}
+            flags={row.flags}
+            readOnly={!canFlag}
+            onSync={onFlagSync}
+            isPending={flagPending}
+            triggerContent={
+              <span
+                title={assignedTooltip}
+                aria-label={assignedTooltip}
+                className="inline-flex"
+              >
+                <div className="flex items-center -space-x-1">
+                  {assignedFlags.map((flag) => (
+                    <ActivityFlagIcon
+                      key={`${flag.teamId}:${flag.assigneeId}`}
+                      assigneeName={flag.assigneeName}
+                      assigneeFlagColour={flag.assigneeFlagColour}
+                    />
+                  ))}
+                </div>
+              </span>
+            }
+          />
+        ) : hasAssignedUsers ? (
+          <span
+            data-no-row-nav
+            onClick={(e) => e.stopPropagation()}
+            title={assignedTooltip}
+            aria-label={assignedTooltip}
+            className="inline-flex"
+          >
+            <div className="flex items-center -space-x-1">
+              {assignedFlags.map((flag) => (
+                <ActivityFlagIcon
+                  key={`${flag.teamId}:${flag.assigneeId}`}
+                  assigneeName={flag.assigneeName}
+                  assigneeFlagColour={flag.assigneeFlagColour}
+                />
+              ))}
+            </div>
+          </span>
+        ) : canFlag && onFlagSync ? (
+          <ActivityFlagPopover
+            activityId={row.id}
+            flags={row.flags}
+            readOnly={!canFlag}
+            onSync={onFlagSync}
+            isPending={flagPending}
+          />
+        ) : null}
       </div>
       {(row.isConfidential || row.isIssue) && (
         <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0 text-sm font-semibold">

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -68,11 +68,7 @@ import { getLookAheadStatusLabel } from '@/constants/form-options';
 import { useActivityTableFilterLookups } from '@/hooks/useActivityTableFilterLookups';
 import { useActivityTablePreferences } from '@/hooks/useActivityTablePreferences';
 import { useAuth } from '@/hooks/useAuth';
-import {
-  useActivityList,
-  useRemoveActivityFlag,
-  useUpsertActivityFlag,
-} from '@/hooks/useCalendar';
+import { useActivityList, useSyncActivityFlags } from '@/hooks/useCalendar';
 import {
   useLiveActivityRowHighlights,
   useLiveActivitySyncContext,
@@ -234,19 +230,17 @@ function OverviewCell({
   row,
   canViewPitchStatus,
   canFlag,
-  onFlagAssign,
-  onFlagUnassign,
+  onFlagSync,
   flagPending,
 }: {
   row: ActivityTableRow;
   canViewPitchStatus: boolean;
   canFlag?: boolean;
-  onFlagAssign?: (
+  onFlagSync?: (
     teamId: number,
-    assigneeId: number,
-    assigneeName?: string
+    assigneeIds: number[],
+    assigneeNames?: string[]
   ) => void;
-  onFlagUnassign?: (teamId: number, assigneeName?: string) => void;
   flagPending?: boolean;
 }) {
   const pitchLabel =
@@ -258,18 +252,15 @@ function OverviewCell({
   return (
     <div>
       <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0 text-xs font-semibold text-slate-900">
-        {(canFlag || row.flags.length > 0) &&
-          onFlagAssign &&
-          onFlagUnassign && (
-            <ActivityFlagPopover
-              activityId={row.id}
-              flags={row.flags}
-              readOnly={!canFlag}
-              onAssign={onFlagAssign}
-              onUnassign={onFlagUnassign}
-              isPending={flagPending}
-            />
-          )}
+        {(canFlag || row.flags.length > 0) && onFlagSync && (
+          <ActivityFlagPopover
+            activityId={row.id}
+            flags={row.flags}
+            readOnly={!canFlag}
+            onSync={onFlagSync}
+            isPending={flagPending}
+          />
+        )}
         <span
           data-no-row-nav
           onClick={(e) => e.stopPropagation()}
@@ -1047,8 +1038,7 @@ export function ActivityTable({
   const error = activitiesQuery.isError ? activitiesQuery.error : null;
 
   const canFlag = hasPermission(PERMISSIONS.ACTIVITIES.FLAG);
-  const upsertFlagMutation = useUpsertActivityFlag();
-  const removeFlagMutation = useRemoveActivityFlag();
+  const syncFlagsMutation = useSyncActivityFlags();
 
   const onPaginationChangeStable = useCallback(
     (
@@ -1225,23 +1215,14 @@ export function ActivityTable({
             row={row.original}
             canViewPitchStatus={pitchFieldVisibility.canViewPitchStatus}
             canFlag={canFlag}
-            onFlagAssign={(teamId, assigneeId, assigneeName) =>
-              upsertFlagMutation.mutate({
+            onFlagSync={(teamId, assigneeIds, assigneeNames) =>
+              syncFlagsMutation.mutate({
                 activityId: row.original.id,
-                body: { teamId, assigneeId },
-                assigneeName,
+                body: { teamId, assigneeIds },
+                assigneeNames,
               })
             }
-            onFlagUnassign={(teamId, assigneeName) =>
-              removeFlagMutation.mutate({
-                activityId: row.original.id,
-                teamId,
-                assigneeName,
-              })
-            }
-            flagPending={
-              upsertFlagMutation.isPending || removeFlagMutation.isPending
-            }
+            flagPending={syncFlagsMutation.isPending}
           />
         ),
       }),
@@ -1347,8 +1328,7 @@ export function ActivityTable({
       handleSortChange,
       pitchFieldVisibility.canViewPitchStatus,
       canFlag,
-      upsertFlagMutation,
-      removeFlagMutation,
+      syncFlagsMutation,
     ]
   );
 

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -844,6 +844,8 @@ export interface ActivityTableProps {
   sharedWithTeamIds?: number[];
   /** When set, only activities whose IDs are in this list are shown (favourites tab). */
   favouriteActivityIds?: number[];
+  /** IDs currently in the user's watchlist; used to show the watchlist star indicator. */
+  watchlistActivityIds?: number[];
   /** When set, only activities flag-assigned to any of these users are shown. */
   flagAssigneeUserIds?: number[];
   /**
@@ -861,6 +863,7 @@ export function ActivityTable({
   commsContactLeadUserIds,
   sharedWithTeamIds,
   favouriteActivityIds,
+  watchlistActivityIds,
   flagAssigneeUserIds,
   activeSavedFilter: activeSavedFilterFromParent,
   onActiveSavedFilterChange,
@@ -1253,6 +1256,11 @@ export function ActivityTable({
     );
   }, [filteredData, effectiveSortKey, effectiveSortDirection]);
 
+  const watchlistActivityIdSet = useMemo(
+    () => new Set(watchlistActivityIds ?? []),
+    [watchlistActivityIds]
+  );
+
   // Track which row ids we have seen so we can animate only newly arrived rows on refetch
   const seenIdsRef = useRef<Set<number>>(new Set());
   const [newRowIds, setNewRowIds] = useState<Set<number>>(new Set());
@@ -1327,6 +1335,7 @@ export function ActivityTable({
             row={row.original}
             canViewPitchStatus={pitchFieldVisibility.canViewPitchStatus}
             canFlag={canFlag}
+            isFavourite={watchlistActivityIdSet.has(row.original.id)}
             onFlagSync={(teamId, assigneeIds, assigneeNames) =>
               syncFlagsMutation.mutate({
                 activityId: row.original.id,
@@ -1440,6 +1449,7 @@ export function ActivityTable({
       handleSortChange,
       pitchFieldVisibility.canViewPitchStatus,
       canFlag,
+      watchlistActivityIdSet,
       syncFlagsMutation,
     ]
   );

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -33,7 +33,10 @@ import { DEFAULT_ACTIVITY_FILTER_STATE, PERMISSIONS } from '@corpcal/shared';
 import { SYSTEM_ROLES } from '@corpcal/shared/auth';
 import { sanitizeLegendSwatchHexColor } from '@corpcal/shared/schemas';
 import { contrastingBlackOrWhiteForegroundHex } from '@corpcal/shared/utils';
-import { ActivityFlagIcon } from '@/components/activity/activities/ActivityFlagIcon';
+import {
+  ActivityFlagIcon,
+  ActivityFlagOverflowIcon,
+} from '@/components/activity/activities/ActivityFlagIcon';
 import { ActivityFlagPopover } from '@/components/activity/activities/ActivityFlagPopover';
 import { ErrorState } from '@/components/shared';
 import {
@@ -262,6 +265,8 @@ function OverviewCell({
     return Array.from(uniqueFlags.values());
   }, [row.flags]);
   const hasAssignedUsers = assignedFlags.length > 0;
+  const visibleAssignedFlags = assignedFlags.slice(0, 3);
+  const overflowAssignedCount = Math.max(assignedFlags.length - 3, 0);
   const assignedTooltip = assignedFlags
     .map((flag) => flag.assigneeName)
     .join(', ');
@@ -309,14 +314,31 @@ function OverviewCell({
                 aria-label={assignedTooltip}
                 className="inline-flex"
               >
-                <div className="flex items-center -space-x-1">
-                  {assignedFlags.map((flag) => (
-                    <ActivityFlagIcon
+                <div className="flex items-center">
+                  {visibleAssignedFlags.map((flag, index) => (
+                    <span
                       key={`${flag.teamId}:${flag.assigneeId}`}
-                      assigneeName={flag.assigneeName}
-                      assigneeFlagColour={flag.assigneeFlagColour}
-                    />
+                      className={index > 0 ? '-ml-0.5' : undefined}
+                      style={{ zIndex: index + 1 }}
+                    >
+                      <ActivityFlagIcon
+                        assigneeName={flag.assigneeName}
+                        assigneeFlagColour={flag.assigneeFlagColour}
+                      />
+                    </span>
                   ))}
+                  {overflowAssignedCount > 0 ? (
+                    <span
+                      className={
+                        visibleAssignedFlags.length > 0 ? '-ml-0.5' : undefined
+                      }
+                      style={{ zIndex: visibleAssignedFlags.length + 1 }}
+                    >
+                      <ActivityFlagOverflowIcon
+                        extraCount={overflowAssignedCount}
+                      />
+                    </span>
+                  ) : null}
                 </div>
               </span>
             }
@@ -329,14 +351,31 @@ function OverviewCell({
             aria-label={assignedTooltip}
             className="inline-flex"
           >
-            <div className="flex items-center -space-x-1">
-              {assignedFlags.map((flag) => (
-                <ActivityFlagIcon
+            <div className="flex items-center">
+              {visibleAssignedFlags.map((flag, index) => (
+                <span
                   key={`${flag.teamId}:${flag.assigneeId}`}
-                  assigneeName={flag.assigneeName}
-                  assigneeFlagColour={flag.assigneeFlagColour}
-                />
+                  className={index > 0 ? '-ml-0.5' : undefined}
+                  style={{ zIndex: index + 1 }}
+                >
+                  <ActivityFlagIcon
+                    assigneeName={flag.assigneeName}
+                    assigneeFlagColour={flag.assigneeFlagColour}
+                  />
+                </span>
               ))}
+              {overflowAssignedCount > 0 ? (
+                <span
+                  className={
+                    visibleAssignedFlags.length > 0 ? '-ml-0.5' : undefined
+                  }
+                  style={{ zIndex: visibleAssignedFlags.length + 1 }}
+                >
+                  <ActivityFlagOverflowIcon
+                    extraCount={overflowAssignedCount}
+                  />
+                </span>
+              ) : null}
             </div>
           </span>
         ) : canFlag && onFlagSync ? (

--- a/calendar-ui/src/components/activity/activities/ActivityFlagIcon.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagIcon.tsx
@@ -10,6 +10,11 @@ type ActivityFlagIconProps = {
   className?: string;
 };
 
+type ActivityFlagOverflowIconProps = {
+  extraCount: number;
+  className?: string;
+};
+
 function getAssigneeInitials(assigneeName: string): string {
   return assigneeName
     .split(' ')
@@ -44,7 +49,7 @@ export function ActivityFlagIcon({
 
   return (
     <span className={cn(iconContainerClassName, className)}>
-      <Avatar size="sm" className="size-full">
+      <Avatar size="sm" className="size-full border border-white/70">
         <AvatarFallback className="text-[8px] font-medium">
           {getAssigneeInitials(assigneeName)}
         </AvatarFallback>
@@ -54,6 +59,21 @@ export function ActivityFlagIcon({
         style={{ fill: flagColour, color: flagColour }}
         aria-hidden
       />
+    </span>
+  );
+}
+
+export function ActivityFlagOverflowIcon({
+  extraCount,
+  className,
+}: ActivityFlagOverflowIconProps): ReactElement {
+  return (
+    <span className={cn(iconContainerClassName, className)}>
+      <Avatar size="sm" className="size-full border border-white/70">
+        <AvatarFallback className="text-[7px] font-semibold">
+          +{extraCount}
+        </AvatarFallback>
+      </Avatar>
     </span>
   );
 }

--- a/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
@@ -92,6 +92,17 @@ export function ActivityFlagPopover({
     .map((f) => f.assigneeName)
     .join(', ');
   const iconFlag = existingFlagsForPrimaryTeam[0] ?? null;
+  const primaryTeamMembers = useMemo(
+    () =>
+      primaryTeamId == null
+        ? []
+        : members.filter((member) => member.teamId === primaryTeamId),
+    [members, primaryTeamId]
+  );
+  const primaryTeamMemberIdSet = useMemo(
+    () => new Set(primaryTeamMembers.map((member) => member.userId)),
+    [primaryTeamMembers]
+  );
 
   // Fetch team members when popover opens (once per mount)
   useEffect(() => {
@@ -125,15 +136,15 @@ export function ActivityFlagPopover({
 
   // Build sorted options: current user first, then alphabetically
   const options = useMemo(() => {
-    const me = members.find((m) => m.userId === user?.id);
-    const rest = members
+    const me = primaryTeamMembers.find((m) => m.userId === user?.id);
+    const rest = primaryTeamMembers
       .filter((m) => m.userId !== user?.id)
       .sort((a, b) => a.label.localeCompare(b.label));
     return [...(me ? [me] : []), ...rest].map((m) => ({
       value: String(m.userId),
       label: m.userId === user?.id ? `${m.label} (you)` : m.label,
     }));
-  }, [members, user]);
+  }, [primaryTeamMembers, user]);
 
   // Seed draft selection from server state when opening so users can multi-select before saving.
   useEffect(() => {
@@ -151,11 +162,14 @@ export function ActivityFlagPopover({
 
   const handleSave = () => {
     if (!primaryTeamId) return;
-    const selectedSet = new Set(draftAssigneeIds);
-    const nextAssigneeNames = members
+    const nextAssigneeIds = draftAssigneeIds.filter((assigneeId) =>
+      primaryTeamMemberIdSet.has(assigneeId)
+    );
+    const selectedSet = new Set(nextAssigneeIds);
+    const nextAssigneeNames = primaryTeamMembers
       .filter((m) => selectedSet.has(m.userId))
       .map((m) => m.label);
-    onSync(primaryTeamId, draftAssigneeIds, nextAssigneeNames);
+    onSync(primaryTeamId, nextAssigneeIds, nextAssigneeNames);
     setOpen(false);
   };
 

--- a/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
@@ -264,7 +264,7 @@ export function ActivityFlagPopover({
               type="button"
               size="sm"
               onClick={handleSave}
-              disabled={isPending || !primaryTeamId}
+              disabled={isPending || !primaryTeamId || primaryTeamMembers.length === 0}
             >
               Save assignments
             </Button>

--- a/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
@@ -3,7 +3,7 @@
  *
  * A quick-assign popover shown from the Activity List row (no modal, no notes).
  * Opens when the Flag button is clicked; shows a searchable list of teammates
- * with a single-select checkbox pattern.
+ * with a multi-select checkbox pattern.
  *
  * Same flag semantics as AssignActivityModal but inline, no note field.
  */
@@ -33,10 +33,12 @@ interface ActivityFlagPopoverProps {
   activityId: number;
   /** Existing flags for the current user's teams. */
   flags: ActivityFlagResponse[];
-  /** Called to set or replace the flag for a team. */
-  onAssign: (teamId: number, assigneeId: number, assigneeName?: string) => void;
-  /** Called to remove the flag for a team. */
-  onUnassign: (teamId: number, assigneeName?: string) => void;
+  /** Called to sync the full assignee set for a team. */
+  onSync: (
+    teamId: number,
+    assigneeIds: number[],
+    assigneeNames?: string[]
+  ) => void;
   isPending?: boolean;
   /** When true, shows assignment state without any interactive controls. */
   readOnly?: boolean;
@@ -45,8 +47,7 @@ interface ActivityFlagPopoverProps {
 export function ActivityFlagPopover({
   activityId: _activityId,
   flags,
-  onAssign,
-  onUnassign,
+  onSync,
   isPending = false,
   readOnly = false,
 }: ActivityFlagPopoverProps) {
@@ -66,12 +67,27 @@ export function ActivityFlagPopover({
     [user?.teamIds]
   );
   const teamIdSet = useMemo(() => new Set(teamIds), [teamIds]);
-  const existingFlag = useMemo(
-    () => flags.find((f) => teamIdSet.has(f.teamId)) ?? null,
+  const existingFlags = useMemo(
+    () => flags.filter((f) => teamIdSet.has(f.teamId)),
     [flags, teamIdSet]
   );
-  const isFlagged = existingFlag !== null;
-  const primaryTeamId = existingFlag?.teamId ?? teamIds[0] ?? null;
+  const primaryTeamId = existingFlags[0]?.teamId ?? teamIds[0] ?? null;
+  const existingFlagsForPrimaryTeam = useMemo(
+    () =>
+      primaryTeamId == null
+        ? []
+        : existingFlags.filter((f) => f.teamId === primaryTeamId),
+    [existingFlags, primaryTeamId]
+  );
+  const selectedAssigneeIds = useMemo(
+    () => existingFlagsForPrimaryTeam.map((f) => f.assigneeId),
+    [existingFlagsForPrimaryTeam]
+  );
+  const isFlagged = selectedAssigneeIds.length > 0;
+  const flaggedLabel = existingFlagsForPrimaryTeam
+    .map((f) => f.assigneeName)
+    .join(', ');
+  const iconFlag = existingFlagsForPrimaryTeam[0] ?? null;
 
   // Fetch team members when popover opens (once per mount)
   useEffect(() => {
@@ -115,27 +131,32 @@ export function ActivityFlagPopover({
     }));
   }, [members, user]);
 
-  const handleSelect = (memberId: number) => {
+  const handleToggle = (memberId: number) => {
     if (!primaryTeamId) return;
-    const name = members.find((m) => m.userId === memberId)?.label;
-    if (existingFlag?.assigneeId === memberId) {
-      onUnassign(primaryTeamId, existingFlag.assigneeName);
+    const selectedSet = new Set(selectedAssigneeIds);
+    if (selectedSet.has(memberId)) {
+      selectedSet.delete(memberId);
     } else {
-      onAssign(primaryTeamId, memberId, name);
+      selectedSet.add(memberId);
     }
+    const nextAssigneeIds = Array.from(selectedSet);
+    const nextAssigneeNames = members
+      .filter((m) => selectedSet.has(m.userId))
+      .map((m) => m.label);
+    onSync(primaryTeamId, nextAssigneeIds, nextAssigneeNames);
     setOpen(false);
   };
 
   if (readOnly) {
-    if (!isFlagged || !existingFlag) return null;
+    if (!isFlagged || !iconFlag) return null;
     return (
       <span
-        title={`Assigned to ${existingFlag.assigneeName}`}
-        aria-label={`Assigned to ${existingFlag.assigneeName}`}
+        title={`Assigned to ${flaggedLabel}`}
+        aria-label={`Assigned to ${flaggedLabel}`}
       >
         <ActivityFlagIcon
-          assigneeName={existingFlag.assigneeName}
-          assigneeFlagColour={existingFlag.assigneeFlagColour}
+          assigneeName={iconFlag.assigneeName}
+          assigneeFlagColour={iconFlag.assigneeFlagColour}
         />
       </span>
     );
@@ -149,21 +170,19 @@ export function ActivityFlagPopover({
           variant="ghost"
           size="icon"
           aria-label={
-            isFlagged ? 'Assigned — click to reassign' : 'Assign activity'
-          }
-          title={
             isFlagged
-              ? `Assigned to ${existingFlag.assigneeName}`
+              ? 'Assigned — click to edit assignments'
               : 'Assign activity'
           }
+          title={isFlagged ? `Assigned to ${flaggedLabel}` : 'Assign activity'}
           disabled={isPending || !primaryTeamId}
           data-no-row-nav
           onClick={(e) => e.stopPropagation()}
           className="size-6 shrink-0"
         >
           <ActivityFlagIcon
-            assigneeName={isFlagged ? existingFlag.assigneeName : null}
-            assigneeFlagColour={existingFlag?.assigneeFlagColour}
+            assigneeName={isFlagged ? (iconFlag?.assigneeName ?? null) : null}
+            assigneeFlagColour={iconFlag?.assigneeFlagColour}
           />
         </Button>
       </PopoverTrigger>
@@ -188,13 +207,13 @@ export function ActivityFlagPopover({
             renderOption={(opt) => {
               const memberId = parseInt(opt.value, 10);
               const isMe = memberId === user?.id;
-              const isSelected = existingFlag?.assigneeId === memberId;
+              const isSelected = selectedAssigneeIds.includes(memberId);
               const hasTeammates = options.length > 1;
               return (
                 <>
                   <button
                     type="button"
-                    onClick={() => handleSelect(memberId)}
+                    onClick={() => handleToggle(memberId)}
                     className="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
                   >
                     <Checkbox

--- a/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
+++ b/calendar-ui/src/components/activity/activities/ActivityFlagPopover.tsx
@@ -7,7 +7,7 @@
  *
  * Same flag semantics as AssignActivityModal but inline, no note field.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import type { ActivityFlagResponse } from '@corpcal/shared/api/types';
 import { fetchTeamById } from '@/api/teamsApi';
@@ -42,6 +42,8 @@ interface ActivityFlagPopoverProps {
   isPending?: boolean;
   /** When true, shows assignment state without any interactive controls. */
   readOnly?: boolean;
+  /** Optional custom trigger content (e.g., assigned avatar stack). */
+  triggerContent?: ReactNode;
 }
 
 export function ActivityFlagPopover({
@@ -50,11 +52,13 @@ export function ActivityFlagPopover({
   onSync,
   isPending = false,
   readOnly = false,
+  triggerContent,
 }: ActivityFlagPopoverProps) {
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [members, setMembers] = useState<TeamMemberOption[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
+  const [draftAssigneeIds, setDraftAssigneeIds] = useState<number[]>([]);
 
   const teamIds = useMemo(
     () =>
@@ -131,19 +135,27 @@ export function ActivityFlagPopover({
     }));
   }, [members, user]);
 
+  // Seed draft selection from server state when opening so users can multi-select before saving.
+  useEffect(() => {
+    if (!open) return;
+    setDraftAssigneeIds(selectedAssigneeIds);
+  }, [open, selectedAssigneeIds]);
+
   const handleToggle = (memberId: number) => {
+    setDraftAssigneeIds((prev) =>
+      prev.includes(memberId)
+        ? prev.filter((id) => id !== memberId)
+        : [...prev, memberId]
+    );
+  };
+
+  const handleSave = () => {
     if (!primaryTeamId) return;
-    const selectedSet = new Set(selectedAssigneeIds);
-    if (selectedSet.has(memberId)) {
-      selectedSet.delete(memberId);
-    } else {
-      selectedSet.add(memberId);
-    }
-    const nextAssigneeIds = Array.from(selectedSet);
+    const selectedSet = new Set(draftAssigneeIds);
     const nextAssigneeNames = members
       .filter((m) => selectedSet.has(m.userId))
       .map((m) => m.label);
-    onSync(primaryTeamId, nextAssigneeIds, nextAssigneeNames);
+    onSync(primaryTeamId, draftAssigneeIds, nextAssigneeNames);
     setOpen(false);
   };
 
@@ -168,7 +180,7 @@ export function ActivityFlagPopover({
         <Button
           type="button"
           variant="ghost"
-          size="icon"
+          size={triggerContent ? 'sm' : 'icon'}
           aria-label={
             isFlagged
               ? 'Assigned — click to edit assignments'
@@ -178,12 +190,14 @@ export function ActivityFlagPopover({
           disabled={isPending || !primaryTeamId}
           data-no-row-nav
           onClick={(e) => e.stopPropagation()}
-          className="size-6 shrink-0"
+          className={triggerContent ? 'h-6 shrink-0 px-1.5' : 'size-6 shrink-0'}
         >
-          <ActivityFlagIcon
-            assigneeName={isFlagged ? (iconFlag?.assigneeName ?? null) : null}
-            assigneeFlagColour={iconFlag?.assigneeFlagColour}
-          />
+          {triggerContent ?? (
+            <ActivityFlagIcon
+              assigneeName={isFlagged ? (iconFlag?.assigneeName ?? null) : null}
+              assigneeFlagColour={iconFlag?.assigneeFlagColour}
+            />
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -207,7 +221,7 @@ export function ActivityFlagPopover({
             renderOption={(opt) => {
               const memberId = parseInt(opt.value, 10);
               const isMe = memberId === user?.id;
-              const isSelected = selectedAssigneeIds.includes(memberId);
+              const isSelected = draftAssigneeIds.includes(memberId);
               const hasTeammates = options.length > 1;
               return (
                 <>
@@ -229,6 +243,18 @@ export function ActivityFlagPopover({
               );
             }}
           />
+        )}
+        {!loadingMembers && (
+          <div className="flex justify-end border-t px-3 py-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSave}
+              disabled={isPending || !primaryTeamId}
+            >
+              Save assignments
+            </Button>
+          </div>
         )}
       </PopoverContent>
     </Popover>

--- a/calendar-ui/src/components/activity/activities/AssignActivityModal.tsx
+++ b/calendar-ui/src/components/activity/activities/AssignActivityModal.tsx
@@ -1,18 +1,10 @@
 import { Loader2 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ActivityFlagResponse } from '@corpcal/shared/api/types';
 import { fetchTeamById } from '@/api/teamsApi';
+import { FilterSearchableList } from '@/components/activity/ActivityTable/FilterSearchableList';
 import { Button } from '@/components/ui/button';
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxSeparator,
-} from '@/components/ui/combobox';
 import {
   Dialog,
   DialogContent,
@@ -37,15 +29,13 @@ interface AssignActivityModalProps {
   /** Existing flags for the current user's teams. */
   flags: ActivityFlagResponse[];
   isSubmitting: boolean;
-  /** Called when user confirms an assignment. */
-  onAssign: (
+  /** Sync the full assignee set for an activity/team pair. */
+  onSync: (
     teamId: number,
-    assigneeId: number,
+    assigneeIds: number[],
     note?: string,
-    assigneeName?: string
+    assigneeNames?: string[]
   ) => void;
-  /** Called when user removes the current flag for a team. */
-  onUnassign: (teamId: number, assigneeName?: string) => void;
   displayId?: string;
 }
 
@@ -54,34 +44,22 @@ export function AssignActivityModal({
   onOpenChange,
   flags,
   isSubmitting,
-  onAssign,
-  onUnassign,
+  onSync,
   displayId,
 }: AssignActivityModalProps) {
   const { user } = useAuth();
   const [note, setNote] = useState('');
-  const [selectedMember, setSelectedMember] = useState<TeamMemberOption | null>(
-    null
-  );
+  const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
   const [members, setMembers] = useState<TeamMemberOption[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
+  const seededTeamIdRef = useRef<number | null>(null);
 
   const userTeamIds = useMemo(
     () => user?.teamIds ?? [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [user?.teamIds?.join(',')]
   );
-
-  // Find the existing flag for the currently selected team; if none is selected yet,
-  // fall back to the first flag that belongs to any of the user's teams.
-  const existingFlag = useMemo(() => {
-    if (selectedTeamId !== null) {
-      return flags.find((f) => f.teamId === selectedTeamId) ?? null;
-    }
-
-    return flags.find((f) => userTeamIds.includes(f.teamId)) ?? null;
-  }, [flags, selectedTeamId, userTeamIds]);
 
   // Fetch members for all of the user's teams when the dialog opens.
   useEffect(() => {
@@ -114,12 +92,10 @@ export function AssignActivityModal({
             return currentTeamId;
           }
 
-          if (
-            existingFlag &&
-            availableTeams.some((team) => team.id === existingFlag.teamId)
-          ) {
-            return existingFlag.teamId;
-          }
+          const teamWithFlags = flags.find((f) =>
+            availableTeams.some((t) => t.id === f.teamId)
+          );
+          if (teamWithFlags) return teamWithFlags.teamId;
 
           return availableTeams[0]?.id ?? null;
         });
@@ -138,177 +114,158 @@ export function AssignActivityModal({
     return () => {
       isCancelled = true;
     };
-  }, [open, userTeamIds, existingFlag]);
+  }, [open, userTeamIds, flags]);
 
-  // Pre-select existing assignee when dialog opens (after members are loaded)
+  // Seed selections from existing flags once per team when dialog opens.
   useEffect(() => {
-    if (open && existingFlag && members.length > 0) {
-      setSelectedMember(
-        members.find((m) => m.userId === existingFlag.assigneeId) ?? null
-      );
-      setNote(existingFlag.note ?? '');
-    } else if (open && !existingFlag) {
-      setSelectedMember(null);
+    if (!open) {
+      setSelectedMemberIds([]);
       setNote('');
+      seededTeamIdRef.current = null;
+      return;
     }
-  }, [open, existingFlag, members]);
+    if (selectedTeamId === null || selectedTeamId === seededTeamIdRef.current) {
+      return;
+    }
+    seededTeamIdRef.current = selectedTeamId;
+    const flagsForTeam = flags.filter((f) => f.teamId === selectedTeamId);
+    setSelectedMemberIds(flagsForTeam.map((f) => f.assigneeId));
+    setNote(flagsForTeam[0]?.note ?? '');
+  }, [open, selectedTeamId, flags]);
 
-  const handleConfirm = () => {
-    if (!selectedTeamId || !selectedMember) return;
-    onAssign(
-      selectedTeamId,
-      selectedMember.userId,
-      note.trim() || undefined,
-      selectedMember.label
+  const handleToggle = (memberId: number) => {
+    setSelectedMemberIds((prev) =>
+      prev.includes(memberId)
+        ? prev.filter((id) => id !== memberId)
+        : [...prev, memberId]
     );
   };
 
-  const handleUnassign = () => {
+  const handleConfirm = () => {
     if (!selectedTeamId) return;
-    onUnassign(selectedTeamId, existingFlag?.assigneeName ?? undefined);
+    const teamMembers = members.filter((m) => m.teamId === selectedTeamId);
+    const selectedNames = teamMembers
+      .filter((m) => selectedMemberIds.includes(m.userId))
+      .map((m) => m.label);
+    onSync(
+      selectedTeamId,
+      selectedMemberIds,
+      note.trim() || undefined,
+      selectedNames
+    );
   };
 
   const handleOpenChange = (value: boolean) => {
     if (!value) {
-      setSelectedMember(null);
+      setSelectedMemberIds([]);
       setNote('');
     }
     onOpenChange(value);
   };
 
-  // Put current user first, rest alphabetical
+  // Members for the selected team, current user first then alphabetical
   const me = useMemo(
-    () => (user ? members.find((m) => m.userId === user.id) : undefined),
-    [members, user]
+    () =>
+      user
+        ? members.find(
+            (m) => m.userId === user.id && m.teamId === selectedTeamId
+          )
+        : undefined,
+    [members, user, selectedTeamId]
   );
   const restMembers = useMemo(
     () =>
       members
-        .filter((m) => m.userId !== user?.id)
+        .filter((m) => m.teamId === selectedTeamId && m.userId !== user?.id)
         .sort((a, b) => a.label.localeCompare(b.label)),
-    [members, user]
+    [members, user, selectedTeamId]
   );
-  const comboboxItems = useMemo(
-    () => [...(me ? [me] : []), ...restMembers],
-    [me, restMembers]
-  );
-
-  // Render the combobox popup inside the dialog so Radix's focus trap
-  // doesn't block pointer events on the Base UI portal.
-  const [dialogContainer, setDialogContainer] = useState<HTMLDivElement | null>(
-    null
+  const options = useMemo(
+    () =>
+      [...(me ? [me] : []), ...restMembers].map((m) => ({
+        value: String(m.userId),
+        label: m.userId === user?.id ? `${m.label} (you)` : m.label,
+      })),
+    [me, restMembers, user]
   );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
-        <div ref={setDialogContainer}>
-          <DialogHeader>
-            <DialogTitle>Assign activity</DialogTitle>
-            <DialogDescription>
-              Assign activities that require your or a teammate&apos;s
-              attention. Assignments are visible to teammates in the activities
-              list.
-            </DialogDescription>
-          </DialogHeader>
+        <DialogHeader>
+          <DialogTitle>Assign activity</DialogTitle>
+          <DialogDescription>
+            Select teammates to assign for follow-up. Assignments are visible to
+            all teammates in the activities list.
+          </DialogDescription>
+        </DialogHeader>
 
-          {displayId && (
-            <p className="text-muted-foreground text-sm">
-              Activity:{' '}
-              <span className="text-foreground font-medium">{displayId}</span>
-            </p>
-          )}
+        {displayId && (
+          <p className="text-muted-foreground text-sm">
+            Activity:{' '}
+            <span className="text-foreground font-medium">{displayId}</span>
+          </p>
+        )}
 
-          <div className="space-y-4">
-            <div className="space-y-1.5">
-              <Label htmlFor="flag-assignee">Assignee</Label>
-              {loadingMembers ? (
-                <div className="text-muted-foreground flex items-center gap-2 text-sm">
-                  <Loader2 className="size-4 animate-spin" />
-                  Loading teammates…
-                </div>
-              ) : (
-                <Combobox
-                  items={comboboxItems}
-                  value={selectedMember}
-                  onValueChange={(m: TeamMemberOption | null) =>
-                    setSelectedMember(m)
-                  }
-                  itemToStringValue={(m: TeamMemberOption) => m.label}
-                >
-                  <ComboboxInput placeholder="Search teammates…" />
-                  <ComboboxContent container={dialogContainer ?? undefined}>
-                    <ComboboxEmpty>No teammates found.</ComboboxEmpty>
-                    <ComboboxList>
-                      {(m: TeamMemberOption) => (
-                        <>
-                          {me && m === restMembers[0] && <ComboboxSeparator />}
-                          <ComboboxItem key={m.userId} value={m}>
-                            {m.userId === user?.id
-                              ? `${m.label} (you)`
-                              : m.label}
-                          </ComboboxItem>
-                        </>
-                      )}
-                    </ComboboxList>
-                  </ComboboxContent>
-                </Combobox>
-              )}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="flag-note">Add a note (optional)</Label>
-              <Textarea
-                id="flag-note"
-                placeholder="Give additional context"
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                rows={3}
-                maxLength={1000}
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Assignees</Label>
+            {loadingMembers ? (
+              <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                <Loader2 className="size-4 animate-spin" />
+                Loading teammates…
+              </div>
+            ) : (
+              <FilterSearchableList
+                options={options}
+                selectedIds={selectedMemberIds}
+                onToggle={handleToggle}
+                searchPlaceholder="Search teammates…"
+                emptyMessage="No teammates found."
+                maxHeight="200px"
               />
-            </div>
+            )}
           </div>
 
-          <DialogFooter className="flex-col gap-2 pt-4 sm:flex-row sm:justify-between">
-            <div>
-              {existingFlag && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={handleUnassign}
-                  disabled={isSubmitting}
-                  className="text-muted-foreground"
-                >
-                  Remove assignment
-                </Button>
-              )}
-            </div>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleOpenChange(false)}
-                disabled={isSubmitting}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                onClick={handleConfirm}
-                disabled={isSubmitting || !selectedMember || !selectedTeamId}
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="size-4 animate-spin" aria-hidden />
-                    Saving…
-                  </>
-                ) : (
-                  'Save assignee'
-                )}
-              </Button>
-            </div>
-          </DialogFooter>
+          <div className="space-y-1.5">
+            <Label htmlFor="flag-note">Add a note (optional)</Label>
+            <Textarea
+              id="flag-note"
+              placeholder="Give additional context"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={3}
+              maxLength={1000}
+            />
+          </div>
         </div>
+
+        <DialogFooter className="flex-col gap-2 pt-4 sm:flex-row sm:justify-end">
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirm}
+              disabled={isSubmitting || !selectedTeamId}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                  Saving…
+                </>
+              ) : (
+                'Save assignments'
+              )}
+            </Button>
+          </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/calendar-ui/src/components/activity/activities/AssignActivityModal.tsx
+++ b/calendar-ui/src/components/activity/activities/AssignActivityModal.tsx
@@ -14,6 +14,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -21,6 +28,11 @@ interface TeamMemberOption {
   userId: number;
   label: string;
   teamId: number;
+}
+
+interface TeamOption {
+  id: number;
+  label: string;
 }
 
 interface AssignActivityModalProps {
@@ -52,6 +64,7 @@ export function AssignActivityModal({
   const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
   const [members, setMembers] = useState<TeamMemberOption[]>([]);
+  const [teamOptions, setTeamOptions] = useState<TeamOption[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
   const seededTeamIdRef = useRef<number | null>(null);
 
@@ -82,8 +95,13 @@ export function AssignActivityModal({
             teamId: team.id,
           }))
         );
+        const nextTeamOptions: TeamOption[] = availableTeams.map((team) => ({
+          id: team.id,
+          label: team.displayName ?? team.name,
+        }));
 
         setMembers(opts);
+        setTeamOptions(nextTeamOptions);
         setSelectedTeamId((currentTeamId) => {
           if (
             currentTeamId !== null &&
@@ -103,6 +121,7 @@ export function AssignActivityModal({
       .catch(() => {
         if (isCancelled) return;
         setMembers([]);
+        setTeamOptions([]);
         setSelectedTeamId(null);
       })
       .finally(() => {
@@ -208,6 +227,38 @@ export function AssignActivityModal({
         )}
 
         <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="assign-team">Team</Label>
+            {teamOptions.length > 1 ? (
+              <Select
+                value={selectedTeamId != null ? String(selectedTeamId) : ''}
+                onValueChange={(value) => {
+                  const parsed = Number(value);
+                  setSelectedTeamId(Number.isNaN(parsed) ? null : parsed);
+                }}
+                disabled={isSubmitting || loadingMembers}
+              >
+                <SelectTrigger id="assign-team" className="w-full">
+                  <SelectValue placeholder="Select team" />
+                </SelectTrigger>
+                <SelectContent>
+                  {teamOptions.map((team) => (
+                    <SelectItem key={team.id} value={String(team.id)}>
+                      {team.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <div
+                id="assign-team"
+                className="text-muted-foreground bg-muted rounded-md border px-3 py-2 text-sm"
+              >
+                {teamOptions[0]?.label ?? 'No team available'}
+              </div>
+            )}
+          </div>
+
           <div className="space-y-1.5">
             <Label>Assignees</Label>
             {loadingMembers ? (

--- a/calendar-ui/src/hooks/useCalendar.tsx
+++ b/calendar-ui/src/hooks/useCalendar.tsx
@@ -352,6 +352,7 @@ export function useRemoveAssigneeActivityFlag(options?: {
       teamId: number;
       assigneeId: number;
       assigneeName?: string;
+      suppressSuccessToast?: boolean;
     }) => removeAssigneeActivityFlag(activityId, teamId, assigneeId),
     onSuccess: (_, vars) => {
       void qc.invalidateQueries({ queryKey: ['activities'] });
@@ -360,11 +361,13 @@ export function useRemoveAssigneeActivityFlag(options?: {
         source: 'local',
         activityId: vars.activityId,
       });
-      toast.success(
-        vars.assigneeName
-          ? `Activity unassigned from ${vars.assigneeName}`
-          : 'Activity unassigned'
-      );
+      if (!vars.suppressSuccessToast) {
+        toast.success(
+          vars.assigneeName
+            ? `Activity unassigned from ${vars.assigneeName}`
+            : 'Activity unassigned'
+        );
+      }
       options?.onSuccess?.();
     },
     onError: (error) => {

--- a/calendar-ui/src/hooks/useCalendar.tsx
+++ b/calendar-ui/src/hooks/useCalendar.tsx
@@ -13,6 +13,7 @@ import type {
   SoftDeleteRequest,
   UpdateActivityRequest,
   UpsertActivityFlagRequest,
+  UpsertActivityFlagsRequest,
 } from '@corpcal/shared/schemas';
 
 import {
@@ -26,7 +27,11 @@ import {
   softDeleteActivity,
   updateActivity,
 } from '../api/activitiesApi';
-import { removeActivityFlag, upsertActivityFlag } from '../api/flagsApi';
+import {
+  removeActivityFlag,
+  syncActivityFlags,
+  upsertActivityFlag,
+} from '../api/flagsApi';
 import {
   buildOptimisticActivity,
   normalizeListParams,
@@ -263,6 +268,38 @@ export function useUpsertActivityFlag(options?: { onSuccess?: () => void }) {
     },
     onError: (error) => {
       showErrorToast(error, 'Failed to assign activity');
+    },
+  });
+}
+
+/** Sync (set) all assignees for an activity/team pair. */
+export function useSyncActivityFlags(options?: { onSuccess?: () => void }) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      activityId,
+      body,
+    }: {
+      activityId: number;
+      body: UpsertActivityFlagsRequest;
+      assigneeNames?: string[];
+    }) => syncActivityFlags(activityId, body),
+    onSuccess: (_, vars) => {
+      void qc.invalidateQueries({ queryKey: ['activities'] });
+      void qc.invalidateQueries({ queryKey: ['activity', vars.activityId] });
+      scheduleLiveActivityRefresh(qc, {
+        source: 'local',
+        activityId: vars.activityId,
+      });
+      if ((vars.assigneeNames?.length ?? 0) > 0) {
+        toast.success(`Activity assigned to ${vars.assigneeNames!.join(', ')}`);
+      } else {
+        toast.success('Activity assignments updated');
+      }
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      showErrorToast(error, 'Failed to update activity assignments');
     },
   });
 }

--- a/calendar-ui/src/hooks/useCalendar.tsx
+++ b/calendar-ui/src/hooks/useCalendar.tsx
@@ -29,6 +29,7 @@ import {
 } from '../api/activitiesApi';
 import {
   removeActivityFlag,
+  removeAssigneeActivityFlag,
   syncActivityFlags,
   upsertActivityFlag,
 } from '../api/flagsApi';
@@ -316,6 +317,42 @@ export function useRemoveActivityFlag(options?: { onSuccess?: () => void }) {
       teamId: number;
       assigneeName?: string;
     }) => removeActivityFlag(activityId, teamId),
+    onSuccess: (_, vars) => {
+      void qc.invalidateQueries({ queryKey: ['activities'] });
+      void qc.invalidateQueries({ queryKey: ['activity', vars.activityId] });
+      scheduleLiveActivityRefresh(qc, {
+        source: 'local',
+        activityId: vars.activityId,
+      });
+      toast.success(
+        vars.assigneeName
+          ? `Activity unassigned from ${vars.assigneeName}`
+          : 'Activity unassigned'
+      );
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      showErrorToast(error, 'Failed to unassign activity');
+    },
+  });
+}
+
+/** Remove a single assignee flag for an activity/team pair. */
+export function useRemoveAssigneeActivityFlag(options?: {
+  onSuccess?: () => void;
+}) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      activityId,
+      teamId,
+      assigneeId,
+    }: {
+      activityId: number;
+      teamId: number;
+      assigneeId: number;
+      assigneeName?: string;
+    }) => removeAssigneeActivityFlag(activityId, teamId, assigneeId),
     onSuccess: (_, vars) => {
       void qc.invalidateQueries({ queryKey: ['activities'] });
       void qc.invalidateQueries({ queryKey: ['activity', vars.activityId] });

--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -149,7 +149,7 @@ export const ActivityListPage = () => {
   const hasMultipleTeamsWithMinistry = teamsWithMinistry.length > 1;
 
   const tableProps = useMemo(() => {
-    const base = {};
+    const base = { watchlistActivityIds: favouriteActivityIds };
     switch (activeTab) {
       case 'all':
         return base;

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -859,13 +859,13 @@ export function ActivityPage({
         onHistoryClick={() => setHistoryOpen(true)}
         flags={activity.flags ?? []}
         canFlag={canFlag}
-        onFlagAssign={
+        onFlagSync={
           canFlag
-            ? (teamId, assigneeId, note, assigneeName) =>
+            ? (teamId, assigneeIds, note, assigneeNames) =>
                 syncFlagsMutation.mutate({
                   activityId: id,
-                  body: { teamId, assigneeIds: [assigneeId], note },
-                  assigneeNames: assigneeName ? [assigneeName] : undefined,
+                  body: { teamId, assigneeIds, note },
+                  assigneeNames,
                 })
             : undefined
         }

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -54,12 +54,11 @@ import { useActivityWebSocket } from '../hooks/useActivityWebSocket';
 import { useAuth } from '../hooks/useAuth';
 import {
   useDeleteActivity,
-  useRemoveActivityFlag,
   useRequestDeleteActivity,
   useRestoreActivity,
   useSoftDeleteActivity,
+  useSyncActivityFlags,
   useUpdateActivity,
-  useUpsertActivityFlag,
 } from '../hooks/useCalendar';
 import {
   EDIT_LOCK_CONFLICT_TOAST,
@@ -264,10 +263,7 @@ export function ActivityPage({
   const restoreMutation = useRestoreActivity();
   const softDeleteMutation = useSoftDeleteActivity();
   const requestDeleteMutation = useRequestDeleteActivity();
-  const upsertFlagMutation = useUpsertActivityFlag({
-    onSuccess: () => void refreshActivity(),
-  });
-  const removeFlagMutation = useRemoveActivityFlag({
+  const syncFlagsMutation = useSyncActivityFlags({
     onSuccess: () => void refreshActivity(),
   });
 
@@ -651,13 +647,17 @@ export function ActivityPage({
     unassignMe?: boolean
   ) => {
     if (unassignMe) {
-      const myFlags =
-        activity.flags?.filter((f) => f.assigneeId === user?.id) ?? [];
-      myFlags.forEach((flag) => {
-        removeFlagMutation.mutate({
+      const flagsByTeam = new Map<number, number[]>();
+      (activity.flags ?? []).forEach((flag) => {
+        const next = flagsByTeam.get(flag.teamId) ?? [];
+        next.push(flag.assigneeId);
+        flagsByTeam.set(flag.teamId, next);
+      });
+      flagsByTeam.forEach((assigneeIds, teamId) => {
+        const nextAssigneeIds = assigneeIds.filter((aId) => aId !== user?.id);
+        syncFlagsMutation.mutate({
           activityId: id,
-          teamId: flag.teamId,
-          assigneeName: flag.assigneeName,
+          body: { teamId, assigneeIds: nextAssigneeIds },
         });
       });
     }
@@ -862,19 +862,21 @@ export function ActivityPage({
         onFlagAssign={
           canFlag
             ? (teamId, assigneeId, note, assigneeName) =>
-                upsertFlagMutation.mutate({
+                syncFlagsMutation.mutate({
                   activityId: id,
-                  body: { teamId, assigneeId, note },
-                  assigneeName,
+                  body: { teamId, assigneeIds: [assigneeId], note },
+                  assigneeNames: assigneeName ? [assigneeName] : undefined,
                 })
             : undefined
         }
         onFlagUnassign={(teamId, assigneeName) =>
-          removeFlagMutation.mutate({ activityId: id, teamId, assigneeName })
+          syncFlagsMutation.mutate({
+            activityId: id,
+            body: { teamId, assigneeIds: [] },
+            assigneeNames: assigneeName ? [assigneeName] : undefined,
+          })
         }
-        isFlagPending={
-          upsertFlagMutation.isPending || removeFlagMutation.isPending
-        }
+        isFlagPending={syncFlagsMutation.isPending}
         isFavourite={isFavourite(id)}
         onFavouriteToggle={() => toggleFavourite(id)}
         isFavouriteToggling={isFavouriteToggling}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -54,6 +54,7 @@ import { useActivityWebSocket } from '../hooks/useActivityWebSocket';
 import { useAuth } from '../hooks/useAuth';
 import {
   useDeleteActivity,
+  useRemoveAssigneeActivityFlag,
   useRequestDeleteActivity,
   useRestoreActivity,
   useSoftDeleteActivity,
@@ -264,6 +265,9 @@ export function ActivityPage({
   const softDeleteMutation = useSoftDeleteActivity();
   const requestDeleteMutation = useRequestDeleteActivity();
   const syncFlagsMutation = useSyncActivityFlags({
+    onSuccess: () => void refreshActivity(),
+  });
+  const removeAssigneeFlagMutation = useRemoveAssigneeActivityFlag({
     onSuccess: () => void refreshActivity(),
   });
 
@@ -646,20 +650,21 @@ export function ActivityPage({
     markAsCompleted?: boolean,
     unassignMe?: boolean
   ) => {
-    if (unassignMe) {
-      const flagsByTeam = new Map<number, number[]>();
-      (activity.flags ?? []).forEach((flag) => {
-        const next = flagsByTeam.get(flag.teamId) ?? [];
-        next.push(flag.assigneeId);
-        flagsByTeam.set(flag.teamId, next);
-      });
-      flagsByTeam.forEach((assigneeIds, teamId) => {
-        const nextAssigneeIds = assigneeIds.filter((aId) => aId !== user?.id);
-        syncFlagsMutation.mutate({
-          activityId: id,
-          body: { teamId, assigneeIds: nextAssigneeIds },
-        });
-      });
+    if (unassignMe && user?.id != null) {
+      const myFlags = (activity.flags ?? []).filter(
+        (flag) => flag.assigneeId === user.id
+      );
+
+      await Promise.all(
+        myFlags.map((flag) =>
+          removeAssigneeFlagMutation.mutateAsync({
+            activityId: id,
+            teamId: flag.teamId,
+            assigneeId: flag.assigneeId,
+            assigneeName: flag.assigneeName,
+          })
+        )
+      );
     }
     if (markAsCompleted) {
       if (isDirty) {
@@ -869,14 +874,17 @@ export function ActivityPage({
                 })
             : undefined
         }
-        onFlagUnassign={(teamId, assigneeName) =>
-          syncFlagsMutation.mutate({
+        onFlagUnassign={(teamId, assigneeId, assigneeName) =>
+          removeAssigneeFlagMutation.mutate({
             activityId: id,
-            body: { teamId, assigneeIds: [] },
-            assigneeNames: assigneeName ? [assigneeName] : undefined,
+            teamId,
+            assigneeId,
+            assigneeName,
           })
         }
-        isFlagPending={syncFlagsMutation.isPending}
+        isFlagPending={
+          syncFlagsMutation.isPending || removeAssigneeFlagMutation.isPending
+        }
         isFavourite={isFavourite(id)}
         onFavouriteToggle={() => toggleFavourite(id)}
         isFavouriteToggling={isFavouriteToggling}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -655,16 +655,28 @@ export function ActivityPage({
         (flag) => flag.assigneeId === user.id
       );
 
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         myFlags.map((flag) =>
           removeAssigneeFlagMutation.mutateAsync({
             activityId: id,
             teamId: flag.teamId,
             assigneeId: flag.assigneeId,
             assigneeName: flag.assigneeName,
+            suppressSuccessToast: true,
           })
         )
       );
+
+      const removedCount = results.filter(
+        (result) => result.status === 'fulfilled'
+      ).length;
+      if (removedCount > 0) {
+        toast.success(
+          removedCount === 1
+            ? 'Activity unassigned'
+            : `Activity unassigned from ${removedCount} teams`
+        );
+      }
     }
     if (markAsCompleted) {
       if (isDirty) {

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -855,6 +855,7 @@ export function ActivityPage({
       />
       <ActivityPageHeader
         displayId={displayId}
+        currentUserId={user?.id ?? null}
         title={activity.title ?? ''}
         categories={categories}
         leadMinistry={activity.leadMinistry ?? null}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -655,7 +655,7 @@ export function ActivityPage({
         (flag) => flag.assigneeId === user.id
       );
 
-      await Promise.all(
+      await Promise.allSettled(
         myFlags.map((flag) =>
           removeAssigneeFlagMutation.mutateAsync({
             activityId: id,

--- a/openshift/deploy/overlays/dev/kustomization.yaml
+++ b/openshift/deploy/overlays/dev/kustomization.yaml
@@ -14,3 +14,6 @@ images:
   - name: calendar-ui
     newName: image-registry.openshift-image-registry.svc:5000/${DEV_NAMESPACE}/calendar-ui
     newTag: ${APP_VERSION}
+
+patches:
+  - path: patches/calendar-ui-configmap.patch.yaml

--- a/openshift/deploy/overlays/dev/patches/calendar-ui-configmap.patch.yaml
+++ b/openshift/deploy/overlays/dev/patches/calendar-ui-configmap.patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: calendar-ui-config
+data:
+  config.js: |-
+    window.__APP_CONFIG__ = {
+      ENABLE_SNOWPLOW: 'true'
+    };

--- a/openshift/deploy/overlays/staging/kustomization.yaml
+++ b/openshift/deploy/overlays/staging/kustomization.yaml
@@ -14,3 +14,6 @@ images:
   - name: image-registry.openshift-image-registry.svc:5000/${TOOLS_NAMESPACE}/calendar-ui
     newName: image-registry.openshift-image-registry.svc:5000/${STAGING_NAMESPACE}/calendar-ui
     newTag: ${APP_VERSION}
+
+patches:
+  - path: patches/calendar-ui-configmap.patch.yaml

--- a/openshift/deploy/overlays/staging/patches/calendar-ui-configmap.patch.yaml
+++ b/openshift/deploy/overlays/staging/patches/calendar-ui-configmap.patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: calendar-ui-config
+data:
+  config.js: |-
+    window.__APP_CONFIG__ = {
+      ENABLE_SNOWPLOW: 'true'
+    };

--- a/packages/database/migrations/0011_20260629_activity_flags_multi_assignee.sql
+++ b/packages/database/migrations/0011_20260629_activity_flags_multi_assignee.sql
@@ -1,0 +1,10 @@
+-- Allow multiple assignees per (activity, team) by keying uniqueness on assignee too.
+ALTER TABLE "activity_flags"
+  DROP CONSTRAINT IF EXISTS "activity_flags_activity_id_team_id_unique";
+
+ALTER TABLE "activity_flags"
+  ADD CONSTRAINT "activity_flags_activity_id_team_id_assignee_id_unique"
+  UNIQUE ("activity_id", "team_id", "assignee_id");
+
+CREATE INDEX IF NOT EXISTS "activity_flags_activity_id_team_id_idx"
+  ON "activity_flags" ("activity_id", "team_id");

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782172800000,
       "tag": "0010_20260623_teams_abbreviation_varchar6",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1782691200000,
+      "tag": "0011_20260629_activity_flags_multi_assignee",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/activityFlags.ts
+++ b/packages/database/src/schema/activityFlags.ts
@@ -1,5 +1,6 @@
 import { relations } from 'drizzle-orm';
 import {
+  index,
   integer,
   pgTable,
   serial,
@@ -15,7 +16,8 @@ import { users } from './user';
 /**
  * ActivityFlags table - Tracks which user is assigned ("flagged") per activity per team.
  * Rules:
- *   - At most one flag per (activity, team) pair.
+ *   - Multiple assignees are allowed per (activity, team) pair.
+ *   - At most one row per (activity, team, assignee) tuple.
  *   - Any team member with activities.flag permission can set or replace the flag.
  *   - Any active team member can remove the flag (no flag permission required).
  *   - Removing is done by deleting the row.
@@ -44,7 +46,13 @@ export const activityFlags = pgTable(
       .notNull()
       .defaultNow(),
   },
-  (table) => [unique().on(table.activityId, table.teamId)]
+  (table) => [
+    unique().on(table.activityId, table.teamId, table.assigneeId),
+    index('activity_flags_activity_id_team_id_idx').on(
+      table.activityId,
+      table.teamId
+    ),
+  ]
 );
 
 export const activityFlagsRelations = relations(activityFlags, ({ one }) => ({

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -18,6 +18,7 @@ export type {
 export type {
   ActivityFlagResponse,
   UpsertActivityFlagRequest,
+  UpsertActivityFlagsRequest,
 } from '../schemas/activity-flag.schema';
 export type {
   BannerSettings,

--- a/packages/shared/src/schemas/activity-flag.schema.ts
+++ b/packages/shared/src/schemas/activity-flag.schema.ts
@@ -39,3 +39,22 @@ export const upsertActivityFlagRequestSchema = z.object({
 export type UpsertActivityFlagRequest = z.infer<
   typeof upsertActivityFlagRequestSchema
 >;
+
+/** Request body for PUT /activities/:id/flags — syncs the full assignee set for the caller's team. */
+export const upsertActivityFlagsRequestSchema = z.object({
+  /** Team ID scoping this flag set (must be one of the caller's teams). */
+  teamId: z.number().int(),
+  /** Full desired assignee set for this activity/team (duplicates are rejected). */
+  assigneeIds: z
+    .array(z.number().int())
+    .max(1000)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: 'assigneeIds must not contain duplicates',
+    }),
+  /** Optional contextual note stored with newly-created flags in this request. */
+  note: z.string().max(1000).optional(),
+});
+
+export type UpsertActivityFlagsRequest = z.infer<
+  typeof upsertActivityFlagsRequestSchema
+>;


### PR DESCRIPTION
Fixes an issue where snowplow analytics must be set to true explicitly and by hand. 

**with these changes, will Snowplow be set to true the next time code is merged into the branch deployed to OpenShift?**

Yes, for the environments covered by those overlays.

After your change, the deploy render now forces ENABLE_SNOWPLOW to true in:

Dev overlay: [calendar-ui-configmap.patch.yaml]
Staging overlay: [calendar-ui-configmap.patch.yaml]
So the next merge that triggers the dev OpenShift deploy path (develop branch flow) will apply [config.js] with Snowplow true.
Same for staging when its deploy workflow runs.

Only caveat: this is true as long as deployment continues to use the same openshift/deploy overlay path in GitHub Actions. Prod was not changed.

**Will anything need to be set by whoever is deploying for this to work?**

No extra Snowplow toggle is needed from the person deploying.

As long as they run the normal deploy workflow that applies the overlays, the setting is already baked into the manifests and will apply automatically.

What still must already be in place (unchanged from before):

The deploy workflow must target the same overlays: [kustomization.yaml]
The deployment must use the existing mounted runtime config path:
[deployment.yaml]
The cluster/network must allow browser access to Snowplow endpoints (script + collector), otherwise requests still won’t leave the app even with true.
So operationally: no new manual step for deployers, just run the usual deployment.

**how can snowplow be turned off for an environment?**

Two clean ways, depending on how permanent you want it.

Turn it off explicitly in that environment overlay
Set ENABLE_SNOWPLOW to false in the env patch file:
[calendar-ui-configmap.patch.yaml]
or
[calendar-ui-configmap.patch.yaml]
Keep the patch wired in the env kustomization:
[kustomization.yaml]

Turn it off by removing the env override
Remove the patch entry from that env kustomization file.
Then it falls back to base config, which is already false:
[configmap.yaml]
Result after next deploy:

That environment serves [config.js] with Snowplow off.
No extra deployer input is needed.