### PR TITLE
Build/enable GitHub actions artifacts

### DIFF
--- a/.github/workflows/artifactory-build.yaml
+++ b/.github/workflows/artifactory-build.yaml
@@ -1,4 +1,4 @@
-name: Test Artifactory Build & Push
+name: Artifactory Build
 
 on:
   push:
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       stage:
-        description: 'Test stage: login-only, build-only, or full (build+push)'
+        description: 'Build stage: login-only, build-only, or full (build+push)'
         required: true
         type: choice
         options:
           - login-only
           - build-only
           - full
-        default: login-only
+        default: full
       image_repo:
         description: 'Optional Artifactory docker repo override'
         required: false
@@ -32,14 +32,14 @@ env:
   ARTIFACTORY_DEV_IMAGE_REPO: ${{ vars.ARTIFACTORY_DEV_IMAGE_REPO }}
 
 jobs:
-  test-artifactory:
-    name: Test Artifactory
+  artifactory-build:
+    name: Artifactory Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve test stage
+      - name: Resolve build stage
         id: stage
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then

--- a/.github/workflows/artifactory-build.yaml
+++ b/.github/workflows/artifactory-build.yaml
@@ -1,9 +1,6 @@
 name: Artifactory Build
 
 on:
-  push:
-    branches:
-      - 'build/enable-github-actions-artifacts'
   workflow_dispatch:
     inputs:
       stage:
@@ -130,7 +127,7 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Build Results" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Stage:** ${{ steps.stage.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Environment:** ${{ steps.repo.outputs.environment }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Registry:** ${{ env.REGISTRY }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-artifactory-build.yaml
+++ b/.github/workflows/test-artifactory-build.yaml
@@ -1,6 +1,11 @@
 name: Test Artifactory Build & Push
 
 on:
+  push:
+    branches:
+      - 'build/enable-github-actions-artifacts'
+    paths:
+      - '.github/workflows/test-artifactory-build.yaml'
   workflow_dispatch:
     inputs:
       stage:

--- a/.github/workflows/test-artifactory-build.yaml
+++ b/.github/workflows/test-artifactory-build.yaml
@@ -40,6 +40,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve test stage
+        id: stage
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "value=build-only" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ inputs.stage }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve image tag
         id: tag
         run: |
@@ -58,7 +67,7 @@ jobs:
 
       # ── Stage 2: Build ──
       - name: Build calendar-service
-        if: inputs.stage == 'build-only' || inputs.stage == 'full'
+        if: steps.stage.outputs.value == 'build-only' || steps.stage.outputs.value == 'full'
         run: |
           docker build \
             -f calendar-service/Dockerfile \
@@ -66,7 +75,7 @@ jobs:
             .
 
       - name: Build calendar-ui
-        if: inputs.stage == 'build-only' || inputs.stage == 'full'
+        if: steps.stage.outputs.value == 'build-only' || steps.stage.outputs.value == 'full'
         run: |
           docker build \
             -f calendar-ui/Dockerfile \
@@ -75,7 +84,7 @@ jobs:
 
       # ── Stage 3: Push ──
       - name: Validate push inputs
-        if: inputs.stage == 'full'
+        if: steps.stage.outputs.value == 'full'
         run: |
           if [[ -z "${{ inputs.image_repo }}" ]]; then
             echo "::error::'image_repo' is required for full stage (e.g. dc4c90-docker-local)"
@@ -83,14 +92,14 @@ jobs:
           fi
 
       - name: Tag and push calendar-service
-        if: inputs.stage == 'full'
+        if: steps.stage.outputs.value == 'full'
         run: |
           PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-service:${{ steps.tag.outputs.tag }}"
           docker tag "$REGISTRY/calendar-service:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
           docker push "$PUSH_TAG"
 
       - name: Tag and push calendar-ui
-        if: inputs.stage == 'full'
+        if: steps.stage.outputs.value == 'full'
         run: |
           PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-ui:${{ steps.tag.outputs.tag }}"
           docker tag "$REGISTRY/calendar-ui:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
@@ -99,7 +108,7 @@ jobs:
       - name: Summary
         run: |
           echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Stage:** ${{ inputs.stage }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Stage:** ${{ steps.stage.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Registry:** ${{ env.REGISTRY }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Branch:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-artifactory-build.yaml
+++ b/.github/workflows/test-artifactory-build.yaml
@@ -16,7 +16,7 @@ on:
           - full
         default: login-only
       image_repo:
-        description: "Artifactory docker repo path (only needed for 'full' stage, e.g. dc4c90-docker-local)"
+        description: 'Optional Artifactory docker repo override'
         required: false
         type: string
       image_tag:
@@ -28,7 +28,8 @@ permissions:
   contents: read
 
 env:
-  REGISTRY: artifacts.developer.gov.bc.ca
+  REGISTRY: ${{ vars.ARTIFACTORY_REGISTRY }}
+  ARTIFACTORY_DEV_IMAGE_REPO: ${{ vars.ARTIFACTORY_DEV_IMAGE_REPO }}
 
 jobs:
   test-artifactory:
@@ -50,10 +51,25 @@ jobs:
       - name: Resolve image repo
         id: repo
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "value=gdc4-corpcal-dev" >> "$GITHUB_OUTPUT"
-          else
+          if [[ -n "${{ inputs.image_repo }}" ]]; then
             echo "value=${{ inputs.image_repo }}" >> "$GITHUB_OUTPUT"
+            echo "environment=override" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "value=$ARTIFACTORY_DEV_IMAGE_REPO" >> "$GITHUB_OUTPUT"
+          echo "environment=dev" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Artifactory configuration
+        run: |
+          if [[ -z "$REGISTRY" ]]; then
+            echo "::error::Set repo variable ARTIFACTORY_REGISTRY"
+            exit 1
+          fi
+
+          if [[ "${{ steps.stage.outputs.value }}" == "full" && -z "${{ steps.repo.outputs.value }}" ]]; then
+            echo "::error::Set repo variable ARTIFACTORY_DEV_IMAGE_REPO or use image_repo override"
+            exit 1
           fi
 
       - name: Resolve image tag
@@ -94,7 +110,7 @@ jobs:
         if: steps.stage.outputs.value == 'full'
         run: |
           if [[ -z "${{ steps.repo.outputs.value }}" ]]; then
-            echo "::error::'image_repo' is required for full stage (e.g. dc4c90-docker-local)"
+            echo "::error::Set repo variable ARTIFACTORY_DEV_IMAGE_REPO or use image_repo override"
             exit 1
           fi
 
@@ -116,6 +132,7 @@ jobs:
         run: |
           echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Stage:** ${{ steps.stage.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Environment:** ${{ steps.repo.outputs.environment }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Registry:** ${{ env.REGISTRY }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Branch:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-artifactory-build.yaml
+++ b/.github/workflows/test-artifactory-build.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'build/enable-github-actions-artifacts'
-    paths:
-      - '.github/workflows/test-artifactory-build.yaml'
   workflow_dispatch:
     inputs:
       stage:
@@ -34,7 +32,7 @@ env:
 
 jobs:
   test-artifactory:
-    name: 'Test Artifactory (${{ inputs.stage }})'
+    name: Test Artifactory
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -44,9 +42,18 @@ jobs:
         id: stage
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "value=build-only" >> "$GITHUB_OUTPUT"
+            echo "value=full" >> "$GITHUB_OUTPUT"
           else
             echo "value=${{ inputs.stage }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve image repo
+        id: repo
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "value=gdc4-corpcal-dev" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ inputs.image_repo }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Resolve image tag
@@ -86,7 +93,7 @@ jobs:
       - name: Validate push inputs
         if: steps.stage.outputs.value == 'full'
         run: |
-          if [[ -z "${{ inputs.image_repo }}" ]]; then
+          if [[ -z "${{ steps.repo.outputs.value }}" ]]; then
             echo "::error::'image_repo' is required for full stage (e.g. dc4c90-docker-local)"
             exit 1
           fi
@@ -94,14 +101,14 @@ jobs:
       - name: Tag and push calendar-service
         if: steps.stage.outputs.value == 'full'
         run: |
-          PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-service:${{ steps.tag.outputs.tag }}"
+          PUSH_TAG="$REGISTRY/${{ steps.repo.outputs.value }}/calendar-service:${{ steps.tag.outputs.tag }}"
           docker tag "$REGISTRY/calendar-service:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
           docker push "$PUSH_TAG"
 
       - name: Tag and push calendar-ui
         if: steps.stage.outputs.value == 'full'
         run: |
-          PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-ui:${{ steps.tag.outputs.tag }}"
+          PUSH_TAG="$REGISTRY/${{ steps.repo.outputs.value }}/calendar-ui:${{ steps.tag.outputs.tag }}"
           docker tag "$REGISTRY/calendar-ui:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
           docker push "$PUSH_TAG"
 
@@ -112,6 +119,6 @@ jobs:
           echo "- **Registry:** ${{ env.REGISTRY }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Branch:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -n "${{ inputs.image_repo }}" ]]; then
-            echo "- **Push repo:** ${{ inputs.image_repo }}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "${{ steps.repo.outputs.value }}" ]]; then
+            echo "- **Push repo:** ${{ steps.repo.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/test-artifactory-build.yaml
+++ b/.github/workflows/test-artifactory-build.yaml
@@ -1,0 +1,103 @@
+name: Test Artifactory Build & Push
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'Test stage: login-only, build-only, or full (build+push)'
+        required: true
+        type: choice
+        options:
+          - login-only
+          - build-only
+          - full
+        default: login-only
+      image_repo:
+        description: "Artifactory docker repo path (only needed for 'full' stage, e.g. dc4c90-docker-local)"
+        required: false
+        type: string
+      image_tag:
+        description: 'Image tag for push (defaults to short SHA)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: artifacts.developer.gov.bc.ca
+
+jobs:
+  test-artifactory:
+    name: 'Test Artifactory (${{ inputs.stage }})'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          if [[ -n "${{ inputs.image_tag }}" ]]; then
+            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Stage 1: Login ──
+      - name: Login to Artifactory
+        run: |
+          echo "${{ secrets.ARTIFACTORY_PASSWORD }}" | \
+            docker login "$REGISTRY" \
+              -u "${{ secrets.ARTIFACTORY_USERNAME }}" --password-stdin
+
+      # ── Stage 2: Build ──
+      - name: Build calendar-service
+        if: inputs.stage == 'build-only' || inputs.stage == 'full'
+        run: |
+          docker build \
+            -f calendar-service/Dockerfile \
+            -t "$REGISTRY/calendar-service:${{ steps.tag.outputs.tag }}" \
+            .
+
+      - name: Build calendar-ui
+        if: inputs.stage == 'build-only' || inputs.stage == 'full'
+        run: |
+          docker build \
+            -f calendar-ui/Dockerfile \
+            -t "$REGISTRY/calendar-ui:${{ steps.tag.outputs.tag }}" \
+            .
+
+      # ── Stage 3: Push ──
+      - name: Validate push inputs
+        if: inputs.stage == 'full'
+        run: |
+          if [[ -z "${{ inputs.image_repo }}" ]]; then
+            echo "::error::'image_repo' is required for full stage (e.g. dc4c90-docker-local)"
+            exit 1
+          fi
+
+      - name: Tag and push calendar-service
+        if: inputs.stage == 'full'
+        run: |
+          PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-service:${{ steps.tag.outputs.tag }}"
+          docker tag "$REGISTRY/calendar-service:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
+          docker push "$PUSH_TAG"
+
+      - name: Tag and push calendar-ui
+        if: inputs.stage == 'full'
+        run: |
+          PUSH_TAG="$REGISTRY/${{ inputs.image_repo }}/calendar-ui:${{ steps.tag.outputs.tag }}"
+          docker tag "$REGISTRY/calendar-ui:${{ steps.tag.outputs.tag }}" "$PUSH_TAG"
+          docker push "$PUSH_TAG"
+
+      - name: Summary
+        run: |
+          echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Stage:** ${{ inputs.stage }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Registry:** ${{ env.REGISTRY }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag:** ${{ steps.tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Branch:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "${{ inputs.image_repo }}" ]]; then
+            echo "- **Push repo:** ${{ inputs.image_repo }}" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Adds a manual Artifactory build workflow for publishing application images to JFrog.

The workflow builds `calendar-service` and `calendar-ui`, logs in to `artifacts.developer.gov.bc.ca` using GitHub Secrets, and pushes images to the dev Artifactory Docker repo configured by `ARTIFACTORY_DEV_IMAGE_REPO`.

Verified:
- Artifactory login succeeds
- Both Docker images build successfully
- Images push successfully to `gdc4-corpcal-dev`