### PR TITLE
chore/corpcal 000 copilot agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,62 @@
+# Corporate Calendar — Agent Instructions
+
+Monorepo for corporate calendar activities, approvals, and reporting.
+
+## Repository layout
+
+- `calendar-service` — NestJS backend API
+- `calendar-ui` — React frontend
+- `packages/database` — Drizzle schema, migrations, seeds
+- `packages/shared` — Shared Zod schemas, types, utilities
+- `docs` — Project documentation
+
+## Tech stack
+
+Node.js >= 24, npm workspaces. **Service:** NestJS 11, PostgreSQL, Drizzle, Zod, JWT, Socket.IO. **UI:** React 19, Vite, Tailwind v4, Radix/Shadcn, TanStack Query/Table, react-hook-form + Zod. Env vars in root `.env`.
+
+## Working style
+
+- Read existing code before creating new patterns; reuse components, hooks, utilities, and schemas.
+- Extend existing features instead of parallel abstractions. Keep diffs focused on the task.
+- Run `npm run check` and relevant tests before finishing.
+
+## Path-specific instructions
+
+`.github/instructions/*.instructions.md` auto-apply via `applyTo` when editing matching paths.
+
+## Boundaries
+
+- Do not edit generated output (`dist/`, coverage, `packages/database/migrations`) unless explicitly instructed.
+- Do not run database CLI commands (`db:generate`, `db:migrate`, `db:push`, `db:add-extensions`) — hand off to the user; see `.github/instructions/database.instructions.md`.
+- Do not add dependencies without clear justification.
+- Do not change auth, authorization, or permissions without tests.
+- Do not reorganize folders unless required by the task.
+
+## Coding standards
+
+- TypeScript everywhere; import only needed React symbols (no `import * as React`). Match patterns in the file you edit.
+- Validate with Zod; share schemas in `@corpcal/shared` when used by both UI and API.
+- Schema changes in `packages/database/` — see `.github/instructions/database.instructions.md`.
+
+## UI conventions
+
+- See `.github/instructions/ux.instructions.md` when editing `calendar-ui/`.
+
+## Common commands
+
+`npm start` · `npm run check` · `npm run test` · `npm run build` · `npm run build:packages`
+
+## Architecture
+
+- Build `packages/*` before service/UI when shared types change.
+- **Backend:** Feature modules in `calendar-service/src/<feature>/`. RBAC via `policy/` guards and `DataScopeInterceptor`. DB access in services, not controllers.
+- **Frontend:** `api/`, `components/`, `hooks/`, `lib/`, `pages/`, `schemas/`.
+
+## Testing
+
+- Vitest; colocate `*.spec.ts` / `*.spec.tsx` — not `*.test.ts`. Focus on contracts, validation, pure logic.
+- See `docs/TESTING.md` for full conventions.
+
+## Deeper docs
+
+`README.md` · `docs/TESTING.md` · `docs/ERROR_HANDLING.md` · `docs/AUTH_AND_RBAC.md` · `.github/instructions/` (path-specific)

--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -1,0 +1,46 @@
+---
+description: Drizzle schema, seeds, and migration handoff for packages/database
+applyTo: 'packages/database/**'
+---
+
+# Database instructions
+
+Schema and migrations for `@corpcal/database`. Follow global boundaries: do not run database CLI commands or hand-edit committed migration SQL / `migrations/meta/` unless explicitly instructed.
+
+## What the agent does
+
+- Define tables and columns in `src/schema/` via Drizzle only — no ad-hoc SQL in app code.
+- Export types from schema modules; keep naming consistent with existing tables.
+- Update `seeds/` when lookup or required seed data changes; follow existing numbering.
+- If schema extensions are needed (`pg_trgm`, etc.), edit `scripts/templates/postgresql_extensions.sql` and note it for the user. Tell the user to run `db:add-extensions` only after a squash, not incremental.
+
+## What the user runs (handoff required)
+
+`db:generate` and `db:migrate` require interactive Drizzle Kit prompts agents cannot complete. After schema edits, **stop and tell the user** to run the steps below.
+
+### Incremental migration (default — current repo workflow)
+
+This repo keeps incremental migrations in `migrations/`. Do **not** delete, edit, or archive existing migrations.
+
+1. `npm run db:generate --workspace=packages/database -- YYYYMMDD_description`
+2. Carefully complete Drizzle CLI prompts.
+3. Review generated SQL in `migrations/` — check for unexpected `DROP TABLE` / `DROP COLUMN`.
+4. `npm run db:migrate --workspace=packages/database` (or `db:push` for local-only reset).
+5. `npm run seed --workspace=calendar-service` (if seeds changed).
+
+Do **not** run `db:add-extensions` for incremental migrations.
+
+## Agent handoff template
+
+When finishing schema work, include:
+
+```
+## Schema handoff
+
+**Changes:** <summary of schema/seed changes>
+**Migration name:** YYYYMMDD_kebab-description
+**User steps:** incremental migration workflow above
+**Also note:** <any extension template updates that need applying>
+```
+
+Full workflows: `packages/database/README.md`

--- a/.github/instructions/ux.instructions.md
+++ b/.github/instructions/ux.instructions.md
@@ -1,0 +1,29 @@
+---
+description: calendar-ui design system, components, and table UX patterns
+applyTo: 'calendar-ui/**'
+---
+
+# UI / UX instructions
+
+Frontend conventions for `calendar-ui`. Reuse before creating: check `components/ui/`, `components/shared/`, and nearby feature folders first.
+
+## Design system
+
+- Use semantic Tailwind utilities tied to CSS vars (`bg-background`, `text-foreground`, `border-border`) — defined in `src/styles/globals.css`.
+- BC Gov brand tokens: `--bc-blue`, `--bc-gold`, etc. Font: BCSans via `@corpcal/shared/styles/bcsans-font-face.css`.
+- Do not add styles to `App.css` (legacy). New styling uses Tailwind and `globals.css`.
+- Add or update Shadcn via CLI: `npx shadcn@latest add <component>`. Follow `calendar-ui/docs/SHADCN_STANDARDIZATION_GUIDE.md`.
+- Extend repeated styles via CVA variants, not one-off `className` strings.
+
+## Component structure
+
+- **Pages** compose feature components; keep route logic thin.
+- **Presentation** in `components/`; **data-fetching** in `api/` (axios + TanStack Query) or `hooks/`.
+- **Forms:** react-hook-form + Zod; mirror validation schemas in `@corpcal/shared` when shared with the API.
+
+## Accessibility and patterns
+
+- Preserve labels, focus management, and ARIA on forms, dialogs, tables, and navigation (Radix/Shadcn defaults).
+- **Management tables:** follow `src/components/table/README.md` (Users/Teams exemplar; see `src/pages/UserManagement.tsx`).
+
+More detail: `calendar-ui/README.md` · `calendar-ui/docs/SHADCN_STANDARDIZATION_GUIDE.md` · `calendar-ui/docs/UI_CUSTOMIZE_LOG.md`


### PR DESCRIPTION
## Summary

**Docs changes only. No functional changes**

Adds repo specific Copilot instructions to aid agents in consistency and reduce token usage but laying out repo architecture. Also details database migration process to stop agents from hand-editing Drizzle generate SQL.

1. **Repo-wide instructions:** `.github/copilot-instructions.md`.
   - Layout, tech stack, boundaries, architecture, and testing pointers.
2. **Database instructions:** `.github/instructions/database.instructions.md`.
   - Drizzle schema edits, incremental migration handoff, agent handoff template.
3. **UI instructions:** `.github/instructions/ux.instructions.md`.
   - Design system, component structure, and management table patterns.