### PR TITLE
fix(ui-nginx): disable caching for /config.js so Snowplow flag update…

### DIFF
--- a/calendar-ui/nginx.conf
+++ b/calendar-ui/nginx.conf
@@ -45,9 +45,9 @@ server {
     # Runtime feature flags must update immediately after deploys.
     # Do not cache config.js or clients may keep stale values.
     location = /config.js {
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
     }
 
     # OpenShift readiness / liveness

--- a/calendar-ui/nginx.conf
+++ b/calendar-ui/nginx.conf
@@ -42,6 +42,14 @@ server {
         add_header Expires "0";
     }
 
+    # Runtime feature flags must update immediately after deploys.
+    # Do not cache config.js or clients may keep stale values.
+    location = /config.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
     # OpenShift readiness / liveness
     location = /ready {
         add_header Content-Type text/plain;


### PR DESCRIPTION
…s after deploy

Add a dedicated no-cache location for /config.js to prevent stale runtime feature flags from browser cache while keeping long-lived caching for other static assets.