### PR TITLE
fix(activities): return empty changedFieldsSinceReview for deleted ac…

### DIFF
--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -3243,6 +3243,19 @@ describe('ActivitiesService', () => {
       expect(paths).toContain('title');
     });
 
+    it('returns empty array when activity status is Deleted (soft-deleted)', () => {
+      const response = createMockActivityResponse({
+        activityStatus: 'Deleted',
+        title: 'Filled title',
+      });
+      const paths = service.computeChangedFieldsSinceReview(
+        response,
+        null,
+        REVIEW_SNAPSHOT_VERSION
+      );
+      expect(paths).toEqual([]);
+    });
+
     it('returns undefined when snapshot version mismatches', () => {
       const response = createMockActivityResponse({
         activityStatus: 'Changed',

--- a/calendar-service/src/activities/services/activities.service.ts
+++ b/calendar-service/src/activities/services/activities.service.ts
@@ -315,8 +315,9 @@ export class ActivitiesService {
 
   /**
    * Compute changedFieldsSinceReview from the stored snapshot vs current response.
-   * Returns undefined when snapshot version mismatches; [] when status is New (not yet reviewed);
-   * otherwise the diff paths vs last Reviewed snapshot (empty baseline when snapshot is null).
+   * Returns undefined when snapshot version mismatches; [] when status is New (not yet reviewed)
+   * or Deleted (soft-deleted activities have no meaningful field diff); otherwise the diff paths
+   * vs last Reviewed snapshot (empty baseline when snapshot is null).
    */
   computeChangedFieldsSinceReview(
     response: ActivityResponse,
@@ -330,7 +331,10 @@ export class ActivitiesService {
     if (snapshotVersion !== REVIEW_SNAPSHOT_VERSION) {
       return undefined;
     }
-    if (normalizeActivityStatusLabel(response.activityStatus) === 'new') {
+    const normalizedStatus = normalizeActivityStatusLabel(
+      response.activityStatus
+    );
+    if (normalizedStatus === 'new' || normalizedStatus === 'deleted') {
       return [];
     }
     const currentFormData = mapResponseToFormData(response, lookups);


### PR DESCRIPTION
…tivities

Soft-deleting an activity clears the reviewedFieldSnapshot to null. Without a special case for the 'deleted' status, computeChangedFieldsSinceReview would diff against an empty baseline and report every field as changed.

Short-circuit the diff for 'deleted' status alongside the existing 'new' short-circuit, returning [] instead.