### PR TITLE
fix(activity-save): prevent review status regression on share-only edits

### DIFF
--- a/calendar-service/src/activities/activities.service.spec.ts
+++ b/calendar-service/src/activities/activities.service.spec.ts
@@ -1904,6 +1904,83 @@ describe('ActivitiesService', () => {
         expect(result.activityStatusId).toBe(reviewedStatusId);
       });
 
+      it('treats representatives as the non-exempt field in full save payloads', async () => {
+        const existingActivity = createMockActivity({
+          id: 1,
+          activityStatusId: reviewedStatusId,
+        });
+
+        vi.spyOn(
+          service as unknown as {
+            getReviewDiffLookups: () => Promise<unknown>;
+          },
+          'getReviewDiffLookups'
+        ).mockResolvedValue({});
+
+        vi.spyOn(
+          service as unknown as {
+            getEffectiveReviewExemptFieldKeys: () => Promise<
+              ReadonlySet<string>
+            >;
+          },
+          'getEffectiveReviewExemptFieldKeys'
+        ).mockResolvedValue(new Set(['visibility', 'sharedWithTeamIds']));
+
+        vi.spyOn(
+          service as unknown as {
+            fetchRelatedForActivityIds: (
+              ...args: unknown[]
+            ) => Promise<unknown>;
+          },
+          'fetchRelatedForActivityIds'
+        ).mockResolvedValue({});
+
+        vi.spyOn(
+          service as unknown as {
+            mapFetchedActivityToResponseDto: (
+              ...args: unknown[]
+            ) => ReturnType<typeof createMockActivityResponse>;
+          },
+          'mapFetchedActivityToResponseDto'
+        ).mockReturnValue(
+          createMockActivityResponse({
+            id: 1,
+            activityStatus: 'Reviewed',
+            visibility: 'global',
+            sharedWith: [],
+            representativesAttending: ['Minister Smith'],
+          })
+        );
+
+        const preserveWhenOnlySharedWithChanges = await (
+          service as unknown as {
+            shouldPreserveReviewedStatus: (
+              activityId: number,
+              oldActivity: Activity,
+              dto: UpdateActivityRequest
+            ) => Promise<boolean>;
+          }
+        ).shouldPreserveReviewedStatus(1, existingActivity, {
+          sharedWithTeamIds: [42],
+        });
+
+        const preserveWhenUiPayloadAlsoSendsRepresentatives = await (
+          service as unknown as {
+            shouldPreserveReviewedStatus: (
+              activityId: number,
+              oldActivity: Activity,
+              dto: UpdateActivityRequest
+            ) => Promise<boolean>;
+          }
+        ).shouldPreserveReviewedStatus(1, existingActivity, {
+          sharedWithTeamIds: [42],
+          representatives: [],
+        });
+
+        expect(preserveWhenOnlySharedWithChanges).toBe(true);
+        expect(preserveWhenUiPayloadAlsoSendsRepresentatives).toBe(false);
+      });
+
       it('falls back to Changed when a non-exempt field changes', async () => {
         const existingActivity = createMockActivity({
           id: 1,

--- a/calendar-ui/src/lib/activity-form-payload.test.ts
+++ b/calendar-ui/src/lib/activity-form-payload.test.ts
@@ -125,4 +125,24 @@ describe('buildPayloadForUpdate', () => {
 
     expect(payload.translationLanguageIds).toBeUndefined();
   });
+
+  it('omits representatives when includeRepresentatives is false', () => {
+    const formValues = minimalForm({ representatives: undefined });
+
+    const payload = buildPayloadForUpdate(formValues, formValues, {
+      includeRepresentatives: false,
+    });
+
+    expect(payload).not.toHaveProperty('representatives');
+  });
+
+  it('includes representatives as empty array when includeRepresentatives is true', () => {
+    const formValues = minimalForm({ representatives: [] });
+
+    const payload = buildPayloadForUpdate(formValues, formValues, {
+      includeRepresentatives: true,
+    });
+
+    expect(payload.representatives).toEqual([]);
+  });
 });

--- a/calendar-ui/src/lib/activity-form-payload.ts
+++ b/calendar-ui/src/lib/activity-form-payload.ts
@@ -112,12 +112,11 @@ export function buildPayloadForUpdate(
     ...buildPayloadFromPrepared(prepared, preparedFormValues),
     reportSettings: normalizedReportSettings,
   };
-if (includeRepresentatives) {
+  if (includeRepresentatives) {
     // Include representatives when this update should persist representative edits,
     // including intentional clear-all (`[]`). Callers should set
     // `includeRepresentatives: false` for share/visibility-only saves to avoid implicit clears.
     payload.representatives = preparedFormValues.representatives ?? [];
-  }
   } else {
     delete payload.representatives;
   }

--- a/calendar-ui/src/lib/activity-form-payload.ts
+++ b/calendar-ui/src/lib/activity-form-payload.ts
@@ -68,6 +68,11 @@ export function buildPayloadForCreate(
 export type UpdatePayloadOptions = ActivityFormPayloadOptions & {
   markAsReviewed?: boolean;
   markAsCompleted?: boolean;
+  /**
+   * Include representatives in PATCH payload. When false, representatives are
+   * omitted so unrelated saves do not send implicit clears.
+   */
+  includeRepresentatives?: boolean;
 };
 
 function prepareForSubmit(
@@ -89,8 +94,12 @@ export function buildPayloadForUpdate(
   formValues: ActivityFormData,
   options?: UpdatePayloadOptions
 ): Record<string, unknown> {
-  const { requiredTranslationStatusId, markAsReviewed, markAsCompleted } =
-    options ?? {};
+  const {
+    requiredTranslationStatusId,
+    markAsReviewed,
+    markAsCompleted,
+    includeRepresentatives = true,
+  } = options ?? {};
   const prepared = prepareForSubmit(data, requiredTranslationStatusId);
   const preparedFormValues = prepareForSubmit(
     formValues,
@@ -102,11 +111,14 @@ export function buildPayloadForUpdate(
   const payload: Record<string, unknown> = {
     ...buildPayloadFromPrepared(prepared, preparedFormValues),
     reportSettings: normalizedReportSettings,
-    // For updates, always send the representatives array (even if empty) so the server
-    // can detect when all representatives have been removed. buildPayloadForCreate uses
-    // toUndefinedIfEmpty which converts [] to undefined, hiding removals from history.
-    representatives: formValues.representatives ?? [],
   };
+  if (includeRepresentatives) {
+    // Include representatives when the caller explicitly marks the field as
+    // changed so clear-all (`[]`) is persisted intentionally.
+    payload.representatives = preparedFormValues.representatives ?? [];
+  } else {
+    delete payload.representatives;
+  }
   if (markAsReviewed !== undefined) {
     payload.markAsReviewed = markAsReviewed;
   }

--- a/calendar-ui/src/lib/activity-form-payload.ts
+++ b/calendar-ui/src/lib/activity-form-payload.ts
@@ -112,10 +112,12 @@ export function buildPayloadForUpdate(
     ...buildPayloadFromPrepared(prepared, preparedFormValues),
     reportSettings: normalizedReportSettings,
   };
-  if (includeRepresentatives) {
-    // Include representatives when the caller explicitly marks the field as
-    // changed so clear-all (`[]`) is persisted intentionally.
+if (includeRepresentatives) {
+    // Include representatives when this update should persist representative edits,
+    // including intentional clear-all (`[]`). Callers should set
+    // `includeRepresentatives: false` for share/visibility-only saves to avoid implicit clears.
     payload.representatives = preparedFormValues.representatives ?? [];
+  }
   } else {
     delete payload.representatives;
   }

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -557,10 +557,24 @@ export function ActivityPage({
         } else {
           const opts: UpdatePayloadOptions =
             mode.kind === 'reviewWithSave'
-              ? { markAsReviewed: true, requiredTranslationStatusId }
+              ? {
+                  markAsReviewed: true,
+                  requiredTranslationStatusId,
+                  includeRepresentatives:
+                    !!form.formState.dirtyFields.representatives,
+                }
               : mode.kind === 'completeWithSave'
-                ? { markAsCompleted: true, requiredTranslationStatusId }
-                : { requiredTranslationStatusId };
+                ? {
+                    markAsCompleted: true,
+                    requiredTranslationStatusId,
+                    includeRepresentatives:
+                      !!form.formState.dirtyFields.representatives,
+                  }
+                : {
+                    requiredTranslationStatusId,
+                    includeRepresentatives:
+                      !!form.formState.dirtyFields.representatives,
+                  };
           submitData = {
             ...buildPayloadForUpdate(
               mode.validatedData,


### PR DESCRIPTION
only include representatives in update payload when representatives is dirty avoid sending implicit representatives clears on unrelated saves preserve reviewed status when changing share-with/visibility without non-exempt edits add tests for conditional representatives payload behavior add service test coverage reproducing full-save reviewed-to-changed edge case

This PR fixes a reviewed-status regression where saving a share-only edit could incorrectly move an activity from Reviewed to Changed.

Root Cause

The Activity edit Save path was sending a broad PATCH payload.
That payload could include representatives as an empty array even when the user did not edit representatives.
On the backend, representatives is a non-exempt review field, so that extra field in the payload could trigger Reviewed -> Changed.
What Changed

Added conditional representatives inclusion to update payload construction:
[activity-form-payload.ts](vscode-file://vscode-app/c:/Users/acarmich/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Representatives is now omitted from PATCH when not explicitly requested.
Representatives is still included as an empty array when the field is intentionally edited/cleared.
Wired Activity page submit options to include representatives only when RHF marks representatives as dirty:
[ActivityPage.tsx](vscode-file://vscode-app/c:/Users/acarmich/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Diagnostic/Guardrail Test Added

Added a focused service test proving the difference between:
sharedWithTeamIds-only update (preserves Reviewed)
sharedWithTeamIds plus representatives empty array (does not preserve Reviewed)
[activities.service.spec.ts:1907](vscode-file://vscode-app/c:/Users/acarmich/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Additional Test Coverage

Added payload unit tests for conditional representatives behavior:
[activity-form-payload.test.ts](vscode-file://vscode-app/c:/Users/acarmich/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Behavior After Fix

Share-only or visibility-only saves no longer send implicit representatives changes.
Reviewed status is preserved when only exempt fields are changed.
Intentional representatives edits, including clear-all, still flow correctly and can impact review status as designed.
Validation Performed

calendar-ui payload tests passed: 10/10
calendar-ui ActivityPage tests passed: 24/24
calendar-service ActivitiesService tests passed: 75/75