### PR TITLE
Fix/corpcal 280 browser back scroll position

### DIFF
--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
@@ -2,12 +2,14 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_ACTIVITY_FILTER_STATE } from '@corpcal/shared';
+import { clearStrictModeScrollRestoreFallback } from '@/lib/activity-list-scroll-restore';
 
 import { ActivityTable } from './ActivityTable';
 
 const mockNavigate = vi.fn();
 const mockSetPreferences = vi.fn();
 let mockLocationState: unknown = null;
+let mockNavigationType: 'POP' | 'PUSH' | 'REPLACE' = 'PUSH';
 
 function makeActivity(id: number) {
   return {
@@ -71,6 +73,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
       state: mockLocationState,
     }),
     useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    useNavigationType: () => mockNavigationType,
   };
 });
 
@@ -175,7 +178,9 @@ describe('ActivityTable scroll state capture', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLocationState = null;
+    mockNavigationType = 'PUSH';
     window.sessionStorage.clear();
+    clearStrictModeScrollRestoreFallback();
   });
 
   it('captures page and focus activity when opening details', () => {
@@ -253,6 +258,7 @@ describe('ActivityTable scroll state capture', () => {
   });
 
   it('restores from sessionStorage when location state has no scroll fields (browser back)', async () => {
+    mockNavigationType = 'POP';
     mockLocationState = null;
     window.sessionStorage.setItem(
       'activityListScrollState',
@@ -290,5 +296,30 @@ describe('ActivityTable scroll state capture', () => {
 
     rafSpy.mockRestore();
     cancelSpy.mockRestore();
+  });
+
+  it('does not restore from sessionStorage on direct navigation (non-POP)', async () => {
+    mockNavigationType = 'PUSH';
+    mockLocationState = null;
+    window.sessionStorage.setItem(
+      'activityListScrollState',
+      JSON.stringify({
+        activityListPageIndex: 1,
+        activityListScrollTop: 180,
+        activityListFocusActivityId: 12,
+      })
+    );
+
+    render(<ActivityTable />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Page 1' })).toHaveAttribute(
+        'aria-current',
+        'page'
+      );
+    });
+
+    expect(screen.getByText('Test Activity 1')).toBeInTheDocument();
+    expect(window.sessionStorage.getItem('activityListScrollState')).toBeNull();
   });
 });

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
@@ -251,4 +251,44 @@ describe('ActivityTable scroll state capture', () => {
     rafSpy.mockRestore();
     cancelSpy.mockRestore();
   });
+
+  it('restores from sessionStorage when location state has no scroll fields (browser back)', async () => {
+    mockLocationState = null;
+    window.sessionStorage.setItem(
+      'activityListScrollState',
+      JSON.stringify({
+        activityListPageIndex: 1,
+        activityListScrollTop: 180,
+        activityListFocusActivityId: 12,
+      })
+    );
+
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      });
+    const cancelSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+
+    render(<ActivityTable />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Page 2' })).toHaveAttribute(
+        'aria-current',
+        'page'
+      );
+    });
+
+    const table = screen.getByRole('grid');
+    const scroller = table.closest('div.overflow-auto');
+    expect(scroller).toBeTruthy();
+    expect(scroller?.scrollTop).toBe(180);
+    expect(window.sessionStorage.getItem('activityListScrollState')).toBeNull();
+
+    rafSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
 });

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -23,10 +23,12 @@ import { toast } from 'sonner';
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
+  type MutableRefObject,
 } from 'react';
 
 import { DEFAULT_ACTIVITY_FILTER_STATE, PERMISSIONS } from '@corpcal/shared';
@@ -203,13 +205,44 @@ function writeStoredActivityListScrollState(
 ): void {
   if (typeof window === 'undefined') return;
   try {
+    const existing =
+      parseStoredActivityListScrollState(
+        window.sessionStorage.getItem(ACTIVITY_LIST_SCROLL_STATE_KEY)
+      ) ?? {};
+    const merged: StoredActivityListScrollState = { ...existing };
+    if (state.activityListPageIndex !== undefined) {
+      merged.activityListPageIndex = state.activityListPageIndex;
+    }
+    if (state.activityListScrollTop !== undefined) {
+      merged.activityListScrollTop = state.activityListScrollTop;
+    }
+    if (state.activityListWindowScrollTop !== undefined) {
+      merged.activityListWindowScrollTop = state.activityListWindowScrollTop;
+    }
+    if (state.activityListFocusActivityId !== undefined) {
+      merged.activityListFocusActivityId = state.activityListFocusActivityId;
+    }
     window.sessionStorage.setItem(
       ACTIVITY_LIST_SCROLL_STATE_KEY,
-      JSON.stringify(state)
+      JSON.stringify(merged)
     );
   } catch {
     // ignore
   }
+}
+
+function hasPendingActivityListScrollRestore(refs: {
+  pendingFocusActivityIdRef: MutableRefObject<number | null>;
+  pendingPageIndexRef: MutableRefObject<number | null>;
+  pendingScrollTopRef: MutableRefObject<number | null>;
+  pendingWindowScrollTopRef: MutableRefObject<number | null>;
+}): boolean {
+  return (
+    refs.pendingFocusActivityIdRef.current != null ||
+    refs.pendingPageIndexRef.current != null ||
+    refs.pendingScrollTopRef.current != null ||
+    refs.pendingWindowScrollTopRef.current != null
+  );
 }
 
 function parseStoredActivityListScrollState(
@@ -1395,6 +1428,16 @@ export function ActivityTable({
 
   useEffect(() => {
     if (!isActivityListRoute) return;
+    if (
+      hasPendingActivityListScrollRestore({
+        pendingFocusActivityIdRef,
+        pendingPageIndexRef,
+        pendingScrollTopRef,
+        pendingWindowScrollTopRef,
+      })
+    ) {
+      return;
+    }
     const scrollTop = tableScrollRef.current?.scrollTop ?? 0;
     latestContainerScrollTopRef.current = scrollTop;
     writeStoredActivityListScrollState({
@@ -1775,7 +1818,7 @@ export function ActivityTable({
       ]
     );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isActivityListRoute) return;
 
     const statePageIndex = getActivityListPageIndex(location.state);

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -23,12 +23,10 @@ import { toast } from 'sonner';
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
-  type MutableRefObject,
 } from 'react';
 
 import { DEFAULT_ACTIVITY_FILTER_STATE, PERMISSIONS } from '@corpcal/shared';
@@ -72,6 +70,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { getLookAheadStatusLabel } from '@/constants/form-options';
+import { useActivityListScrollRestore } from '@/hooks/useActivityListScrollRestore';
 import { useActivityTableFilterLookups } from '@/hooks/useActivityTableFilterLookups';
 import { useActivityTablePreferences } from '@/hooks/useActivityTablePreferences';
 import { useAuth } from '@/hooks/useAuth';
@@ -91,12 +90,6 @@ import {
   useUsers,
 } from '@/hooks/useLookups';
 import { useSavedFilters } from '@/hooks/useSavedFilters';
-import {
-  activityFormLinkState,
-  getActivityListPageIndex,
-  getActivityListScrollTop,
-  getActivityListWindowScrollTop,
-} from '@/lib/activity-form-navigation-state';
 import {
   canResolveTranslationLanguageFilter,
   filterActivityRowsByFilters,
@@ -189,127 +182,6 @@ const STATUS_COLUMN_SORT_KEYS = [
 ] as const;
 
 const LIST_REVIEW_HIGHLIGHT_BG = 'bg-[#FFDDB3]';
-
-const ACTIVITY_LIST_SCROLL_STATE_KEY = 'activityListScrollState';
-const ACTIVITY_LIST_SCROLL_DEBUG_KEY = 'activityListScrollDebug';
-
-type StoredActivityListScrollState = {
-  activityListPageIndex?: number;
-  activityListScrollTop?: number;
-  activityListWindowScrollTop?: number;
-  activityListFocusActivityId?: number;
-};
-
-function writeStoredActivityListScrollState(
-  state: StoredActivityListScrollState
-): void {
-  if (typeof window === 'undefined') return;
-  try {
-    const existing =
-      parseStoredActivityListScrollState(
-        window.sessionStorage.getItem(ACTIVITY_LIST_SCROLL_STATE_KEY)
-      ) ?? {};
-    const merged: StoredActivityListScrollState = { ...existing };
-    if (state.activityListPageIndex !== undefined) {
-      merged.activityListPageIndex = state.activityListPageIndex;
-    }
-    if (state.activityListScrollTop !== undefined) {
-      merged.activityListScrollTop = state.activityListScrollTop;
-    }
-    if (state.activityListWindowScrollTop !== undefined) {
-      merged.activityListWindowScrollTop = state.activityListWindowScrollTop;
-    }
-    if (state.activityListFocusActivityId !== undefined) {
-      merged.activityListFocusActivityId = state.activityListFocusActivityId;
-    }
-    window.sessionStorage.setItem(
-      ACTIVITY_LIST_SCROLL_STATE_KEY,
-      JSON.stringify(merged)
-    );
-  } catch {
-    // ignore
-  }
-}
-
-function hasPendingActivityListScrollRestore(refs: {
-  pendingFocusActivityIdRef: MutableRefObject<number | null>;
-  pendingPageIndexRef: MutableRefObject<number | null>;
-  pendingScrollTopRef: MutableRefObject<number | null>;
-  pendingWindowScrollTopRef: MutableRefObject<number | null>;
-}): boolean {
-  return (
-    refs.pendingFocusActivityIdRef.current != null ||
-    refs.pendingPageIndexRef.current != null ||
-    refs.pendingScrollTopRef.current != null ||
-    refs.pendingWindowScrollTopRef.current != null
-  );
-}
-
-function parseStoredActivityListScrollState(
-  raw: string | null
-): StoredActivityListScrollState | null {
-  if (raw == null) return null;
-  try {
-    const parsed = JSON.parse(raw) as StoredActivityListScrollState;
-    const pageIndex = parsed.activityListPageIndex;
-    const containerScrollTop = parsed.activityListScrollTop;
-    const windowScrollTop = parsed.activityListWindowScrollTop;
-    const focusActivityId = parsed.activityListFocusActivityId;
-    return {
-      activityListPageIndex:
-        typeof pageIndex === 'number' &&
-        Number.isInteger(pageIndex) &&
-        pageIndex >= 0
-          ? pageIndex
-          : undefined,
-      activityListScrollTop:
-        typeof containerScrollTop === 'number' &&
-        Number.isFinite(containerScrollTop)
-          ? containerScrollTop
-          : undefined,
-      activityListWindowScrollTop:
-        typeof windowScrollTop === 'number' && Number.isFinite(windowScrollTop)
-          ? windowScrollTop
-          : undefined,
-      activityListFocusActivityId:
-        typeof focusActivityId === 'number' &&
-        Number.isInteger(focusActivityId) &&
-        focusActivityId > 0
-          ? focusActivityId
-          : undefined,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function recordScrollRestoreDebug(
-  event: string,
-  payload: Record<string, unknown>
-) {
-  if (typeof window === 'undefined') return;
-  if (!import.meta.env.DEV) return;
-  const entry = {
-    event,
-    at: new Date().toISOString(),
-    ...payload,
-  };
-  console.debug('[scroll-restore]', entry);
-  try {
-    const existingRaw = window.sessionStorage.getItem(
-      ACTIVITY_LIST_SCROLL_DEBUG_KEY
-    );
-    const parsed = JSON.parse(existingRaw ?? '[]') as unknown;
-    const existing = Array.isArray(parsed) ? parsed : [];
-    const next = [...existing, entry].slice(-40);
-    window.sessionStorage.setItem(
-      ACTIVITY_LIST_SCROLL_DEBUG_KEY,
-      JSON.stringify(next)
-    );
-  } catch {
-    // ignore
-  }
-}
 
 function rowHasChangedPath(row: ActivityTableRow, path: string): boolean {
   const changed = row.changedFieldsSinceReview ?? [];
@@ -1102,13 +974,8 @@ export function ActivityTable({
   } = useActivityTableFilterLookups(canSeeDeleted);
 
   const tableScrollRef = useRef<HTMLDivElement>(null);
-  const latestContainerScrollTopRef = useRef(0);
   const { preferences, setPreferences } =
     useActivityTablePreferences(canSeeDeleted);
-  const pendingFocusActivityIdRef = useRef<number | null>(null);
-  const pendingPageIndexRef = useRef<number | null>(null);
-  const pendingScrollTopRef = useRef<number | null>(null);
-  const pendingWindowScrollTopRef = useRef<number | null>(null);
   const savedFiltersHook = useSavedFilters();
   const [currentSearchParams] = useSearchParams();
   const defaultAppliedRef = useRef(false);
@@ -1392,62 +1259,6 @@ export function ActivityTable({
   );
   const setPagination = onPaginationChangeStable;
 
-  useEffect(() => {
-    if (!isActivityListRoute) return;
-    const scrollContainer = tableScrollRef.current;
-    if (scrollContainer == null) return;
-
-    let rafId = 0;
-    let pending = false;
-
-    const persistScroll = () => {
-      pending = false;
-      const scrollTop = scrollContainer.scrollTop;
-      latestContainerScrollTopRef.current = scrollTop;
-      writeStoredActivityListScrollState({
-        activityListPageIndex: pageIndex,
-        activityListScrollTop: scrollTop,
-        activityListFocusActivityId:
-          pendingFocusActivityIdRef.current ?? undefined,
-      });
-    };
-
-    const onScroll = () => {
-      if (pending) return;
-      pending = true;
-      rafId = window.requestAnimationFrame(persistScroll);
-    };
-
-    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
-
-    return () => {
-      scrollContainer.removeEventListener('scroll', onScroll);
-      window.cancelAnimationFrame(rafId);
-    };
-  }, [isActivityListRoute, pageIndex]);
-
-  useEffect(() => {
-    if (!isActivityListRoute) return;
-    if (
-      hasPendingActivityListScrollRestore({
-        pendingFocusActivityIdRef,
-        pendingPageIndexRef,
-        pendingScrollTopRef,
-        pendingWindowScrollTopRef,
-      })
-    ) {
-      return;
-    }
-    const scrollTop = tableScrollRef.current?.scrollTop ?? 0;
-    latestContainerScrollTopRef.current = scrollTop;
-    writeStoredActivityListScrollState({
-      activityListPageIndex: pageIndex,
-      activityListScrollTop: scrollTop,
-      activityListFocusActivityId:
-        pendingFocusActivityIdRef.current ?? undefined,
-    });
-  }, [isActivityListRoute, pageIndex]);
-
   const userMap = useMemo(() => {
     const map = new Map<string, { name: string; jobTitle?: string | null }>();
     const users = usersQuery.data ?? [];
@@ -1526,6 +1337,23 @@ export function ActivityTable({
       compareActivityRowsByLevels(a, b, sortLevels)
     );
   }, [filteredData, effectiveSortKey, effectiveSortDirection]);
+
+  const sortedActivityIds = useMemo(
+    () => sortedData.map((row) => row.id),
+    [sortedData]
+  );
+
+  const { openActivityWithScroll } = useActivityListScrollRestore({
+    enabled: isActivityListRoute,
+    location,
+    navigate,
+    scrollRef: tableScrollRef,
+    pageIndex,
+    setPageIndex,
+    pageSize: pagination.pageSize,
+    loading,
+    sortedActivityIds,
+  });
 
   const watchlistActivityIdSet = useMemo(
     () => new Set(watchlistActivityIds ?? []),
@@ -1817,257 +1645,6 @@ export function ActivityTable({
         pitchFieldVisibility,
       ]
     );
-
-  useLayoutEffect(() => {
-    if (!isActivityListRoute) return;
-
-    const statePageIndex = getActivityListPageIndex(location.state);
-    const stateScrollTop = getActivityListScrollTop(location.state);
-    const stateWindowScrollTop = getActivityListWindowScrollTop(location.state);
-    let source = 'none';
-    if (
-      statePageIndex != null ||
-      stateScrollTop != null ||
-      stateWindowScrollTop != null
-    ) {
-      pendingPageIndexRef.current = statePageIndex;
-      pendingScrollTopRef.current = stateScrollTop;
-      pendingWindowScrollTopRef.current = stateWindowScrollTop;
-      source = 'location.state';
-    } else if (typeof window !== 'undefined') {
-      try {
-        const stored = parseStoredActivityListScrollState(
-          window.sessionStorage.getItem(ACTIVITY_LIST_SCROLL_STATE_KEY)
-        );
-        if (stored != null) {
-          pendingFocusActivityIdRef.current =
-            stored.activityListFocusActivityId ?? null;
-          pendingPageIndexRef.current = stored.activityListPageIndex ?? null;
-          pendingScrollTopRef.current = stored.activityListScrollTop ?? null;
-          pendingWindowScrollTopRef.current =
-            stored.activityListWindowScrollTop ?? null;
-          source = 'sessionStorage';
-        }
-      } catch {
-        // ignore
-      }
-    }
-    recordScrollRestoreDebug('pending set', {
-      source,
-      focusActivityId: pendingFocusActivityIdRef.current,
-      pageIndex: pendingPageIndexRef.current,
-      container: pendingScrollTopRef.current,
-      window: pendingWindowScrollTopRef.current,
-      hasState: location.state != null,
-      pathname: location.pathname,
-    });
-  }, [isActivityListRoute, location]);
-
-  useEffect(() => {
-    if (!isActivityListRoute) return;
-
-    const targetActivityId = pendingFocusActivityIdRef.current;
-    const targetPageIndex = pendingPageIndexRef.current;
-    const targetContainer = pendingScrollTopRef.current;
-    const targetWindow = pendingWindowScrollTopRef.current;
-    if (
-      targetActivityId == null &&
-      targetPageIndex == null &&
-      targetContainer == null &&
-      targetWindow == null
-    ) {
-      return;
-    }
-
-    if (
-      targetPageIndex == null &&
-      targetActivityId != null &&
-      pagination.pageSize > 0
-    ) {
-      const targetSortedIndex = sortedData.findIndex(
-        (activity) => activity.id === targetActivityId
-      );
-      if (targetSortedIndex >= 0) {
-        const derivedPageIndex = Math.floor(
-          targetSortedIndex / pagination.pageSize
-        );
-        if (pageIndex !== derivedPageIndex) {
-          setPageIndex(derivedPageIndex);
-          return;
-        }
-      }
-    }
-
-    if (targetPageIndex != null && pageIndex !== targetPageIndex) {
-      setPageIndex(targetPageIndex);
-      return;
-    }
-
-    if (loading || sortedData.length === 0) return;
-    if (typeof window === 'undefined') return;
-
-    const previousScrollRestoration =
-      'scrollRestoration' in window.history
-        ? window.history.scrollRestoration
-        : null;
-    const restoreScrollRestoration = () => {
-      if (previousScrollRestoration == null) return;
-      window.history.scrollRestoration = previousScrollRestoration;
-    };
-
-    // Prevent the browser's native scroll restoration from resetting window
-    // scroll to 0 on SPA back-navigation and fighting the restore below.
-    if (previousScrollRestoration != null) {
-      window.history.scrollRestoration = 'manual';
-    }
-
-    recordScrollRestoreDebug('begin restore', {
-      targetActivityId,
-      targetPageIndex,
-      pageIndex,
-      targetContainer,
-      targetWindow,
-      rows: sortedData.length,
-    });
-
-    let cancelled = false;
-    let rafId = 0;
-    let attempts = 0;
-    // The table's scroll container height only becomes tall enough to accept
-    // the saved scrollTop once its rows have laid out, which can take several
-    // frames (async rows, lazy chunk, refetch). Retry until the position is
-    // actually applied rather than assuming it stuck on the first frame.
-    const maxAttempts = 90;
-
-    const step = () => {
-      if (cancelled) return;
-      const scrollContainer = tableScrollRef.current;
-      const rowTargetFromActivity = (() => {
-        if (scrollContainer == null || targetActivityId == null) return null;
-        const rowElement = scrollContainer.querySelector<HTMLElement>(
-          `[data-activity-id="${targetActivityId}"]`
-        );
-        if (rowElement == null) return null;
-        return Math.max(
-          0,
-          rowElement.offsetTop - Math.floor(scrollContainer.clientHeight * 0.35)
-        );
-      })();
-      const effectiveContainerTarget =
-        targetContainer ?? rowTargetFromActivity ?? null;
-
-      if (
-        scrollContainer != null &&
-        effectiveContainerTarget != null &&
-        scrollContainer.scrollTop !== effectiveContainerTarget
-      ) {
-        scrollContainer.scrollTop = effectiveContainerTarget;
-      }
-      if (targetWindow != null && window.scrollY !== targetWindow) {
-        window.scrollTo(0, targetWindow);
-      }
-
-      attempts += 1;
-
-      // Only consider the inner table restored when its scrollTop actually
-      // reaches the saved value. Do NOT treat "container can't scroll further"
-      // as reached: before the rows render, scrollHeight ≈ clientHeight makes
-      // that heuristic falsely true and leaves the table pinned to the top.
-      const containerReached =
-        effectiveContainerTarget == null ||
-        (scrollContainer != null &&
-          Math.abs(scrollContainer.scrollTop - effectiveContainerTarget) <= 1);
-
-      const windowReached =
-        targetWindow == null || Math.abs(window.scrollY - targetWindow) <= 1;
-
-      if (attempts === 1 || attempts % 20 === 0) {
-        recordScrollRestoreDebug('attempt', {
-          attempts,
-          target: effectiveContainerTarget,
-          rowTargetFromActivity,
-          targetActivityId,
-          actual: scrollContainer?.scrollTop,
-          scrollHeight: scrollContainer?.scrollHeight,
-          clientHeight: scrollContainer?.clientHeight,
-          hasContainer: scrollContainer != null,
-        });
-      }
-
-      if ((containerReached && windowReached) || attempts >= maxAttempts) {
-        recordScrollRestoreDebug('done', {
-          attempts,
-          containerReached,
-          windowReached,
-          targetActivityId,
-          pageIndex,
-          finalScrollTop: scrollContainer?.scrollTop,
-        });
-        restoreScrollRestoration();
-        pendingFocusActivityIdRef.current = null;
-        pendingPageIndexRef.current = null;
-        pendingScrollTopRef.current = null;
-        pendingWindowScrollTopRef.current = null;
-        try {
-          window.sessionStorage.removeItem(ACTIVITY_LIST_SCROLL_STATE_KEY);
-        } catch {
-          // ignore
-        }
-        return;
-      }
-
-      rafId = window.requestAnimationFrame(step);
-    };
-
-    rafId = window.requestAnimationFrame(step);
-
-    return () => {
-      cancelled = true;
-      window.cancelAnimationFrame(rafId);
-      restoreScrollRestoration();
-    };
-  }, [
-    isActivityListRoute,
-    loading,
-    pageIndex,
-    pagination.pageSize,
-    setPageIndex,
-    sortedData,
-    sortedData.length,
-  ]);
-
-  const openActivityWithScroll = useCallback(
-    (activityId: number) => {
-      const containerScrollTop = tableScrollRef.current?.scrollTop ?? 0;
-      latestContainerScrollTopRef.current = containerScrollTop;
-      const windowScrollTop =
-        typeof window !== 'undefined' ? window.scrollY : 0;
-      try {
-        const scrollState = {
-          activityListPageIndex: pageIndex,
-          activityListScrollTop:
-            latestContainerScrollTopRef.current ?? containerScrollTop,
-          activityListWindowScrollTop: windowScrollTop,
-          activityListFocusActivityId: activityId,
-        } satisfies StoredActivityListScrollState;
-        pendingFocusActivityIdRef.current = activityId;
-        writeStoredActivityListScrollState(scrollState);
-        recordScrollRestoreDebug('capture', scrollState);
-      } catch {
-        // ignore
-      }
-      void navigate(
-        `/activity/${activityId}`,
-        activityFormLinkState(
-          location,
-          containerScrollTop,
-          windowScrollTop,
-          pageIndex
-        )
-      );
-    },
-    [navigate, location, pageIndex]
-  );
 
   const handleClearAllCriteria = useCallback(() => {
     defaultSuppressedByClearRef.current = true;

--- a/calendar-ui/src/hooks/useActivityListScrollRestore.ts
+++ b/calendar-ui/src/hooks/useActivityListScrollRestore.ts
@@ -1,0 +1,384 @@
+import {
+  NavigationType,
+  useNavigationType,
+  type Location,
+  type NavigateFunction,
+} from 'react-router-dom';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type RefObject,
+} from 'react';
+
+import { activityFormLinkState } from '@/lib/activity-form-navigation-state';
+import {
+  ACTIVITY_LIST_SCROLL_STATE_KEY,
+  clearStoredActivityListScrollState,
+  clearStrictModeScrollRestoreFallback,
+  hasPendingActivityListScrollRestore,
+  recordScrollRestoreDebug,
+  resolveActivityListScrollRestorePending,
+  stashStrictModeScrollRestoreFallback,
+  takeStrictModeScrollRestoreFallback,
+  writeStoredActivityListScrollState,
+  type ActivityListScrollRestorePending,
+  type StoredActivityListScrollState,
+} from '@/lib/activity-list-scroll-restore';
+
+const MAX_RESTORE_ATTEMPTS = 90;
+
+type UseActivityListScrollRestoreOptions = {
+  enabled: boolean;
+  location: Location;
+  navigate: NavigateFunction;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  pageIndex: number;
+  setPageIndex: (index: number) => void;
+  pageSize: number;
+  loading: boolean;
+  sortedActivityIds: number[];
+};
+
+function computeRowScrollTarget(
+  scrollContainer: HTMLElement,
+  activityId: number
+): number | null {
+  const rowElement = scrollContainer.querySelector<HTMLElement>(
+    `[data-activity-id="${activityId}"]`
+  );
+  if (rowElement == null) return null;
+  return Math.max(
+    0,
+    rowElement.offsetTop - Math.floor(scrollContainer.clientHeight * 0.35)
+  );
+}
+
+export function useActivityListScrollRestore({
+  enabled,
+  location,
+  navigate,
+  scrollRef,
+  pageIndex,
+  setPageIndex,
+  pageSize,
+  loading,
+  sortedActivityIds,
+}: UseActivityListScrollRestoreOptions): {
+  openActivityWithScroll: (activityId: number) => void;
+} {
+  const navigationType = useNavigationType();
+  const latestContainerScrollTopRef = useRef(0);
+  const pendingRef = useRef<ActivityListScrollRestorePending | null>(null);
+  const restoreCompletedRef = useRef(false);
+  const allowSessionStorageFallback = navigationType === NavigationType.Pop;
+
+  useEffect(() => {
+    if (!enabled) {
+      pendingRef.current = null;
+      restoreCompletedRef.current = false;
+      clearStrictModeScrollRestoreFallback();
+    }
+  }, [enabled]);
+
+  useLayoutEffect(() => {
+    if (!enabled || restoreCompletedRef.current) return;
+
+    const strictFallback = takeStrictModeScrollRestoreFallback();
+    if (strictFallback != null) {
+      pendingRef.current = strictFallback;
+      recordScrollRestoreDebug('pending set', {
+        source: 'strictModeFallback',
+        focusActivityId: strictFallback.focusActivityId,
+        pageIndex: strictFallback.pageIndex,
+        container: strictFallback.containerScrollTop,
+        window: strictFallback.windowScrollTop,
+        hasState: location.state != null,
+        pathname: location.pathname,
+      });
+      return;
+    }
+
+    const storageRaw =
+      typeof window !== 'undefined'
+        ? window.sessionStorage.getItem(ACTIVITY_LIST_SCROLL_STATE_KEY)
+        : null;
+    const resolved = resolveActivityListScrollRestorePending(
+      location.state,
+      storageRaw,
+      { allowSessionStorageFallback }
+    );
+
+    if (resolved == null) {
+      pendingRef.current = null;
+      if (!allowSessionStorageFallback && storageRaw != null) {
+        clearStoredActivityListScrollState();
+      }
+      return;
+    }
+
+    pendingRef.current = resolved.pending;
+    recordScrollRestoreDebug('pending set', {
+      source: resolved.source,
+      focusActivityId: resolved.pending.focusActivityId,
+      pageIndex: resolved.pending.pageIndex,
+      container: resolved.pending.containerScrollTop,
+      window: resolved.pending.windowScrollTop,
+      hasState: location.state != null,
+      pathname: location.pathname,
+    });
+  }, [allowSessionStorageFallback, enabled, location]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const scrollContainer = scrollRef.current;
+    if (scrollContainer == null) return;
+
+    let rafId = 0;
+    let pending = false;
+
+    const persistScroll = () => {
+      pending = false;
+      const scrollTop = scrollContainer.scrollTop;
+      latestContainerScrollTopRef.current = scrollTop;
+      if (restoreCompletedRef.current) return;
+      writeStoredActivityListScrollState({
+        activityListPageIndex: pageIndex,
+        activityListScrollTop: scrollTop,
+      });
+    };
+
+    const onScroll = () => {
+      if (pending) return;
+      pending = true;
+      rafId = window.requestAnimationFrame(persistScroll);
+    };
+
+    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      scrollContainer.removeEventListener('scroll', onScroll);
+      window.cancelAnimationFrame(rafId);
+    };
+  }, [enabled, pageIndex, scrollRef]);
+
+  useEffect(() => {
+    if (!enabled || restoreCompletedRef.current) return;
+    if (pendingRef.current != null) return;
+
+    const scrollTop = scrollRef.current?.scrollTop ?? 0;
+    latestContainerScrollTopRef.current = scrollTop;
+    writeStoredActivityListScrollState({
+      activityListPageIndex: pageIndex,
+      activityListScrollTop: scrollTop,
+    });
+  }, [enabled, pageIndex, scrollRef]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const pending = pendingRef.current;
+    if (pending == null || !hasPendingActivityListScrollRestore(pending)) {
+      return;
+    }
+
+    const {
+      focusActivityId: targetActivityId,
+      pageIndex: targetPageIndex,
+      containerScrollTop: targetContainer,
+      windowScrollTop: targetWindow,
+    } = pending;
+
+    if (targetPageIndex == null && targetActivityId != null && pageSize > 0) {
+      const targetSortedIndex = sortedActivityIds.indexOf(targetActivityId);
+      if (targetSortedIndex >= 0) {
+        const derivedPageIndex = Math.floor(targetSortedIndex / pageSize);
+        if (pageIndex !== derivedPageIndex) {
+          setPageIndex(derivedPageIndex);
+          return;
+        }
+      }
+    }
+
+    if (targetPageIndex != null && pageIndex !== targetPageIndex) {
+      setPageIndex(targetPageIndex);
+      return;
+    }
+
+    if (loading || sortedActivityIds.length === 0) return;
+    if (typeof window === 'undefined') return;
+
+    const previousScrollRestoration =
+      'scrollRestoration' in window.history
+        ? window.history.scrollRestoration
+        : null;
+    const restoreScrollRestoration = () => {
+      if (previousScrollRestoration == null) return;
+      window.history.scrollRestoration = previousScrollRestoration;
+    };
+
+    if (previousScrollRestoration != null) {
+      window.history.scrollRestoration = 'manual';
+    }
+
+    recordScrollRestoreDebug('begin restore', {
+      targetActivityId,
+      targetPageIndex,
+      pageIndex,
+      targetContainer,
+      targetWindow,
+      rows: sortedActivityIds.length,
+    });
+
+    let cancelled = false;
+    let rafLoopId = 0;
+    let attempts = 0;
+
+    const finishRestore = () => {
+      restoreScrollRestoration();
+      const completedPending = pendingRef.current;
+      if (completedPending != null) {
+        stashStrictModeScrollRestoreFallback(completedPending);
+      }
+      pendingRef.current = null;
+      restoreCompletedRef.current = true;
+      clearStoredActivityListScrollState();
+
+      void navigate(
+        {
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+        },
+        { replace: true, state: null }
+      );
+    };
+
+    const step = () => {
+      if (cancelled) return;
+
+      const scrollContainer = scrollRef.current;
+      const rowTargetFromActivity =
+        scrollContainer != null && targetActivityId != null
+          ? computeRowScrollTarget(scrollContainer, targetActivityId)
+          : null;
+      const effectiveContainerTarget =
+        targetContainer ?? rowTargetFromActivity ?? null;
+
+      if (
+        scrollContainer != null &&
+        effectiveContainerTarget != null &&
+        scrollContainer.scrollTop !== effectiveContainerTarget
+      ) {
+        scrollContainer.scrollTop = effectiveContainerTarget;
+      }
+      if (targetWindow != null && window.scrollY !== targetWindow) {
+        window.scrollTo(0, targetWindow);
+      }
+
+      attempts += 1;
+
+      const needsContainerScroll =
+        targetContainer != null || targetActivityId != null;
+      const containerReached = needsContainerScroll
+        ? effectiveContainerTarget != null &&
+          scrollContainer != null &&
+          Math.abs(scrollContainer.scrollTop - effectiveContainerTarget) <= 1
+        : true;
+
+      const windowReached =
+        targetWindow == null || Math.abs(window.scrollY - targetWindow) <= 1;
+
+      if (attempts === 1 || attempts % 20 === 0) {
+        recordScrollRestoreDebug('attempt', {
+          attempts,
+          target: effectiveContainerTarget,
+          rowTargetFromActivity,
+          targetActivityId,
+          actual: scrollContainer?.scrollTop,
+          scrollHeight: scrollContainer?.scrollHeight,
+          clientHeight: scrollContainer?.clientHeight,
+          hasContainer: scrollContainer != null,
+        });
+      }
+
+      if (
+        (containerReached && windowReached) ||
+        attempts >= MAX_RESTORE_ATTEMPTS
+      ) {
+        recordScrollRestoreDebug('done', {
+          attempts,
+          containerReached,
+          windowReached,
+          targetActivityId,
+          pageIndex,
+          finalScrollTop: scrollContainer?.scrollTop,
+        });
+        finishRestore();
+        return;
+      }
+
+      rafLoopId = window.requestAnimationFrame(step);
+    };
+
+    rafLoopId = window.requestAnimationFrame(step);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(rafLoopId);
+      restoreScrollRestoration();
+    };
+  }, [
+    enabled,
+    loading,
+    location.hash,
+    location.pathname,
+    location.search,
+    navigate,
+    pageIndex,
+    pageSize,
+    scrollRef,
+    setPageIndex,
+    sortedActivityIds,
+  ]);
+
+  const openActivityWithScroll = useCallback(
+    (activityId: number) => {
+      restoreCompletedRef.current = false;
+      pendingRef.current = null;
+      clearStrictModeScrollRestoreFallback();
+
+      const containerScrollTop = scrollRef.current?.scrollTop ?? 0;
+      latestContainerScrollTopRef.current = containerScrollTop;
+      const windowScrollTop =
+        typeof window !== 'undefined' ? window.scrollY : 0;
+
+      const scrollState = {
+        activityListPageIndex: pageIndex,
+        activityListScrollTop:
+          latestContainerScrollTopRef.current ?? containerScrollTop,
+        activityListWindowScrollTop: windowScrollTop,
+        activityListFocusActivityId: activityId,
+      } satisfies StoredActivityListScrollState;
+
+      writeStoredActivityListScrollState(scrollState);
+      recordScrollRestoreDebug('capture', scrollState);
+
+      void navigate(
+        `/activity/${activityId}`,
+        activityFormLinkState(
+          location,
+          containerScrollTop,
+          windowScrollTop,
+          pageIndex,
+          activityId
+        )
+      );
+    },
+    [location, navigate, pageIndex, scrollRef]
+  );
+
+  return { openActivityWithScroll };
+}

--- a/calendar-ui/src/lib/activity-form-navigation-state.spec.ts
+++ b/calendar-ui/src/lib/activity-form-navigation-state.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   activityFormLinkState,
+  buildActivityListScrollRestoreReturnState,
   getActivityFormBackTarget,
+  getActivityListFocusActivityId,
   getActivityListPageIndex,
   getActivityListScrollTop,
   getActivityListWindowScrollTop,
@@ -14,7 +16,8 @@ describe('activity-form-navigation-state', () => {
       { pathname: '/activities', search: '?page=2', hash: '#top' },
       384,
       96,
-      2
+      2,
+      42
     ).state;
 
     expect(state).toEqual({
@@ -22,6 +25,7 @@ describe('activity-form-navigation-state', () => {
       activityListScrollTop: 384,
       activityListWindowScrollTop: 96,
       activityListPageIndex: 2,
+      activityListFocusActivityId: 42,
     });
   });
 
@@ -48,5 +52,31 @@ describe('activity-form-navigation-state', () => {
       getActivityListWindowScrollTop({ activityListWindowScrollTop: 'bad' })
     ).toBeNull();
     expect(getActivityListPageIndex({ activityListPageIndex: -1 })).toBeNull();
+  });
+
+  it('builds scroll-restore return state with focus id fallback', () => {
+    expect(
+      buildActivityListScrollRestoreReturnState(
+        {
+          from: '/?tab=all',
+          activityListPageIndex: 1,
+          activityListScrollTop: 180,
+        },
+        99
+      )
+    ).toEqual({
+      activityListPageIndex: 1,
+      activityListScrollTop: 180,
+      activityListFocusActivityId: 99,
+    });
+  });
+
+  it('reads focus activity id from state', () => {
+    expect(
+      getActivityListFocusActivityId({ activityListFocusActivityId: 12 })
+    ).toBe(12);
+    expect(
+      getActivityListFocusActivityId({ activityListFocusActivityId: 0 })
+    ).toBeNull();
   });
 });

--- a/calendar-ui/src/lib/activity-form-navigation-state.ts
+++ b/calendar-ui/src/lib/activity-form-navigation-state.ts
@@ -9,6 +9,7 @@ export type ActivityFormNavigationState = {
   activityListScrollTop?: number;
   activityListWindowScrollTop?: number;
   activityListPageIndex?: number;
+  activityListFocusActivityId?: number;
 };
 
 /**
@@ -22,13 +23,15 @@ export function activityFormLinkState(
   location: Pick<Location, 'pathname' | 'search' | 'hash'>,
   activityListScrollTop: number | null | undefined,
   activityListWindowScrollTop?: number | null,
-  activityListPageIndex?: number | null
+  activityListPageIndex?: number | null,
+  activityListFocusActivityId?: number | null
 ): { state: ActivityFormNavigationState };
 export function activityFormLinkState(
   location: Pick<Location, 'pathname' | 'search' | 'hash'>,
   activityListScrollTop?: number | null,
   activityListWindowScrollTop?: number | null,
-  activityListPageIndex?: number | null
+  activityListPageIndex?: number | null,
+  activityListFocusActivityId?: number | null
 ): { state: ActivityFormNavigationState } {
   const state: ActivityFormNavigationState = {
     from: `${location.pathname}${location.search}${location.hash}`,
@@ -54,6 +57,14 @@ export function activityFormLinkState(
     activityListPageIndex >= 0
   ) {
     state.activityListPageIndex = activityListPageIndex;
+  }
+
+  if (
+    typeof activityListFocusActivityId === 'number' &&
+    Number.isInteger(activityListFocusActivityId) &&
+    activityListFocusActivityId > 0
+  ) {
+    state.activityListFocusActivityId = activityListFocusActivityId;
   }
 
   return { state };
@@ -103,4 +114,44 @@ export function getActivityListPageIndex(state: unknown): number | null {
     return null;
   }
   return pageIndex;
+}
+
+export function getActivityListFocusActivityId(state: unknown): number | null {
+  if (state === null || typeof state !== 'object') return null;
+  const focusActivityId = (state as { activityListFocusActivityId?: unknown })
+    .activityListFocusActivityId;
+  if (
+    typeof focusActivityId !== 'number' ||
+    !Number.isInteger(focusActivityId) ||
+    focusActivityId <= 0
+  ) {
+    return null;
+  }
+  return focusActivityId;
+}
+
+/**
+ * Scroll-restore fields forwarded when returning to the activity list.
+ * Omits `from` so stale restore state is not re-applied on later navigations.
+ */
+export function buildActivityListScrollRestoreReturnState(
+  state: unknown,
+  focusActivityId?: number | null
+): Record<string, number> {
+  const activityListPageIndex = getActivityListPageIndex(state);
+  const activityListScrollTop = getActivityListScrollTop(state);
+  const activityListWindowScrollTop = getActivityListWindowScrollTop(state);
+  const activityListFocusActivityId =
+    focusActivityId ?? getActivityListFocusActivityId(state);
+
+  return {
+    ...(activityListPageIndex != null && { activityListPageIndex }),
+    ...(activityListScrollTop != null && { activityListScrollTop }),
+    ...(activityListWindowScrollTop != null && {
+      activityListWindowScrollTop,
+    }),
+    ...(activityListFocusActivityId != null && {
+      activityListFocusActivityId,
+    }),
+  };
 }

--- a/calendar-ui/src/lib/activity-list-scroll-restore.spec.ts
+++ b/calendar-ui/src/lib/activity-list-scroll-restore.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveActivityListScrollRestorePending,
+  stashStrictModeScrollRestoreFallback,
+  takeStrictModeScrollRestoreFallback,
+} from './activity-list-scroll-restore';
+
+describe('activity-list-scroll-restore', () => {
+  it('merges location state with sessionStorage for focus id', () => {
+    const resolved = resolveActivityListScrollRestorePending(
+      {
+        activityListPageIndex: 1,
+        activityListScrollTop: 180,
+      },
+      JSON.stringify({
+        activityListPageIndex: 1,
+        activityListScrollTop: 180,
+        activityListFocusActivityId: 12,
+      })
+    );
+
+    expect(resolved?.source).toBe('location.state+sessionStorage');
+    expect(resolved?.pending).toEqual({
+      pageIndex: 1,
+      containerScrollTop: 180,
+      windowScrollTop: null,
+      focusActivityId: 12,
+    });
+  });
+
+  it('reads sessionStorage when location state has no scroll fields and POP is allowed', () => {
+    const resolved = resolveActivityListScrollRestorePending(
+      null,
+      JSON.stringify({
+        activityListPageIndex: 2,
+        activityListScrollTop: 240,
+        activityListFocusActivityId: 5,
+      }),
+      { allowSessionStorageFallback: true }
+    );
+
+    expect(resolved?.source).toBe('sessionStorage');
+    expect(resolved?.pending.focusActivityId).toBe(5);
+  });
+
+  it('ignores sessionStorage when location state is empty and POP is not allowed', () => {
+    const resolved = resolveActivityListScrollRestorePending(
+      null,
+      JSON.stringify({
+        activityListPageIndex: 2,
+        activityListScrollTop: 240,
+        activityListFocusActivityId: 5,
+      }),
+      { allowSessionStorageFallback: false }
+    );
+
+    expect(resolved).toBeNull();
+  });
+
+  it('passes strict-mode fallback once', () => {
+    stashStrictModeScrollRestoreFallback({
+      pageIndex: 1,
+      containerScrollTop: 100,
+      windowScrollTop: null,
+      focusActivityId: 3,
+    });
+
+    expect(takeStrictModeScrollRestoreFallback()).toEqual({
+      pageIndex: 1,
+      containerScrollTop: 100,
+      windowScrollTop: null,
+      focusActivityId: 3,
+    });
+    expect(takeStrictModeScrollRestoreFallback()).toBeNull();
+  });
+});

--- a/calendar-ui/src/lib/activity-list-scroll-restore.ts
+++ b/calendar-ui/src/lib/activity-list-scroll-restore.ts
@@ -1,0 +1,226 @@
+import {
+  getActivityListFocusActivityId,
+  getActivityListPageIndex,
+  getActivityListScrollTop,
+  getActivityListWindowScrollTop,
+} from '@/lib/activity-form-navigation-state';
+
+export const ACTIVITY_LIST_SCROLL_STATE_KEY = 'activityListScrollState';
+const ACTIVITY_LIST_SCROLL_DEBUG_KEY = 'activityListScrollDebug';
+
+export type StoredActivityListScrollState = {
+  activityListPageIndex?: number;
+  activityListScrollTop?: number;
+  activityListWindowScrollTop?: number;
+  activityListFocusActivityId?: number;
+};
+
+export type ActivityListScrollRestorePending = {
+  focusActivityId: number | null;
+  pageIndex: number | null;
+  containerScrollTop: number | null;
+  windowScrollTop: number | null;
+};
+
+/** Survives React StrictMode remount after sessionStorage is cleared post-restore. */
+let strictModeScrollRestoreFallback: ActivityListScrollRestorePending | null =
+  null;
+
+export function stashStrictModeScrollRestoreFallback(
+  pending: ActivityListScrollRestorePending
+): void {
+  strictModeScrollRestoreFallback = pending;
+}
+
+export function takeStrictModeScrollRestoreFallback(): ActivityListScrollRestorePending | null {
+  const pending = strictModeScrollRestoreFallback;
+  strictModeScrollRestoreFallback = null;
+  return pending;
+}
+
+export function clearStrictModeScrollRestoreFallback(): void {
+  strictModeScrollRestoreFallback = null;
+}
+
+export function parseStoredActivityListScrollState(
+  raw: string | null
+): StoredActivityListScrollState | null {
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredActivityListScrollState;
+    const pageIndex = parsed.activityListPageIndex;
+    const containerScrollTop = parsed.activityListScrollTop;
+    const windowScrollTop = parsed.activityListWindowScrollTop;
+    const focusActivityId = parsed.activityListFocusActivityId;
+    return {
+      activityListPageIndex:
+        typeof pageIndex === 'number' &&
+        Number.isInteger(pageIndex) &&
+        pageIndex >= 0
+          ? pageIndex
+          : undefined,
+      activityListScrollTop:
+        typeof containerScrollTop === 'number' &&
+        Number.isFinite(containerScrollTop)
+          ? containerScrollTop
+          : undefined,
+      activityListWindowScrollTop:
+        typeof windowScrollTop === 'number' && Number.isFinite(windowScrollTop)
+          ? windowScrollTop
+          : undefined,
+      activityListFocusActivityId:
+        typeof focusActivityId === 'number' &&
+        Number.isInteger(focusActivityId) &&
+        focusActivityId > 0
+          ? focusActivityId
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredActivityListScrollState(
+  state: StoredActivityListScrollState
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const existing =
+      parseStoredActivityListScrollState(
+        window.sessionStorage.getItem(ACTIVITY_LIST_SCROLL_STATE_KEY)
+      ) ?? {};
+    const merged: StoredActivityListScrollState = { ...existing };
+    if (state.activityListPageIndex !== undefined) {
+      merged.activityListPageIndex = state.activityListPageIndex;
+    }
+    if (state.activityListScrollTop !== undefined) {
+      merged.activityListScrollTop = state.activityListScrollTop;
+    }
+    if (state.activityListWindowScrollTop !== undefined) {
+      merged.activityListWindowScrollTop = state.activityListWindowScrollTop;
+    }
+    if (state.activityListFocusActivityId !== undefined) {
+      merged.activityListFocusActivityId = state.activityListFocusActivityId;
+    }
+    window.sessionStorage.setItem(
+      ACTIVITY_LIST_SCROLL_STATE_KEY,
+      JSON.stringify(merged)
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function clearStoredActivityListScrollState(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(ACTIVITY_LIST_SCROLL_STATE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function hasPendingActivityListScrollRestore(
+  pending: ActivityListScrollRestorePending
+): boolean {
+  return (
+    pending.focusActivityId != null ||
+    pending.pageIndex != null ||
+    pending.containerScrollTop != null ||
+    pending.windowScrollTop != null
+  );
+}
+
+export type ResolveActivityListScrollRestoreOptions = {
+  /** When false, sessionStorage is only used to merge focus id into location.state. */
+  allowSessionStorageFallback?: boolean;
+};
+
+/**
+ * Merges router location.state with sessionStorage so in-app back (state) still
+ * picks up focus id from storage when only partial fields were forwarded.
+ * SessionStorage-only restore is gated by `allowSessionStorageFallback` (browser POP).
+ */
+export function resolveActivityListScrollRestorePending(
+  locationState: unknown,
+  storageRaw: string | null,
+  options?: ResolveActivityListScrollRestoreOptions
+): { pending: ActivityListScrollRestorePending; source: string } | null {
+  const allowSessionStorageFallback =
+    options?.allowSessionStorageFallback ?? false;
+
+  const fromStatePageIndex = getActivityListPageIndex(locationState);
+  const fromStateScrollTop = getActivityListScrollTop(locationState);
+  const fromStateWindowScrollTop =
+    getActivityListWindowScrollTop(locationState);
+  const fromStateFocusActivityId =
+    getActivityListFocusActivityId(locationState);
+
+  const hasStateScrollFields =
+    fromStatePageIndex != null ||
+    fromStateScrollTop != null ||
+    fromStateWindowScrollTop != null ||
+    fromStateFocusActivityId != null;
+
+  const stored =
+    hasStateScrollFields || allowSessionStorageFallback
+      ? parseStoredActivityListScrollState(storageRaw)
+      : null;
+
+  if (!hasStateScrollFields && stored == null) {
+    return null;
+  }
+
+  const pending: ActivityListScrollRestorePending = {
+    pageIndex: fromStatePageIndex ?? stored?.activityListPageIndex ?? null,
+    containerScrollTop:
+      fromStateScrollTop ?? stored?.activityListScrollTop ?? null,
+    windowScrollTop:
+      fromStateWindowScrollTop ?? stored?.activityListWindowScrollTop ?? null,
+    focusActivityId:
+      fromStateFocusActivityId ?? stored?.activityListFocusActivityId ?? null,
+  };
+
+  if (!hasPendingActivityListScrollRestore(pending)) {
+    return null;
+  }
+
+  let source = 'none';
+  if (hasStateScrollFields && stored != null) {
+    source = 'location.state+sessionStorage';
+  } else if (hasStateScrollFields) {
+    source = 'location.state';
+  } else {
+    source = 'sessionStorage';
+  }
+
+  return { pending, source };
+}
+
+export function recordScrollRestoreDebug(
+  event: string,
+  payload: Record<string, unknown>
+): void {
+  if (typeof window === 'undefined') return;
+  if (!import.meta.env.DEV) return;
+  const entry = {
+    event,
+    at: new Date().toISOString(),
+    ...payload,
+  };
+  console.debug('[scroll-restore]', entry);
+  try {
+    const existingRaw = window.sessionStorage.getItem(
+      ACTIVITY_LIST_SCROLL_DEBUG_KEY
+    );
+    const parsed = JSON.parse(existingRaw ?? '[]') as unknown;
+    const existing = Array.isArray(parsed) ? parsed : [];
+    const next = [...existing, entry].slice(-40);
+    window.sessionStorage.setItem(
+      ACTIVITY_LIST_SCROLL_DEBUG_KEY,
+      JSON.stringify(next)
+    );
+  } catch {
+    // ignore
+  }
+}

--- a/calendar-ui/src/pages/ActivityPage.tsx
+++ b/calendar-ui/src/pages/ActivityPage.tsx
@@ -70,10 +70,8 @@ import { useElementIsIntersecting } from '../hooks/useElementIsIntersecting';
 import { useFavourites } from '../hooks/useFavourites';
 import { getActivityFieldLabel } from '../lib/activity-form-labels';
 import {
+  buildActivityListScrollRestoreReturnState,
   getActivityFormBackTarget,
-  getActivityListPageIndex,
-  getActivityListScrollTop,
-  getActivityListWindowScrollTop,
 } from '../lib/activity-form-navigation-state';
 import {
   buildMarkReviewedOnlyPayload,
@@ -404,21 +402,10 @@ export function ActivityPage({
 
   const handleGoBack = useCallback(() => {
     const fromState = getActivityFormBackTarget(location.state);
-    const activityListPageIndex = getActivityListPageIndex(location.state);
-    const activityListScrollTop = getActivityListScrollTop(location.state);
-    const activityListWindowScrollTop = getActivityListWindowScrollTop(
-      location.state
-    );
     if (fromState != null) {
       void navigate(fromState, {
         replace: true,
-        state: {
-          ...(activityListPageIndex != null && { activityListPageIndex }),
-          ...(activityListScrollTop != null && { activityListScrollTop }),
-          ...(activityListWindowScrollTop != null && {
-            activityListWindowScrollTop,
-          }),
-        },
+        state: buildActivityListScrollRestoreReturnState(location.state, id),
       });
       return;
     }
@@ -427,7 +414,7 @@ export function ActivityPage({
     } else {
       void navigate('/');
     }
-  }, [navigate, location.state]);
+  }, [navigate, location.state, id]);
 
   const mayEditFormFields =
     canEditActivity && (!isBlockedStatus || canEditWhenBlocked);


### PR DESCRIPTION
# PR: fix/CORPCAL-280-browser-back-scroll-position → fix/CORPCAL-280-preserve-scroll-position-on-back-navigate-activities

## Summary

Copilot already checked its suggested fix on my local, so figured this would be easier than just sending the comment.

Polishes browser back navigation losing activity list scroll position
- was not functioning for native browser Back
- removes restore when navigating by sidebar or home link (checks for POP type)

Refactors the restore logic from ActivityTable into a dedicated hook.
Builds on the parent branch's scroll-preservation work with sessionStorage fallback.

## Changes

1. **Browser back scroll restore:** sessionStorage merge and `useLayoutEffect` restore before paint.
   - Fallback when `location.state` is empty after browser back.
   - SessionStorage-only restore is now gated on useNavigationType() being POP (previously restored whenever list loaded with empty location.state, which could include sidebar/link navigation); this removes unexpected/state scroll position on sidebar navigation.
2. **Scroll restore extraction:** move logic out of `ActivityTable`.
   - moves out inline logic to `useActivityListScrollRestore` hook and `activity-list-scroll-restore` lib.
   - `activityListFocusActivityId` on navigation state; `ActivityPage` uses `buildActivityListScrollRestoreReturnState`.

## Testing

- Vitest: `ActivityTable.spec`, `activity-form-navigation-state.spec`, `activity-list-scroll-restore.spec` (via lint-staged).
- Manual: open activity from list → browser back → list scroll and page position restored.
