### PR TITLE
fix(pitch status visibility): visible to all users. Editable by advan…

### DIFF
--- a/docs/AUTH_AND_RBAC.md
+++ b/docs/AUTH_AND_RBAC.md
@@ -491,7 +491,7 @@ Users who can see an activity only because it is **shared with** one of their te
 
 List and detail activity responses run `redactActivityResponse` in the activities controller. For scopes that have an `activities.<scope>.view` permission, the user must hold that permission, the matching `activities.<scope>.edit` permission (edit implies view), or a role that bypasses field view checks (Advanced Viewer, Advanced Editor, Admin, System Admin). Otherwise those response fields are omitted.
 
-Some scopes **do not** define a view permission: **translations**, **pitch required status**, and **pitch date** are always included for users who can access the activity; editing them still requires the corresponding `activities.<scope>.edit` grants where applicable.
+Some scopes **do not** enforce a view permission: **translations**, **pitch required status**, and **pitch date** are always included for users who can access the activity; editing them still requires the corresponding `activities.<scope>.edit` grants where applicable.
 
 #### Using dataScope in controllers and services
 

--- a/docs/AUTH_AND_RBAC.md
+++ b/docs/AUTH_AND_RBAC.md
@@ -491,7 +491,7 @@ Users who can see an activity only because it is **shared with** one of their te
 
 List and detail activity responses run `redactActivityResponse` in the activities controller. For scopes that have an `activities.<scope>.view` permission, the user must hold that permission, the matching `activities.<scope>.edit` permission (edit implies view), or a role that bypasses field view checks (Advanced Viewer, Advanced Editor, Admin, System Admin). Otherwise those response fields are omitted.
 
-Some scopes **do not** define a view permission: **translations** and **pitch date** are always included for users who can access the activity; editing them still requires the corresponding `activities.<scope>.edit` grants where applicable.
+Some scopes **do not** define a view permission: **translations**, **pitch required status**, and **pitch date** are always included for users who can access the activity; editing them still requires the corresponding `activities.<scope>.edit` grants where applicable.
 
 #### Using dataScope in controllers and services
 

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -256,7 +256,7 @@ The schema is defined in `src/schema/`:
 
 ## Field-level activity permissions
 
-Seed `seeds/0006_20260331_field_level_permissions_seed.sql` defines granular `activities.<scope>.view` / `activities.<scope>.edit` rows. **View** permissions exist for `notes`, `lookAhead`, and `pitchStatus` (API may omit those fields when the user lacks view access). **Pitch date** and **translations** use **edit-only** field permissions where applicable (no separate view permission for pitch date; anyone who can view the activity sees those values).
+Seed `seeds/0006_20260331_field_level_permissions_seed.sql` defines granular `activities.<scope>.view` / `activities.<scope>.edit` rows. **View** permissions are enforced for `notes` and `lookAhead` (API may omit those fields when the user lacks view access). **Pitch required status**, **pitch date**, and **translations** are visible to all users who can view the activity; editing still requires the corresponding `activities.<scope>.edit` grants.
 
 Seeds are tracked in `_seed_history` by **filename**. If you renumber or merge seed files on a database that was seeded with older names, run seeds with `force: true` (where the CLI or API exposes it), truncate `_seed_history`, or wipe the database so every file runs again in order.
 

--- a/packages/database/seeds/0013_20260727_pitch_status_edit_advanced_editor_plus_seed.sql
+++ b/packages/database/seeds/0013_20260727_pitch_status_edit_advanced_editor_plus_seed.sql
@@ -1,0 +1,17 @@
+-- Enforce pitch-required status edit access for Advanced Editor+ roles only.
+-- Idempotent and safe to re-run.
+
+-- Remove legacy team-scoped edit grants that could allow non-elevated edits.
+DELETE FROM team_permissions tp
+USING permissions p
+WHERE tp.permission_id = p.id
+  AND p.key = 'activities.pitchStatus.edit';
+
+-- Grant pitch status edit to Advanced Editor, Admin, and System Admin roles.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name IN ('Advanced Editor', 'Admin', 'System Admin')
+  AND p.key = 'activities.pitchStatus.edit'
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/packages/database/seeds/0013_20260727_pitch_status_edit_advanced_editor_plus_seed.sql
+++ b/packages/database/seeds/0013_20260727_pitch_status_edit_advanced_editor_plus_seed.sql
@@ -14,4 +14,4 @@ FROM roles r
 CROSS JOIN permissions p
 WHERE r.name IN ('Advanced Editor', 'Admin', 'System Admin')
   AND p.key = 'activities.pitchStatus.edit'
-ON CONFLICT (role_id, permission_id) DO NOTHING;
+ON CONFLICT (role_id, permission_id) DO UPDATE SET is_active = true, updated_at = now();

--- a/packages/shared/src/auth/activity-field-scopes.test.ts
+++ b/packages/shared/src/auth/activity-field-scopes.test.ts
@@ -61,22 +61,22 @@ describe('canViewActivityFieldScope', () => {
   it('returns false for view-restricted scopes when Viewer lacks grants', () => {
     expect(canViewActivityFieldScope(viewer, 'notes')).toBe(false);
     expect(canViewActivityFieldScope(viewer, 'lookAhead')).toBe(false);
-    expect(canViewActivityFieldScope(viewer, 'pitchStatus')).toBe(false);
   });
 
-  it('returns true for translations and pitchDate without grants (no view permission)', () => {
+  it('returns true for translations, pitchStatus, and pitchDate without grants (no view permission)', () => {
     expect(canViewActivityFieldScope(viewer, 'translations')).toBe(true);
+    expect(canViewActivityFieldScope(viewer, 'pitchStatus')).toBe(true);
     expect(canViewActivityFieldScope(viewer, 'pitchDate')).toBe(true);
   });
 
   it('returns false for view-restricted scopes when Editor lacks grants', () => {
     expect(canViewActivityFieldScope(editor, 'notes')).toBe(false);
     expect(canViewActivityFieldScope(editor, 'lookAhead')).toBe(false);
-    expect(canViewActivityFieldScope(editor, 'pitchStatus')).toBe(false);
   });
 
-  it('returns true for translations and pitchDate when Editor lacks other grants', () => {
+  it('returns true for translations, pitchStatus, and pitchDate when Editor lacks other grants', () => {
     expect(canViewActivityFieldScope(editor, 'translations')).toBe(true);
+    expect(canViewActivityFieldScope(editor, 'pitchStatus')).toBe(true);
     expect(canViewActivityFieldScope(editor, 'pitchDate')).toBe(true);
   });
 
@@ -150,8 +150,8 @@ describe('getViewableFieldScopes', () => {
     const result = getViewableFieldScopes(viewer);
     expect(result.has('translations')).toBe(true);
     expect(result.has('pitchDate')).toBe(true);
-    expect(result.has('pitchStatus')).toBe(false);
-    expect(result.size).toBe(2);
+    expect(result.has('pitchStatus')).toBe(true);
+    expect(result.size).toBe(3);
   });
 
   it('returns all scopes for Advanced Viewer', () => {
@@ -164,8 +164,9 @@ describe('getViewableFieldScopes', () => {
     const result = getViewableFieldScopes(editorWithNotesGrant);
     expect(result.has('notes')).toBe(true);
     expect(result.has('translations')).toBe(true);
+    expect(result.has('pitchStatus')).toBe(true);
     expect(result.has('pitchDate')).toBe(true);
-    expect(result.size).toBe(3);
+    expect(result.size).toBe(4);
   });
 });
 

--- a/packages/shared/src/auth/activity-field-scopes.ts
+++ b/packages/shared/src/auth/activity-field-scopes.ts
@@ -6,7 +6,7 @@
  *
  * View rule (scopes with a view permission): has <scope>.view OR <scope>.edit OR role is
  * Advanced Viewer / Advanced Editor / Admin / System Admin.
- * Scopes without a view permission (translations, pitchDate) are always visible; edit is still gated.
+ * Scopes without a view permission (translations, pitchStatus, pitchDate) are always visible; edit is still gated.
  * Edit rule: has <scope>.edit only (no role bypass).
  */
 
@@ -59,7 +59,7 @@ export const ACTIVITY_FIELD_SCOPE_CONFIG: Record<
     requestFields: ['translationsRequiredStatusId', 'translationLanguageIds'],
   },
   pitchStatus: {
-    viewKey: PERMISSIONS.ACTIVITIES.PITCH_STATUS_VIEW,
+    viewKey: null,
     editKey: PERMISSIONS.ACTIVITIES.PITCH_STATUS_EDIT,
     responseFields: ['pitchRequiredStatusId', 'pitchRequiredStatus'],
     requestFields: ['pitchRequiredStatusId'],

--- a/packages/shared/src/utils/redact-activity-response.test.ts
+++ b/packages/shared/src/utils/redact-activity-response.test.ts
@@ -109,7 +109,7 @@ describe('redactActivityResponse', () => {
     expect(result.pitchDate).toBe('2025-03-01');
   });
 
-  it('strips pitch status but keeps pitch date when pitch status is not viewable', () => {
+  it('keeps pitch status and pitch date when pitch status is globally viewable', () => {
     const viewerNoPitchStatus = {
       permissions: [
         'activities.view',
@@ -119,12 +119,12 @@ describe('redactActivityResponse', () => {
       roleName: SYSTEM_ROLES.EDITOR,
     };
     const result = redactActivityResponse(activity, viewerNoPitchStatus);
-    expect(result.pitchRequiredStatusId).toBeUndefined();
-    expect(result.pitchRequiredStatus).toBeUndefined();
+    expect(result.pitchRequiredStatusId).toBe(2);
+    expect(result.pitchRequiredStatus).toBe('Required');
     expect(result.pitchDate).toBe('2025-03-01');
   });
 
-  it('strips view-restricted fields for Viewer without grants; keeps date/time status, translations, and pitch date', () => {
+  it('strips view-restricted fields for Viewer without grants; keeps date/time status, translations, pitch status, and pitch date', () => {
     const result = redactActivityResponse(activity, viewerNoGrants);
     expect(result.notes).toBeUndefined();
     expect(result.dateStatusId).toBe(2);
@@ -136,8 +136,8 @@ describe('redactActivityResponse', () => {
     expect(result.translationsRequired).toEqual(['French']);
     expect(result.translationsRequiredStatusId).toBe(1);
     expect(result.translationsRequiredStatus).toBe('Pending');
-    expect(result.pitchRequiredStatusId).toBeUndefined();
-    expect(result.pitchRequiredStatus).toBeUndefined();
+    expect(result.pitchRequiredStatusId).toBe(2);
+    expect(result.pitchRequiredStatus).toBe('Required');
     expect(result.pitchDate).toBe('2025-03-01');
   });
 


### PR DESCRIPTION
CORPCAL-283: Make pitch required visible to all users; restrict edits to Advanced Editor+

Summary:
This change updates field-scope policy for pitch required status so that all users who can view an activity can also view pitch required status, while editing remains restricted to elevated roles.

I did not make any UI changes around being read-only beyond what is in the rest of the form. 