### PR TITLE
style(filters): improve sematics of filter text

### DIFF
--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTableEmptyState.spec.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTableEmptyState.spec.tsx
@@ -40,7 +40,7 @@ describe('ActivityTableEmptyState', () => {
       screen.getByText('No activities match the current filters')
     ).toBeInTheDocument();
     const clearButton = screen.getByRole('button', {
-      name: /clear all filters/i,
+      name: /reset all filters/i,
     });
     await userEvent.click(clearButton);
     expect(onClearFilters).toHaveBeenCalledTimes(1);
@@ -66,7 +66,7 @@ describe('ActivityTableEmptyState', () => {
     );
 
     expect(
-      screen.queryByRole('button', { name: /clear all filters/i })
+      screen.queryByRole('button', { name: /reset all filters/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTableEmptyState.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTableEmptyState.tsx
@@ -45,7 +45,7 @@ export function ActivityTableEmptyState({
           onClick={onClearFilters}
           className="mt-4 text-sm font-medium text-slate-700 underline hover:text-slate-900"
         >
-          Clear all filters
+          Reset all filters
         </button>
       ) : null}
     </div>

--- a/calendar-ui/src/components/shared/ResponsiveFilterRow.tsx
+++ b/calendar-ui/src/components/shared/ResponsiveFilterRow.tsx
@@ -1060,7 +1060,7 @@ export function ResponsiveFilterRow({
                           onPointerDown={handleClearAllPointerDown}
                           onClick={handleClearAllClick}
                           className={filterTriggerStyles.clearIcon}
-                          aria-label="Clear all filters"
+                          aria-label="Reset all filters"
                         >
                           <X className="h-3.5 w-3.5" />
                         </span>

--- a/calendar-ui/src/components/table/TableSummaryBar.tsx
+++ b/calendar-ui/src/components/table/TableSummaryBar.tsx
@@ -153,7 +153,7 @@ interface TableSummaryBarProps {
   appliedFilterTypeLabels?: string[];
   /** Defaults to 3; remainder summarized as “+n more”. */
   maxVisibleFilterTypes?: number;
-  /** When set, renders a compact “Clear filters” control for all breakpoints. */
+  /** When set, renders a compact “Reset all filters” control for all breakpoints. */
   onClearFilters?: () => void;
   /**
    * When non-empty, an info control before the summary opens a read-only popover with one row
@@ -261,10 +261,10 @@ export function TableSummaryBar({
             type="button"
             onClick={onClearFilters}
             className="text-muted-foreground hover:text-foreground hover:bg-accent focus-visible:ring-ring/50 inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-normal transition-colors outline-none focus-visible:ring-[3px]"
-            aria-label="Clear all filters"
+            aria-label="Reset all filters"
           >
             <X className="size-3 shrink-0" aria-hidden />
-            Clear all filters
+            Reset all filters
           </button>
         ) : null}
       </span>


### PR DESCRIPTION
## Summary

Improves semantics of remove filters text.
On the reports page, baseline default date filter is maintained when onClear is clicked. PR updates to "Reset all filters", which is more flexible.