### PR TITLE
Style/corpcal 000 increase table h

### DIFF
--- a/calendar-ui/src/components/layout/PageHeader.tsx
+++ b/calendar-ui/src/components/layout/PageHeader.tsx
@@ -2,28 +2,21 @@ import { type ReactNode } from 'react';
 
 interface PageHeaderProps {
   title: string;
-  description?: string;
   action?: ReactNode;
   className?: string;
 }
 
 /**
  * Reusable page header component with consistent styling.
- * Provides a title, optional description, and optional action element.
+ * Provides a title and optional action element.
  */
-export function PageHeader({
-  title,
-  description,
-  action,
-  className = '',
-}: PageHeaderProps) {
+export function PageHeader({ title, action, className = '' }: PageHeaderProps) {
   return (
     <div
-      className={`${className} mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between`}
+      className={`${className} mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between`}
     >
       <div>
         <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
-        <p className="text-sm text-slate-600">{description}</p>
       </div>
       {action && <div className="shrink-0">{action}</div>}
     </div>

--- a/calendar-ui/src/components/table/tableConstants.ts
+++ b/calendar-ui/src/components/table/tableConstants.ts
@@ -3,13 +3,26 @@
  * Use these to keep table layout and styling consistent and avoid drift.
  */
 
-/** Scroll area height for data tables. Used by TableScrollContainer so Users table and EventTable (Calendar Entries) share the same height and behavior. */
-export const TABLE_SCROLL_HEIGHT =
-  'max(240px, min(720px, 60vh, 100vh - 400px))';
+/**
+ * Viewport-based table height: reserve space for everything except the scroll container
+ * (page padding, pagination, filters/header/tabs/summary, borders) so {@link SidebarInset}
+ * does not scroll. Tune this single offset if parent scroll appears after layout changes.
+ */
+const TABLE_SCROLL_PAGE_OFFSET = '24.25rem';
 
-/** Print preview scroll height; same as {@link TABLE_SCROLL_HEIGHT} minus the preview toolbar row (h-9). */
-export const REPORT_PRINT_PREVIEW_SCROLL_HEIGHT =
-  'max(240px, min(720px, 60vh, 100vh - 436px))';
+/** Upper bound for the scroll area on very tall viewports. */
+const TABLE_SCROLL_VIEWPORT_MAX = '1200px';
+
+/** Print preview toolbar (h-9) below the same chrome as data tables. */
+const REPORT_PRINT_PREVIEW_TOOLBAR = '2.25rem';
+
+const TABLE_SCROLL_VIEWPORT_HEIGHT = `calc(100svh - var(--header-height, 3.5rem) - ${TABLE_SCROLL_PAGE_OFFSET})`;
+
+/** Scroll area height for data tables. Used by TableScrollContainer so Users table and EventTable (Calendar Entries) share the same height and behavior. */
+export const TABLE_SCROLL_HEIGHT = `max(240px, min(${TABLE_SCROLL_VIEWPORT_MAX}, ${TABLE_SCROLL_VIEWPORT_HEIGHT}))`;
+
+/** Print preview scroll height; same viewport reserve as {@link TABLE_SCROLL_HEIGHT} minus the preview toolbar row (h-9). */
+export const REPORT_PRINT_PREVIEW_SCROLL_HEIGHT = `max(240px, min(${TABLE_SCROLL_VIEWPORT_MAX}, calc(${TABLE_SCROLL_VIEWPORT_HEIGHT} - ${REPORT_PRINT_PREVIEW_TOOLBAR})))`;
 
 /** Min-width for filter/sort dropdown and popover panels. Use as className (e.g. with cn()) so base components stay flexible. */
 export const FILTER_PANEL_MIN_WIDTH = 'min-w-[180px]';

--- a/calendar-ui/src/components/table/tableConstants.ts
+++ b/calendar-ui/src/components/table/tableConstants.ts
@@ -8,7 +8,8 @@
  * (page padding, pagination, filters/header/tabs/summary, borders) so {@link SidebarInset}
  * does not scroll. Tune this single offset if parent scroll appears after layout changes.
  */
-const TABLE_SCROLL_PAGE_OFFSET = '24.25rem';
+/** Compact {@link PageHeader} (mb-4, title only); reduce if parent scroll appears. */
+const TABLE_SCROLL_PAGE_OFFSET = '22.5rem';
 
 /** Upper bound for the scroll area on very tall viewports. */
 const TABLE_SCROLL_VIEWPORT_MAX = '1200px';

--- a/calendar-ui/src/pages/ActivityListPage.tsx
+++ b/calendar-ui/src/pages/ActivityListPage.tsx
@@ -188,7 +188,6 @@ export const ActivityListPage = () => {
     <>
       <PageHeader
         title="Calendar activities"
-        description="View and manage calendar activities"
         action={
           canCreateActivity ? (
             <Button asChild>

--- a/calendar-ui/src/pages/CreateActivityForm.tsx
+++ b/calendar-ui/src/pages/CreateActivityForm.tsx
@@ -208,10 +208,7 @@ export const CreateActivityForm: FC = () => {
   return (
     <ErrorBoundary FallbackComponent={FormErrorFallback}>
       <ActivityFormStickyHeader />
-      <PageHeader
-        title="Create New Activity"
-        description="Fill in the activity details below"
-      />
+      <PageHeader title="Create New Activity" />
 
       <Form {...form}>
         <form

--- a/calendar-ui/src/pages/GlobalHistory.tsx
+++ b/calendar-ui/src/pages/GlobalHistory.tsx
@@ -794,7 +794,7 @@ export function GlobalHistory() {
       </Tabs>
 
       <div className="mb-2 flex flex-wrap items-center gap-3">
-        <div className="relative w-[240px] max-w-[240px] min-w-[240px]">
+        <div className="relative w-60 max-w-60 min-w-60">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
           <Input
             type="text"

--- a/calendar-ui/src/pages/ReportsPage.tsx
+++ b/calendar-ui/src/pages/ReportsPage.tsx
@@ -609,7 +609,6 @@ export function ReportsPage() {
     <>
       <PageHeader
         title="Reports"
-        description="Generate and export various activity reports"
         action={
           <div className="flex flex-wrap items-center gap-2">
             <Button

--- a/calendar-ui/src/pages/Settings.test.tsx
+++ b/calendar-ui/src/pages/Settings.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { render, screen } from '@/test/test-utils';
+import { render, screen, within } from '@/test/test-utils';
+
+import { Settings } from './Settings';
 
 // Mock every child admin section so the test only exercises Settings itself.
 vi.mock('@/components/admin', () => ({
@@ -83,8 +85,15 @@ const LOOKUP_LINKS = [
   'Tags',
   'Activity statuses',
   'Themes',
-  'Venue presets',
+  'Venue Presets',
 ];
+
+function getQuickNavLinks() {
+  const nav = screen.getByRole('navigation', {
+    name: /settings quick navigation/i,
+  });
+  return within(nav);
+}
 
 describe('Settings quick navigation', () => {
   beforeEach(() => {
@@ -99,24 +108,24 @@ describe('Settings quick navigation', () => {
       });
     });
 
-    it('shows all system-admin-only quick nav links', async () => {
-      const { Settings } = await import('./Settings');
+    it('shows all system-admin-only quick nav links', () => {
       render(<Settings />);
+      const quickNav = getQuickNavLinks();
 
       for (const label of SYSTEM_ADMIN_ONLY_LINKS) {
         expect(
-          screen.getByRole('link', { name: new RegExp(label, 'i') })
+          quickNav.getByRole('link', { name: new RegExp(label, 'i') })
         ).toBeInTheDocument();
       }
     });
 
-    it('shows all lookup quick nav links', async () => {
-      const { Settings } = await import('./Settings');
+    it('shows all lookup quick nav links', () => {
       render(<Settings />);
+      const quickNav = getQuickNavLinks();
 
       for (const label of LOOKUP_LINKS) {
         expect(
-          screen.getByRole('link', { name: new RegExp(label, 'i') })
+          quickNav.getByRole('link', { name: new RegExp(label, 'i') })
         ).toBeInTheDocument();
       }
     });
@@ -130,24 +139,24 @@ describe('Settings quick navigation', () => {
       });
     });
 
-    it('hides system-admin-only quick nav links', async () => {
-      const { Settings } = await import('./Settings');
+    it('hides system-admin-only quick nav links', () => {
       render(<Settings />);
+      const quickNav = getQuickNavLinks();
 
       for (const label of SYSTEM_ADMIN_ONLY_LINKS) {
         expect(
-          screen.queryByRole('link', { name: new RegExp(label, 'i') })
+          quickNav.queryByRole('link', { name: new RegExp(label, 'i') })
         ).not.toBeInTheDocument();
       }
     });
 
-    it('still shows all lookup quick nav links', async () => {
-      const { Settings } = await import('./Settings');
+    it('still shows all lookup quick nav links', () => {
       render(<Settings />);
+      const quickNav = getQuickNavLinks();
 
       for (const label of LOOKUP_LINKS) {
         expect(
-          screen.getByRole('link', { name: new RegExp(label, 'i') })
+          quickNav.getByRole('link', { name: new RegExp(label, 'i') })
         ).toBeInTheDocument();
       }
     });

--- a/calendar-ui/src/pages/Settings.tsx
+++ b/calendar-ui/src/pages/Settings.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/components/admin/LookupAdmins';
 import { ReportCoverContactSettingsAdmin } from '@/components/admin/ReportCoverContactSettingsAdmin';
 import { ReviewExemptFieldsSettingsAdmin } from '@/components/admin/ReviewExemptFieldsSettingsAdmin';
+import { PageHeader } from '@/components/layout';
 import { useAuth } from '@/hooks/useAuth';
 
 type Section =
@@ -166,17 +167,13 @@ export function Settings() {
 
   return (
     <>
-      <h1 className="mb-2 text-2xl font-bold text-slate-900 sm:text-3xl">
-        Settings and configuration
-      </h1>
-      <p className="mb-8 text-sm text-slate-600 sm:text-base">
-        Manage lookup data and system configuration
-      </p>
+      <PageHeader title="Settings and configuration" />
 
       <div>
         {/* Quick Navigation */}
-        <div
+        <nav
           id="quick-navigation"
+          aria-label="Settings quick navigation"
           className="mb-8 rounded-lg border border-slate-200 bg-white shadow-sm"
         >
           <div className="border-b border-slate-200 p-4 sm:p-6">
@@ -206,7 +203,7 @@ export function Settings() {
               })}
             </div>
           </div>
-        </div>
+        </nav>
 
         {/* Admin Sections */}
         <div className="space-y-8">

--- a/calendar-ui/src/pages/UserManagement.tsx
+++ b/calendar-ui/src/pages/UserManagement.tsx
@@ -152,11 +152,7 @@ export function Users() {
 
   return (
     <>
-      <PageHeader
-        title="User & Team Management"
-        description="Manage user accounts, teams, and roles"
-        action={headerAction}
-      />
+      <PageHeader title="User & Team Management" action={headerAction} />
 
       <Tabs
         value={activeTab}

--- a/docs/REPORTS_IMPLEMENTATION.md
+++ b/docs/REPORTS_IMPLEMENTATION.md
@@ -77,7 +77,7 @@ Core Methods:
 
 Matches Activity List View pattern:
 
-1. **PageHeader** with title, description, and Export button (top right)
+1. **PageHeader** with title and Export button (top right)
 2. **Tabs** - Report type selection at top (matches Activity List tabs)
    - Initially loads from stored sessionStorage preference
    - Auto-initializes to first report if none stored


### PR DESCRIPTION
# PR: style/CORPCAL-000-increase-table-h

## Summary

Increase shared table scroll constant (Users, Teams, Calendar Entries, report previews) without scrolling the main layout past pagination (per feedback). Page headers height reduced are title-only and consistent across management pages.

## Changes

1. **Table scroll height:** viewport-based sizing in `tableConstants`.
   - Cap raised from 720px to 1200px
   - `100svh`, `--header-height`, and `TABLE_SCROLL_PAGE_OFFSET` (22.5rem)
   - Print preview uses the same reserve minus the toolbar row

2. **PageHeader:** title + optional action only.
   - Removed `description`; `mb-4`
   - Callsites updated (Users, Activities, Reports, Create activity, Settings)

3. **Settings:** shared `PageHeader` and labelled quick-nav `<nav>`.

4. **Tests/docs:** scoped Settings quick-nav assertions; reports doc tweak; History search width token (`w-60`).

## Testing

- `npm run test -- --run` in `calendar-ui`
- Manual: Users/Teams, Calendar activities, Reports preview, History — table scrolls inside container; pagination visible without extra page scroll
