### PR TITLE
fix(database): ensure public schema before extensions migration

### DIFF
--- a/packages/database/migrations/0000_20260728_postgresql_extensions.sql
+++ b/packages/database/migrations/0000_20260728_postgresql_extensions.sql
@@ -1,5 +1,8 @@
--- PostgreSQL instance setup: extensions and other DDL that Drizzle cannot express in schema.
--- Keep this migration first so later migrations can depend on installed extensions (e.g. pg_trgm for GIN indexes).
--- Safe to append additional CREATE EXTENSION or similar setup statements here.
+-- PostgreSQL extensions setup: Drizzle cannot express in schema.
+
+-- Required when public was dropped (e.g. DROP SCHEMA public CASCADE) without recreating it.
+CREATE SCHEMA IF NOT EXISTS public;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO public;
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/packages/database/scripts/drizzle-migration-helper.js
+++ b/packages/database/scripts/drizzle-migration-helper.js
@@ -70,10 +70,19 @@ try {
     cwd: packageDir,
     shell: true,
   });
+} catch (error) {
+  console.error('');
+  console.error('Failed to generate migration');
+  if (error.message) {
+    console.error(`Error: ${error.message}`);
+  }
+  process.exit(1);
+}
 
-  console.log('');
-  console.log(`Migration "${migrationName}" generated`);
+console.log('');
+console.log(`Migration "${migrationName}" generated`);
 
+try {
   const journalPath = path.join(packageDir, 'migrations/meta/_journal.json');
   if (fs.existsSync(journalPath)) {
     const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
@@ -92,7 +101,9 @@ try {
   }
 } catch (error) {
   console.error('');
-  console.error('Failed to generate migration');
+  console.error(
+    'Migration was generated, but inserting PostgreSQL extensions migration failed'
+  );
   if (error.message) {
     console.error(`Error: ${error.message}`);
   }

--- a/packages/database/scripts/drizzle-migration-helper.js
+++ b/packages/database/scripts/drizzle-migration-helper.js
@@ -3,6 +3,9 @@
 /**
  * Wrapper script for drizzle-kit generate that enforces a migration name.
  *
+ * After a dev squash (exactly one journal entry), runs ensure-postgresql-extensions-first
+ * so the extensions template (public schema + pg_trgm) is inserted as migration 0000.
+ *
  * Usage:
  *   node scripts/generate-migration.js <migration_name>
  *
@@ -11,6 +14,7 @@
  */
 
 const { execSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 // Get the migration name from command line arguments
@@ -69,6 +73,23 @@ try {
 
   console.log('');
   console.log(`Migration "${migrationName}" generated`);
+
+  const journalPath = path.join(packageDir, 'migrations/meta/_journal.json');
+  if (fs.existsSync(journalPath)) {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+    const entryCount = journal.entries?.length ?? 0;
+    if (entryCount === 1) {
+      console.log('');
+      console.log(
+        'Single migration detected (dev squash). Inserting PostgreSQL extensions migration...'
+      );
+      execSync('node scripts/ensure-postgresql-extensions-first.js', {
+        stdio: 'inherit',
+        cwd: packageDir,
+        shell: true,
+      });
+    }
+  }
 } catch (error) {
   console.error('');
   console.error('Failed to generate migration');

--- a/packages/database/scripts/templates/postgresql_extensions.sql
+++ b/packages/database/scripts/templates/postgresql_extensions.sql
@@ -2,4 +2,9 @@
 -- Keep this migration first so later migrations can depend on installed extensions (e.g. pg_trgm for GIN indexes).
 -- Safe to append additional CREATE EXTENSION or similar setup statements here.
 
+-- Required when public was dropped (e.g. DROP SCHEMA public CASCADE) without recreating it.
+CREATE SCHEMA IF NOT EXISTS public;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO public;
+
 CREATE EXTENSION IF NOT EXISTS pg_trgm;


### PR DESCRIPTION
Polish to ensure public schema is created before extensions are migrated.
- recreate public schema and grants in the extensions migration and template
- fixes db:migrate when public was dropped without being recreated
- run ensure-postgresql-extensions-first after squash db:generate (single journal entry)