### PR TITLE
fix(ui-build): migrate optimizeDeps to rolldown and clean build warni…

### DIFF
--- a/calendar-ui/src/components/layout/SystemBanner.tsx
+++ b/calendar-ui/src/components/layout/SystemBanner.tsx
@@ -43,15 +43,15 @@ export function SystemBanner({
           <div
             className={
               'min-w-0 flex-1 text-sm leading-6 whitespace-pre-wrap ' +
-              '[&_strong]:font-semibold ' +
-              '[&_p]:m-0 [&_p]:inline ' +
+              '[_&strong]:font-semibold ' +
+              '[_&p]:m-0 [&_p]:inline ' +
               // default anchor styling (but don't override elements that already have a bg- utility)
-              '[&_a]:opacity-90 [&_a]:transition-opacity [&_a:hover]:opacity-100 ' +
+              '[_&a]:opacity-90 [&_a]:transition-opacity [&_a:hover]:opacity-100 ' +
               '[&_a:not([class*="bg-"])]:bg-[#ffffff] [&_a:not([class*="bg-"])]:text-current ' +
-              '[&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 ' +
-              '[&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 ' +
+              '[_&code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 ' +
+              '[_&ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 ' +
               // default button styling when no explicit bg utility provided
-              '[&_button]:ml-2 [&_button]:inline-block [&_button]:rounded [&_button]:border [&_button]:border-current [&_button]:bg-transparent [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs [&_button]:font-medium [&_button]:transition-all [&_button:hover]:bg-current [&_button:hover]:text-white ' +
+              '[_&button]:inline-block [&_button]:ml-2 [&_button]:rounded [&_button]:border [&_button]:border-current [&_button]:bg-transparent [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs [&_button]:font-medium [&_button]:transition-all [&_button:hover]:bg-current [&_button:hover]:text-white ' +
               '[&_button:not([class*="bg-"])]:bg-[#ffffff]'
             }
             dangerouslySetInnerHTML={{ __html: sanitizedContent }}

--- a/calendar-ui/src/components/layout/SystemBanner.tsx
+++ b/calendar-ui/src/components/layout/SystemBanner.tsx
@@ -43,15 +43,15 @@ export function SystemBanner({
           <div
             className={
               'min-w-0 flex-1 text-sm leading-6 whitespace-pre-wrap ' +
-              '[_&strong]:font-semibold ' +
-              '[_&p]:m-0 [&_p]:inline ' +
+              '[&_strong]:font-semibold ' +
+              '[&_p]:m-0 [&_p]:inline ' +
               // default anchor styling (but don't override elements that already have a bg- utility)
-              '[_&a]:opacity-90 [&_a]:transition-opacity [&_a:hover]:opacity-100 ' +
+              '[&_a]:opacity-90 [&_a]:transition-opacity [&_a:hover]:opacity-100 ' +
               '[&_a:not([class*="bg-"])]:bg-[#ffffff] [&_a:not([class*="bg-"])]:text-current ' +
-              '[_&code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 ' +
-              '[_&ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 ' +
+              '[&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 ' +
+              '[&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 ' +
               // default button styling when no explicit bg utility provided
-              '[_&button]:inline-block [&_button]:ml-2 [&_button]:rounded [&_button]:border [&_button]:border-current [&_button]:bg-transparent [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs [&_button]:font-medium [&_button]:transition-all [&_button:hover]:bg-current [&_button:hover]:text-white ' +
+              '[&_button]:ml-2 [&_button]:inline-block [&_button]:rounded [&_button]:border [&_button]:border-current [&_button]:bg-transparent [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs [&_button]:font-medium [&_button]:transition-all [&_button:hover]:bg-current [&_button:hover]:text-white ' +
               '[&_button:not([class*="bg-"])]:bg-[#ffffff]'
             }
             dangerouslySetInnerHTML={{ __html: sanitizedContent }}

--- a/calendar-ui/vite.config.ts
+++ b/calendar-ui/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, type PluginOption } from 'vite';
 
 import { vendorCodeSplittingGroups } from './vite-chunk-groups';
 
-// Dev (optimizeDeps) and prod (build) must use the same esbuild target. Default
+// Dev (optimizeDeps) and prod (build) must use the same transform target. Default
 // legacy targets cause "Transforming destructuring ... is not supported yet" when
 // pre-bundling modern dependencies (@base-ui/react, reselect, etc.).
 const buildTarget = 'es2022';
@@ -59,8 +59,10 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    esbuildOptions: {
-      target: buildTarget,
+    rolldownOptions: {
+      transform: {
+        target: buildTarget,
+      },
     },
   },
   build: {
@@ -68,6 +70,9 @@ export default defineConfig({
     sourcemap: true,
     // React Compiler and deps assume modern runtimes.
     target: buildTarget,
+    // Current largest chunks are expected (vendor/exceljs); keep warnings meaningful
+    // without noisy output until deeper chunking work lands.
+    chunkSizeWarningLimit: 1000,
     rolldownOptions: {
       output: {
         codeSplitting: {


### PR DESCRIPTION
 migrate optimizeDeps to rolldown and clean build warning noise

replace deprecated optimizeDeps.esbuildOptions with optimizeDeps.rolldownOptions fix Tailwind arbitrary selector syntax in SystemBanner rich-text styles set build.chunkSizeWarningLimit to align warning output with current bundle profile remove Vite deprecation warning and CSS parser warnings from calendar-ui build