### PR TITLE
Fix/corpcal 284 update user views c

### DIFF
--- a/calendar-service/API.md
+++ b/calendar-service/API.md
@@ -322,6 +322,62 @@ This endpoint is intended for team/user-management views that only need counts, 
 
 ---
 
+### Get User Activities (comms scope)
+
+**GET** `/users/:id/activities`
+
+Returns activities where the user has an active comms contact row. Deleted activities are excluded.
+
+**Query parameters**
+
+| Parameter    | Type    | Description                                                                                                 |
+| ------------ | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `fromTeamId` | integer | Optional. When set, only activities with `leadTeamId === fromTeamId` are returned (transfer/removal scope). |
+
+**Example:** `GET /users/12/activities?fromTeamId=3`
+
+**Response:** `200 OK` — `{ "success": true, "data": [{ "id", "label", "value", "isLead" }, ...] }`
+
+---
+
+### Transfer activities
+
+**POST** `/users/:id/transfer-activities`
+
+**Permission:** `users.transfer_activities`
+
+Transfers comms assignments from the source user to `targetUserId` for activities led by `fromTeamId`. The source user must be an active member of `fromTeamId`.
+
+**Body**
+
+| Field            | Type      | Required | Description                                                                                                      |
+| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `targetUserId`   | integer   | yes      | User receiving comms                                                                                             |
+| `fromTeamId`     | integer   | yes      | Lead team scope                                                                                                  |
+| `toTeamId`       | integer   | no       | Destination lead team; defaults to `fromTeamId`                                                                  |
+| `activityIds`    | integer[] | no       | Subset of scoped activities. **Omit** to include all scoped activities. An **explicit empty array is rejected**. |
+| `includeNonLead` | boolean   | yes      | When false, non-lead comms stay unless a cross-team move makes them ineligible                                   |
+| `notes`          | string    | no       | Optional audit note                                                                                              |
+
+**Responses**
+
+- `200 OK` — `{ "success": true, "transferredCount": number }` where `transferredCount` is the number of **activities affected** (comms change and/or cross-team lead update).
+- `400` — No scoped comms, invalid `activityIds`, source not on team, target ineligible, or no comms would change for the given options.
+
+---
+
+### Remove user from team
+
+**DELETE** `/users/:id/teams/:teamId`
+
+**Permission:** `users.edit`. When transferring scoped comms as part of removal, the caller also needs `users.transfer_activities`.
+
+Always clears the user's activity flags for that team. When the user has comms rows on activities led by this team, include a body with `targetUserId` (and optional `toTeamId`, `includeNonLead`, `notes`). When there are no scoped comms rows, the body may be omitted.
+
+**Response:** `200 OK` — `{ "success": true, "transferredCount": number }`
+
+---
+
 ## Lookups Endpoints
 
 Reference data for dropdowns and filters. All responses follow the format: `{ "success": true, "data": [...] }`

--- a/calendar-service/src/activities/activities.module.ts
+++ b/calendar-service/src/activities/activities.module.ts
@@ -47,6 +47,7 @@ import { ActivityUtilsService } from './services/activity-utils.service';
     ActivityFlagsService,
     ActivityHistoryService,
     ActivityDisplayIdSyncService,
+    ActivityUtilsService,
   ],
 })
 export class ActivitiesModule {}

--- a/calendar-service/src/common/test-utils.ts
+++ b/calendar-service/src/common/test-utils.ts
@@ -2,6 +2,7 @@ import type { Activity } from '@corpcal/database/types';
 import type {
   AddUserToTeamBody,
   CreateTeamBody,
+  RemoveUserFromTeamBody,
   TeamDetail,
   TeamHistoryEntry,
   TransferActivitiesBody,
@@ -233,9 +234,16 @@ export const createMockTransferActivitiesBody = (
   overrides?: Partial<TransferActivitiesBody>
 ): TransferActivitiesBody => ({
   targetUserId: 2,
+  fromTeamId: 1,
   activityIds: [1, 2],
-  transferCommsLead: true,
-  transferCommsContact: true,
+  includeNonLead: true,
   notes: undefined,
+  ...overrides,
+});
+
+export const createMockRemoveUserFromTeamBody = (
+  overrides?: Partial<RemoveUserFromTeamBody>
+): RemoveUserFromTeamBody => ({
+  includeNonLead: false,
   ...overrides,
 });

--- a/calendar-service/src/teams/teams.controller.spec.ts
+++ b/calendar-service/src/teams/teams.controller.spec.ts
@@ -160,7 +160,7 @@ describe('TeamsController', () => {
       );
     });
 
-    it('should pass hasCreateAny true when user has activities.create.any', async () => {
+    it('should allow candidates from any team with activities.create.any', async () => {
       mockTeamsService.findCommsContactCandidates.mockResolvedValue([]);
 
       const adminUser: AuthUser = {
@@ -174,6 +174,24 @@ describe('TeamsController', () => {
       };
 
       await controller.getCommsContactCandidates(99, adminUser);
+
+      expect(mockTeamsService.findCommsContactCandidates).toHaveBeenCalledWith(
+        99,
+        [2],
+        true
+      );
+    });
+
+    it('should allow candidates from any team with users.transfer_activities', async () => {
+      mockTeamsService.findCommsContactCandidates.mockResolvedValue([]);
+
+      const transferUser: AuthUser = {
+        ...mockUser,
+        permissions: ['users.transfer_activities'],
+        teamIds: [2],
+      };
+
+      await controller.getCommsContactCandidates(99, transferUser);
 
       expect(mockTeamsService.findCommsContactCandidates).toHaveBeenCalledWith(
         99,

--- a/calendar-service/src/teams/teams.controller.ts
+++ b/calendar-service/src/teams/teams.controller.ts
@@ -106,7 +106,8 @@ export class TeamsController {
     summary: 'List eligible comms contact candidates for a team',
     description:
       'Returns active members of the given team whose role grants activities.edit. ' +
-      "Restricted to the caller's teams unless the caller has activities.create.any.",
+      "Restricted to the caller's teams unless the caller has activities.create.any " +
+      'or users.transfer_activities.',
   })
   @ApiParam({ name: 'teamId', description: 'Lead team ID' })
   @ApiResponse({
@@ -115,24 +116,26 @@ export class TeamsController {
   })
   @ApiResponse({
     status: 403,
-    description: 'Caller is not a member of this team and lacks create.any',
+    description:
+      'Caller is not a member of this team and cannot access cross-team candidates',
   })
   @RequireAnyPermission(
     PERMISSIONS.ACTIVITIES.CREATE,
-    PERMISSIONS.ACTIVITIES.EDIT
+    PERMISSIONS.ACTIVITIES.EDIT,
+    PERMISSIONS.USERS.TRANSFER_ACTIVITIES
   )
   @Get(':teamId/comms-contact-candidates')
   async getCommsContactCandidates(
     @Param('teamId', ParseIntPipe) teamId: number,
     @CurrentUser() user: AuthUser
   ): Promise<{ success: boolean; data: CommsContactCandidate[] }> {
-    const hasCreateAny = user.permissions?.includes(
-      PERMISSIONS.ACTIVITIES.CREATE_ANY
-    );
+    const canViewAnyTeam =
+      user.permissions?.includes(PERMISSIONS.ACTIVITIES.CREATE_ANY) ||
+      user.permissions?.includes(PERMISSIONS.USERS.TRANSFER_ACTIVITIES);
     const data = await this.teamsService.findCommsContactCandidates(
       teamId,
       user.teamIds ?? [],
-      hasCreateAny ?? false
+      canViewAnyTeam ?? false
     );
     return { success: true, data };
   }

--- a/calendar-service/src/teams/teams.service.ts
+++ b/calendar-service/src/teams/teams.service.ts
@@ -129,11 +129,11 @@ export class TeamsService {
   async findCommsContactCandidates(
     teamId: number,
     callerTeamIds: number[],
-    hasCreateAny: boolean
+    canViewAnyTeam: boolean
   ): Promise<CommsContactCandidate[]> {
-    if (!hasCreateAny && !callerTeamIds.includes(teamId)) {
+    if (!canViewAnyTeam && !callerTeamIds.includes(teamId)) {
       throw new ForbiddenException(
-        'You may only view comms contact candidates for teams you belong to.'
+        'You may only view comms contact candidates for teams you belong to unless you can transfer activities across teams.'
       );
     }
 

--- a/calendar-service/src/users/dto/users.dto.ts
+++ b/calendar-service/src/users/dto/users.dto.ts
@@ -6,6 +6,7 @@ import {
   createArrayResponseWrapperSchema,
   createResponseWrapperSchema,
   createUserBodySchema,
+  removeUserFromTeamBodySchema,
   transferActivitiesBodySchema,
   transferActivitiesResponseSchema,
   updateUserBodySchema,
@@ -53,6 +54,14 @@ export class TransferActivitiesDto extends createZodDto(
 ) {}
 
 /**
+ * Request DTO for DELETE /users/:id/teams/:teamId - Remove user from team.
+ * Optional body; see `removeUserFromTeamBodySchema` for defaulting behavior.
+ */
+export class RemoveUserFromTeamDto extends createZodDto(
+  removeUserFromTeamBodySchema
+) {}
+
+/**
  * Response DTO for a single user list item.
  */
 export class UserListItemDto extends createZodDto(userListItemSchema) {}
@@ -81,6 +90,7 @@ const userActivityOptionSchema = z.object({
   id: z.number().int(),
   label: z.string(),
   value: z.number().int(),
+  isLead: z.boolean(),
 });
 
 /**

--- a/calendar-service/src/users/users.controller.spec.ts
+++ b/calendar-service/src/users/users.controller.spec.ts
@@ -133,16 +133,33 @@ describe('UsersController', () => {
   describe('getActivities', () => {
     it('should return activities for user', async () => {
       const activities = [
-        { id: 1, label: 'Activity One', value: 1 },
-        { id: 2, label: 'Activity Two', value: 2 },
+        { id: 1, label: 'Activity One', value: 1, isLead: true },
+        { id: 2, label: 'Activity Two', value: 2, isLead: false },
       ];
       mockUsersService.getActivitiesForUser.mockResolvedValue(activities);
 
       const result = await controller.getActivities(1);
 
       expect(result).toEqual({ success: true, data: activities });
-      expect(mockUsersService.getActivitiesForUser).toHaveBeenCalledWith(1);
+      expect(mockUsersService.getActivitiesForUser).toHaveBeenCalledWith(
+        1,
+        undefined
+      );
       expect(mockUsersService.getActivitiesForUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass fromTeamId scope when provided', async () => {
+      mockUsersService.getActivitiesForUser.mockResolvedValue([]);
+
+      await controller.getActivities(1, '5');
+
+      expect(mockUsersService.getActivitiesForUser).toHaveBeenCalledWith(1, 5);
+    });
+
+    it('should throw BadRequestException for a non-integer fromTeamId', async () => {
+      await expect(controller.getActivities(1, 'not-a-number')).rejects.toThrow(
+        'fromTeamId must be an integer'
+      );
     });
   });
 
@@ -220,18 +237,60 @@ describe('UsersController', () => {
   });
 
   describe('removeFromTeam', () => {
-    it('should remove user from team and return success', async () => {
-      mockUsersService.removeUserFromTeam.mockResolvedValue(undefined);
+    it('should remove user from team with no body (silent removal)', async () => {
+      mockUsersService.removeUserFromTeam.mockResolvedValue({
+        transferredCount: 0,
+      });
 
-      const result = await controller.removeFromTeam(1, 2, mockUser);
+      const result = await controller.removeFromTeam(
+        1,
+        2,
+        { includeNonLead: false },
+        mockUser
+      );
 
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual({ success: true, transferredCount: 0 });
       expect(mockUsersService.removeUserFromTeam).toHaveBeenCalledWith(
         1,
         2,
-        mockUser.id
+        mockUser.id,
+        { includeNonLead: false }
       );
       expect(mockUsersService.removeUserFromTeam).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove user from team and transfer activities when targetUserId is provided', async () => {
+      mockUsersService.removeUserFromTeam.mockResolvedValue({
+        transferredCount: 3,
+      });
+
+      const dto = { targetUserId: 5, includeNonLead: true };
+      const result = await controller.removeFromTeam(1, 2, dto, mockUser);
+
+      expect(result).toEqual({ success: true, transferredCount: 3 });
+      expect(mockUsersService.removeUserFromTeam).toHaveBeenCalledWith(
+        1,
+        2,
+        mockUser.id,
+        dto
+      );
+    });
+
+    it('should throw ForbiddenException when transferring without transfer permission', async () => {
+      const userWithoutTransfer: AuthUser = {
+        ...mockUser,
+        permissions: ['users.view', 'users.edit'],
+      };
+
+      await expect(
+        controller.removeFromTeam(
+          1,
+          2,
+          { targetUserId: 5, includeNonLead: false },
+          userWithoutTransfer
+        )
+      ).rejects.toThrow('You do not have permission to transfer activities.');
+      expect(mockUsersService.removeUserFromTeam).not.toHaveBeenCalled();
     });
   });
 
@@ -277,8 +336,8 @@ describe('UsersController', () => {
 
       const dto = createMockTransferActivitiesBody({
         targetUserId: 2,
-        transferCommsLead: true,
-        transferCommsContact: true,
+        fromTeamId: 1,
+        includeNonLead: true,
       });
       const result = await controller.transferActivities(1, dto, mockUser);
 

--- a/calendar-service/src/users/users.controller.ts
+++ b/calendar-service/src/users/users.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -23,6 +24,7 @@ import {
 
 import { PERMISSIONS, SYSTEM_ROLE_IDS, type AuthUser } from '@corpcal/shared';
 import type {
+  RemoveUserFromTeamBody,
   UserDetail,
   UserHistoryEntry,
   UserListItem,
@@ -30,6 +32,7 @@ import type {
 import {
   addUserToTeamBodySchema,
   createUserBodySchema,
+  removeUserFromTeamBodySchema,
   transferActivitiesBodySchema,
   updateUserBodySchema,
   updateUserSettingsBodySchema,
@@ -44,6 +47,7 @@ import { RequirePermission } from '../policy/decorators/require-permission.decor
 import {
   AddUserToTeamDto,
   CreateUserDto,
+  RemoveUserFromTeamDto,
   TransferActivitiesDto,
   TransferActivitiesResponseDto,
   UpdateUserDto,
@@ -158,20 +162,38 @@ export class UsersController {
   @ApiOperation({
     summary: 'Get activities associated with a user',
     description:
-      'Returns activities where the user is a comms lead or contact. Excludes deleted activities. Used for transfer dialog and "my activities" filters.',
+      'Returns activities where the user is a comms lead or contact. Excludes deleted activities. ' +
+      'When `fromTeamId` is provided, scopes to activities where `leadTeamId === fromTeamId` — ' +
+      'the set used by the transfer-activities and team-removal flows.',
   })
   @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiQuery({
+    name: 'fromTeamId',
+    required: false,
+    description: 'Scope to activities led by this team',
+  })
   @ApiResponse({
     status: 200,
-    description: 'List of activities (id, label, value)',
+    description: 'List of activities (id, label, value, isLead)',
     type: UserActivitiesResponseWrapperDto,
   })
   @Get(':id/activities')
-  async getActivities(@Param('id', ParseIntPipe) id: number): Promise<{
+  async getActivities(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('fromTeamId') fromTeamIdParam?: string
+  ): Promise<{
     success: boolean;
-    data: { id: number; label: string; value: number }[];
+    data: { id: number; label: string; value: number; isLead: boolean }[];
   }> {
-    const data = await this.usersService.getActivitiesForUser(id);
+    let fromTeamId: number | undefined;
+    if (fromTeamIdParam != null && fromTeamIdParam !== '') {
+      fromTeamId = Number(fromTeamIdParam);
+      if (!Number.isInteger(fromTeamId)) {
+        throw new BadRequestException('fromTeamId must be an integer');
+      }
+    }
+
+    const data = await this.usersService.getActivitiesForUser(id, fromTeamId);
     return { success: true, data };
   }
 
@@ -273,20 +295,53 @@ export class UsersController {
     return { success: true };
   }
 
-  @ApiOperation({ summary: 'Remove user from team' })
+  @ApiOperation({
+    summary: 'Remove user from team',
+    description:
+      'Always deletes the user\u2019s activity flags for this team. When the body ' +
+      'is omitted (or has no `targetUserId`) and the user has no comms assignments ' +
+      'scoped to this team, removal is silent. Otherwise `targetUserId` is required ' +
+      'to transfer those comms assignments; requires `users.transfer_activities` in ' +
+      'addition to `users.edit` in that case.',
+  })
   @ApiParam({ name: 'id', description: 'User ID' })
   @ApiParam({ name: 'teamId', description: 'Team ID' })
+  @ApiBody({
+    type: RemoveUserFromTeamDto,
+    description: 'Optional; required only when transferring comms assignments.',
+    required: false,
+  })
   @ApiResponse({ status: 200, description: 'User removed from team' })
+  @ApiResponse({
+    status: 400,
+    description: 'Comms assignments need a target user',
+  })
   @ApiResponse({ status: 404, description: 'User not in team' })
   @RequirePermission('users.edit')
   @Delete(':id/teams/:teamId')
   async removeFromTeam(
     @Param('id', ParseIntPipe) id: number,
     @Param('teamId', ParseIntPipe) teamId: number,
+    @Body(new ZodValidationPipe(removeUserFromTeamBodySchema))
+    dto: RemoveUserFromTeamBody,
     @CurrentUser() currentUser: AuthUser
-  ): Promise<{ success: boolean }> {
-    await this.usersService.removeUserFromTeam(id, teamId, currentUser.id);
-    return { success: true };
+  ): Promise<{ success: boolean; transferredCount: number }> {
+    if (
+      dto.targetUserId != null &&
+      !currentUser.permissions.includes(PERMISSIONS.USERS.TRANSFER_ACTIVITIES)
+    ) {
+      throw new ForbiddenException(
+        'You do not have permission to transfer activities.'
+      );
+    }
+
+    const { transferredCount } = await this.usersService.removeUserFromTeam(
+      id,
+      teamId,
+      currentUser.id,
+      dto
+    );
+    return { success: true, transferredCount };
   }
 
   @ApiOperation({ summary: 'Update user role in team' })

--- a/calendar-service/src/users/users.module.ts
+++ b/calendar-service/src/users/users.module.ts
@@ -3,11 +3,12 @@ import { Module } from '@nestjs/common';
 import { ActivitiesModule } from '../activities/activities.module';
 import { AuthModule } from '../auth/auth.module';
 import { DatabaseModule } from '../database/database.module';
+import { TeamsModule } from '../teams/teams.module';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [DatabaseModule, ActivitiesModule, AuthModule],
+  imports: [DatabaseModule, ActivitiesModule, AuthModule, TeamsModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -902,6 +902,61 @@ describe('UsersService', () => {
       );
     });
 
+    it('should reactivate an existing inactive target comms row when merging', async () => {
+      const setMock = vi.fn().mockReturnThis();
+      mockDatabaseService.db.transaction = vi.fn(
+        async (cb: (tx: typeof mockDatabaseService.db) => Promise<number>) =>
+          cb(mockDatabaseService.db)
+      );
+
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(activeTeamMembership())
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 10, isLead: true }], 'where')
+        )
+        .mockReturnValueOnce(
+          createChain(
+            [
+              { id: 1, adDisplayName: 'Source User', adUsername: null },
+              { id: 2, adDisplayName: 'Target User', adUsername: null },
+            ],
+            'where'
+          )
+        )
+        .mockReturnValueOnce(createChain([{ isLead: false }], 'limit'));
+
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(new Set([2]));
+
+      mockDatabaseService.db.update = vi.fn().mockReturnValue({
+        set: setMock,
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockDatabaseService.db.delete = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockDatabaseService.db.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await service.transferActivities(
+        1,
+        createMockTransferActivitiesBody({
+          targetUserId: 2,
+          fromTeamId: 1,
+          activityIds: [10],
+          includeNonLead: false,
+        }),
+        1
+      );
+
+      expect(setMock).toHaveBeenCalledWith({
+        isLead: true,
+        isActive: true,
+      });
+    });
+
     it('should delete non-lead comms in removal-equivalent scenarios (includeNonLead false, cross-team, source ineligible)', async () => {
       mockDatabaseService.db.transaction = vi.fn(
         async (cb: (tx: typeof mockDatabaseService.db) => Promise<number>) =>

--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -6,12 +6,14 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { ActivityHistoryService } from '../activities/services/activity-history.service';
+import { ActivityUtilsService } from '../activities/services/activity-utils.service';
 import {
   createMockAddUserToTeamBody,
   createMockTransferActivitiesBody,
   createMockUpdateUserTeamRoleBody,
 } from '../common/test-utils';
 import { DatabaseService } from '../database/database.service';
+import { TeamsService } from '../teams/teams.service';
 import { UsersService } from './users.service';
 
 describe('UsersService', () => {
@@ -67,6 +69,14 @@ describe('UsersService', () => {
     recordChange: vi.fn().mockResolvedValue(undefined),
   };
 
+  const mockActivityUtilsService = {
+    computeDisplayIdFromLeadContext: vi.fn().mockReturnValue('TEAM-000001'),
+  };
+
+  const mockTeamsService = {
+    getEligibleCommsUserIds: vi.fn().mockResolvedValue(new Set<number>()),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -79,11 +89,25 @@ describe('UsersService', () => {
           provide: ActivityHistoryService,
           useValue: mockActivityHistoryService,
         },
+        {
+          provide: ActivityUtilsService,
+          useValue: mockActivityUtilsService,
+        },
+        {
+          provide: TeamsService,
+          useValue: mockTeamsService,
+        },
       ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
     vi.clearAllMocks();
+    mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(
+      new Set<number>()
+    );
+    mockActivityUtilsService.computeDisplayIdFromLeadContext.mockReturnValue(
+      'TEAM-000001'
+    );
   });
 
   describe('create', () => {
@@ -392,6 +416,23 @@ describe('UsersService', () => {
   });
 
   describe('removeUserFromTeam', () => {
+    const stubTransactionPassthrough = () => {
+      mockDatabaseService.db.transaction = vi.fn(
+        async (cb: (tx: typeof mockDatabaseService.db) => Promise<number>) =>
+          cb(mockDatabaseService.db)
+      );
+      mockDatabaseService.db.delete = vi
+        .fn()
+        .mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDatabaseService.db.update = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockDatabaseService.db.insert = vi
+        .fn()
+        .mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    };
+
     it('should throw NotFoundException when user not in team', async () => {
       mockDatabaseService.db.select = vi
         .fn()
@@ -402,20 +443,82 @@ describe('UsersService', () => {
       );
     });
 
-    it('should soft-update and record history on success', async () => {
+    it('should silently remove (no comms, no body) and clear flags + membership', async () => {
       mockDatabaseService.db.select = vi
         .fn()
-        .mockReturnValueOnce(createChain([{ role: 'member' }], 'limit'));
+        .mockReturnValueOnce(createChain([{ role: 'member' }], 'limit')) // active membership check
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status lookup
+        .mockReturnValueOnce(createChain([], 'where')); // scoped comms rows: none
 
-      mockDatabaseService.db.update = vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnThis(),
-        where: vi.fn().mockResolvedValue(undefined),
+      stubTransactionPassthrough();
+
+      const result = await service.removeUserFromTeam(1, 2, 1);
+
+      expect(result).toEqual({ transferredCount: 0 });
+      expect(mockDatabaseService.db.delete).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.db.update).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.db.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw BadRequestException when scoped comms exist but no targetUserId given', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ role: 'member' }], 'limit'))
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 10, isLead: true }], 'where')
+        );
+
+      await expect(service.removeUserFromTeam(1, 2, 1)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+
+    it('should transfer scoped comms, clear flags, and deactivate membership', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ role: 'member' }], 'limit')) // active membership check
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status lookup
+        .mockReturnValueOnce(
+          createChain(
+            [
+              { activityId: 10, isLead: true },
+              { activityId: 11, isLead: false },
+            ],
+            'where'
+          )
+        ) // scoped comms rows
+        .mockReturnValueOnce(
+          createChain(
+            [
+              { id: 1, adDisplayName: 'Source User', adUsername: null },
+              { id: 2, adDisplayName: 'Target User', adUsername: null },
+            ],
+            'where'
+          )
+        ) // display names
+        .mockReturnValueOnce(createChain([], 'limit')) // transferSingleCommsRow target-row check (activity 10)
+        .mockReturnValueOnce(createChain([], 'limit')); // transferSingleCommsRow target-row check (activity 11) — n/a since not lead & includeNonLead false, but harmless if unused
+
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(new Set([2]));
+      stubTransactionPassthrough();
+
+      const result = await service.removeUserFromTeam(1, 2, 1, {
+        targetUserId: 2,
+        includeNonLead: false,
       });
 
-      await expect(
-        service.removeUserFromTeam(1, 2, 1)
-      ).resolves.toBeUndefined();
+      expect(result).toEqual({ transferredCount: 2 });
+      expect(mockDatabaseService.db.delete).toHaveBeenCalled();
       expect(mockDatabaseService.db.update).toHaveBeenCalled();
+      expect(mockActivityHistoryService.recordChange).toHaveBeenCalledWith(
+        10,
+        1,
+        'comms_lead_transferred',
+        expect.any(Array),
+        undefined,
+        mockDatabaseService.db
+      );
     });
   });
 
@@ -509,18 +612,16 @@ describe('UsersService', () => {
     it('should return activities where user is comms contact', async () => {
       mockDatabaseService.db.select = vi
         .fn()
-        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'));
-
-      const activityChain = createChain(
-        [
-          { id: 1, title: 'Activity One' },
-          { id: 2, title: 'Activity Two' },
-        ],
-        'orderBy'
-      );
-      mockDatabaseService.db.selectDistinct = vi
-        .fn()
-        .mockReturnValue(activityChain);
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain(
+            [
+              { id: 1, title: 'Activity One', isLead: true },
+              { id: 2, title: 'Activity Two', isLead: false },
+            ],
+            'orderBy'
+          )
+        );
 
       const result = await service.getActivitiesForUser(1);
 
@@ -529,12 +630,32 @@ describe('UsersService', () => {
         id: 1,
         label: 'Activity One',
         value: 1,
+        isLead: true,
       });
       expect(result[1]).toMatchObject({
         id: 2,
         label: 'Activity Two',
         value: 2,
+        isLead: false,
       });
+    });
+
+    it('should scope by fromTeamId when provided', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain(
+            [{ id: 1, title: 'Scoped Activity', isLead: true }],
+            'orderBy'
+          )
+        );
+
+      const result = await service.getActivitiesForUser(1, 5);
+
+      expect(result).toEqual([
+        { id: 1, label: 'Scoped Activity', value: 1, isLead: true },
+      ]);
     });
   });
 
@@ -575,30 +696,62 @@ describe('UsersService', () => {
       await expect(
         service.transferActivities(
           1,
-          createMockTransferActivitiesBody({ targetUserId: 1 }),
+          createMockTransferActivitiesBody({ targetUserId: 1, fromTeamId: 1 }),
           1
         )
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when both transfer flags false', async () => {
+    it('should throw BadRequestException when activityIds are outside the fromTeamId scope', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 10, isLead: true }], 'where')
+        );
+
       await expect(
         service.transferActivities(
           1,
           createMockTransferActivitiesBody({
             targetUserId: 2,
-            transferCommsLead: false,
-            transferCommsContact: false,
+            fromTeamId: 1,
+            activityIds: [10, 999],
           }),
           1
         )
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should record 0 and return transferredCount 0 when no activities', async () => {
-      mockDatabaseService.db.selectDistinct = vi
+    it('should throw BadRequestException when target user is not comms-eligible for the destination team', async () => {
+      mockDatabaseService.db.select = vi
         .fn()
-        .mockReturnValue(createChain([], 'where'));
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 10, isLead: true }], 'where')
+        );
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(
+        new Set([999])
+      );
+
+      await expect(
+        service.transferActivities(
+          1,
+          createMockTransferActivitiesBody({
+            targetUserId: 2,
+            fromTeamId: 1,
+            activityIds: [10],
+          }),
+          1
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should record 0 and return transferredCount 0 when no activities are in scope', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(createChain([], 'where'));
 
       mockDatabaseService.db.insert = vi.fn().mockReturnValue({
         values: vi.fn().mockResolvedValue(undefined),
@@ -608,9 +761,8 @@ describe('UsersService', () => {
         1,
         createMockTransferActivitiesBody({
           targetUserId: 2,
+          fromTeamId: 1,
           activityIds: [],
-          transferCommsLead: true,
-          transferCommsContact: true,
         }),
         1
       );
@@ -618,7 +770,7 @@ describe('UsersService', () => {
       expect(result).toEqual({ transferredCount: 0 });
     });
 
-    it('should update activity_comms_contacts and return transferredCount', async () => {
+    it('should transfer lead and non-lead comms and return transferredCount', async () => {
       mockDatabaseService.db.transaction = vi.fn(
         async (cb: (tx: typeof mockDatabaseService.db) => Promise<number>) =>
           cb(mockDatabaseService.db)
@@ -626,6 +778,7 @@ describe('UsersService', () => {
 
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status
         .mockReturnValueOnce(
           createChain(
             [
@@ -634,10 +787,20 @@ describe('UsersService', () => {
             ],
             'where'
           )
-        )
-        .mockReturnValueOnce(createChain([], 'where'))
-        .mockReturnValueOnce(createChain([], 'limit'))
-        .mockReturnValueOnce(createChain([], 'limit'));
+        ) // scoped comms rows
+        .mockReturnValueOnce(
+          createChain(
+            [
+              { id: 1, adDisplayName: 'Source User', adUsername: null },
+              { id: 2, adDisplayName: 'Target User', adUsername: null },
+            ],
+            'where'
+          )
+        ) // display names
+        .mockReturnValueOnce(createChain([], 'limit')) // transferSingleCommsRow (activity 10)
+        .mockReturnValueOnce(createChain([], 'limit')); // transferSingleCommsRow (activity 11)
+
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(new Set([2]));
 
       mockDatabaseService.db.update = vi.fn().mockReturnValue({
         set: vi.fn().mockReturnThis(),
@@ -652,9 +815,9 @@ describe('UsersService', () => {
         1,
         createMockTransferActivitiesBody({
           targetUserId: 2,
+          fromTeamId: 1,
           activityIds: [10, 11],
-          transferCommsLead: true,
-          transferCommsContact: true,
+          includeNonLead: true,
         }),
         1
       );
@@ -662,6 +825,68 @@ describe('UsersService', () => {
       expect(result).toEqual({ transferredCount: 2 });
       expect(mockDatabaseService.db.transaction).toHaveBeenCalledTimes(1);
       expect(mockActivityHistoryService.recordChange).toHaveBeenCalledTimes(1);
+      expect(mockActivityHistoryService.recordChange).toHaveBeenCalledWith(
+        10,
+        1,
+        'comms_lead_transferred',
+        expect.any(Array),
+        undefined,
+        mockDatabaseService.db
+      );
+    });
+
+    it('should delete non-lead comms in removal-equivalent scenarios (includeNonLead false, cross-team, source ineligible)', async () => {
+      mockDatabaseService.db.transaction = vi.fn(
+        async (cb: (tx: typeof mockDatabaseService.db) => Promise<number>) =>
+          cb(mockDatabaseService.db)
+      );
+
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status
+        .mockReturnValueOnce(
+          createChain([{ activityId: 20, isLead: false }], 'where')
+        ) // scoped comms rows (non-lead only)
+        .mockReturnValueOnce(
+          createChain(
+            [{ id: 1, adDisplayName: 'Source User', adUsername: null }],
+            'where'
+          )
+        ) // display names (target not included since lead never transfers here, only source resolved)
+        .mockReturnValueOnce(
+          createChain([{ abbreviation: 'DEST', ministryId: null }], 'limit')
+        ); // resolveCrossTeamContext team lookup
+
+      // Target team eligibility (used for both target validation and source-eligibility check).
+      // Non-lead is not transferred (includeNonLead false) and source (1) is not eligible on team 2.
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(new Set([2]));
+
+      mockDatabaseService.db.update = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockDatabaseService.db.delete = vi
+        .fn()
+        .mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDatabaseService.db.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await service.transferActivities(
+        1,
+        createMockTransferActivitiesBody({
+          targetUserId: 2,
+          fromTeamId: 1,
+          toTeamId: 2,
+          activityIds: [20],
+          includeNonLead: false,
+        }),
+        1
+      );
+
+      expect(result).toEqual({ transferredCount: 1 });
+      expect(mockDatabaseService.db.delete).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.db.update).toHaveBeenCalled(); // activities.leadTeamId cross-team update
     });
   });
 });

--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -692,6 +692,8 @@ describe('UsersService', () => {
   });
 
   describe('transferActivities', () => {
+    const activeTeamMembership = () => createChain([{ userId: 1 }], 'limit');
+
     it('should throw BadRequestException when source and target are same', async () => {
       await expect(
         service.transferActivities(
@@ -705,6 +707,7 @@ describe('UsersService', () => {
     it('should throw BadRequestException when activityIds are outside the fromTeamId scope', async () => {
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(activeTeamMembership())
         .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
         .mockReturnValueOnce(
           createChain([{ activityId: 10, isLead: true }], 'where')
@@ -726,6 +729,7 @@ describe('UsersService', () => {
     it('should throw BadRequestException when target user is not comms-eligible for the destination team', async () => {
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(activeTeamMembership())
         .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
         .mockReturnValueOnce(
           createChain([{ activityId: 10, isLead: true }], 'where')
@@ -747,27 +751,89 @@ describe('UsersService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should record 0 and return transferredCount 0 when no activities are in scope', async () => {
+    it('should throw BadRequestException when no activities are in scope', async () => {
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(activeTeamMembership())
         .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
         .mockReturnValueOnce(createChain([], 'where'));
 
-      mockDatabaseService.db.insert = vi.fn().mockReturnValue({
-        values: vi.fn().mockResolvedValue(undefined),
-      });
+      await expect(
+        service.transferActivities(
+          1,
+          createMockTransferActivitiesBody({
+            targetUserId: 2,
+            fromTeamId: 1,
+          }),
+          1
+        )
+      ).rejects.toThrow(BadRequestException);
 
-      const result = await service.transferActivities(
-        1,
-        createMockTransferActivitiesBody({
-          targetUserId: 2,
-          fromTeamId: 1,
-          activityIds: [],
-        }),
-        1
-      );
+      expect(mockDatabaseService.db.insert).not.toHaveBeenCalled();
+    });
 
-      expect(result).toEqual({ transferredCount: 0 });
+    it('should throw BadRequestException when activityIds is an explicit empty array', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(activeTeamMembership())
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 10, isLead: true }], 'where')
+        );
+
+      await expect(
+        service.transferActivities(
+          1,
+          createMockTransferActivitiesBody({
+            targetUserId: 2,
+            fromTeamId: 1,
+            activityIds: [],
+          }),
+          1
+        )
+      ).rejects.toThrow(/activityIds must include at least one activity/i);
+    });
+
+    it('should throw BadRequestException when source user is not on fromTeamId', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(createChain([], 'limit'));
+
+      await expect(
+        service.transferActivities(
+          1,
+          createMockTransferActivitiesBody({
+            targetUserId: 2,
+            fromTeamId: 1,
+          }),
+          1
+        )
+      ).rejects.toThrow(/not an active member of team/i);
+    });
+
+    it('should throw BadRequestException when selected options would not change comms', async () => {
+      mockDatabaseService.db.select = vi
+        .fn()
+        .mockReturnValueOnce(activeTeamMembership())
+        .mockReturnValueOnce(createChain([{ id: 99 }], 'limit'))
+        .mockReturnValueOnce(
+          createChain([{ activityId: 11, isLead: false }], 'where')
+        );
+
+      mockTeamsService.getEligibleCommsUserIds.mockResolvedValue(new Set([2]));
+
+      await expect(
+        service.transferActivities(
+          1,
+          createMockTransferActivitiesBody({
+            targetUserId: 2,
+            fromTeamId: 1,
+            activityIds: [11],
+            includeNonLead: false,
+          }),
+          1
+        )
+      ).rejects.toThrow(/No comms assignments would change/i);
     });
 
     it('should transfer lead and non-lead comms and return transferredCount', async () => {
@@ -778,6 +844,7 @@ describe('UsersService', () => {
 
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(activeTeamMembership())
         .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status
         .mockReturnValueOnce(
           createChain(
@@ -843,6 +910,7 @@ describe('UsersService', () => {
 
       mockDatabaseService.db.select = vi
         .fn()
+        .mockReturnValueOnce(activeTeamMembership())
         .mockReturnValueOnce(createChain([{ id: 99 }], 'limit')) // deleted status
         .mockReturnValueOnce(
           createChain([{ activityId: 20, isLead: false }], 'where')

--- a/calendar-service/src/users/users.service.ts
+++ b/calendar-service/src/users/users.service.ts
@@ -974,7 +974,7 @@ export class UsersService {
         );
       await tx
         .update(activityCommsContacts)
-        .set({ isLead: isLead || targetRow.isLead })
+        .set({ isLead: isLead || targetRow.isLead, isActive: true })
         .where(
           and(
             eq(activityCommsContacts.activityId, activityId),
@@ -984,7 +984,7 @@ export class UsersService {
     } else {
       await tx
         .update(activityCommsContacts)
-        .set({ userId: targetUserId })
+        .set({ userId: targetUserId, isActive: true })
         .where(
           and(
             eq(activityCommsContacts.activityId, activityId),
@@ -1141,7 +1141,8 @@ export class UsersService {
 
   /**
    * Returns per-user activity counts for the supplied user IDs.
-   * Excludes deleted activities to match getActivitiesForUser behavior.
+   * Excludes deleted activities and inactive comms contact rows (matches
+   * getActivitiesForUser behavior).
    */
   async getActivityCountsForUsers(
     userIds: number[]
@@ -1157,7 +1158,10 @@ export class UsersService {
       .where(eq(activityStatuses.name, 'deleted' satisfies ActivityStatusName))
       .limit(1);
 
-    const conditions = [inArray(activityCommsContacts.userId, uniqueUserIds)];
+    const conditions = [
+      inArray(activityCommsContacts.userId, uniqueUserIds),
+      eq(activityCommsContacts.isActive, true),
+    ];
     if (deletedStatus?.id != null) {
       conditions.push(ne(activities.activityStatusId, deletedStatus.id));
     }

--- a/calendar-service/src/users/users.service.ts
+++ b/calendar-service/src/users/users.service.ts
@@ -1185,6 +1185,51 @@ export class UsersService {
     }));
   }
 
+  /** Ensures the source user is an active member of `teamId` before team-scoped transfer. */
+  private async assertSourceUserOnTeam(
+    userId: number,
+    teamId: number
+  ): Promise<void> {
+    const [row] = await this.databaseService.db
+      .select({ userId: userTeams.userId })
+      .from(userTeams)
+      .where(
+        and(
+          eq(userTeams.userId, userId),
+          eq(userTeams.teamId, teamId),
+          eq(userTeams.isActive, true)
+        )
+      )
+      .limit(1);
+
+    if (!row) {
+      throw new BadRequestException(
+        `User ${userId} is not an active member of team ${teamId}.`
+      );
+    }
+  }
+
+  /**
+   * Mirrors `applyActivityCommsChanges` to detect whether a scoped row would
+   * produce any side effect (comms move, delete, or cross-team lead update).
+   */
+  private commsChangeWouldApply(
+    row: ScopedCommsRow,
+    params: {
+      includeNonLead: boolean;
+      mode: 'transfer' | 'removal';
+      crossTeam: boolean;
+    }
+  ): boolean {
+    const { includeNonLead, mode, crossTeam } = params;
+
+    if (crossTeam) return true;
+    if (row.isLead) return true;
+    if (includeNonLead) return true;
+    if (mode === 'removal') return true;
+    return false;
+  }
+
   /**
    * Transfers activity comms assignments from `sourceUserId` to `dto.targetUserId`.
    *
@@ -1205,39 +1250,39 @@ export class UsersService {
     const fromTeamId = dto.fromTeamId;
     const toTeamId = dto.toTeamId ?? fromTeamId;
 
+    await this.assertSourceUserOnTeam(sourceUserId, fromTeamId);
+
     const scopedRows = await this.getScopedCommsRows(sourceUserId, fromTeamId);
     const scopedIds = new Set(scopedRows.map((r) => r.activityId));
 
-    let activityIds = dto.activityIds;
-    if (activityIds && activityIds.length > 0) {
-      const invalidIds = activityIds.filter((id) => !scopedIds.has(id));
+    if (scopedIds.size === 0) {
+      throw new BadRequestException(
+        'No comms assignments are in scope for this user and team.'
+      );
+    }
+
+    let activityIds: number[];
+    if (dto.activityIds === undefined) {
+      activityIds = Array.from(scopedIds);
+    } else if (dto.activityIds.length === 0) {
+      throw new BadRequestException(
+        'activityIds must include at least one activity when provided.'
+      );
+    } else {
+      const invalidIds = dto.activityIds.filter((id) => !scopedIds.has(id));
       if (invalidIds.length > 0) {
         throw new BadRequestException(
           `Activities [${invalidIds.join(', ')}] are not eligible for transfer from team ${fromTeamId}.`
         );
       }
-    } else {
-      activityIds = Array.from(scopedIds);
-    }
-
-    if (activityIds.length === 0) {
-      await this.recordUserHistory(
-        sourceUserId,
-        changedByUserId,
-        'activities_transferred',
-        [
-          { field: 'targetUserId', oldValue: null, newValue: dto.targetUserId },
-          { field: 'activityCount', oldValue: null, newValue: 0 },
-        ],
-        dto.notes ?? null
-      );
-      return { transferredCount: 0 };
+      activityIds = dto.activityIds;
     }
 
     const rowsToProcess = scopedRows.filter((r) =>
       activityIds.includes(r.activityId)
     );
 
+    const crossTeam = toTeamId !== fromTeamId;
     const eligibleOnToTeam =
       await this.teamsService.getEligibleCommsUserIds(toTeamId);
     this.validateTransferTarget(
@@ -1246,6 +1291,20 @@ export class UsersService {
       dto.includeNonLead,
       eligibleOnToTeam
     );
+
+    if (
+      !rowsToProcess.some((row) =>
+        this.commsChangeWouldApply(row, {
+          includeNonLead: dto.includeNonLead,
+          mode: 'transfer',
+          crossTeam,
+        })
+      )
+    ) {
+      throw new BadRequestException(
+        'No comms assignments would change for the selected activities and options.'
+      );
+    }
 
     const displayNameById = await this.getDisplayNamesById([
       sourceUserId,
@@ -1256,7 +1315,6 @@ export class UsersService {
     const targetDisplayName =
       displayNameById.get(dto.targetUserId) ?? `User ${dto.targetUserId}`;
 
-    const crossTeam = toTeamId !== fromTeamId;
     const crossTeamContext = crossTeam
       ? await this.resolveCrossTeamContext(toTeamId)
       : null;

--- a/calendar-service/src/users/users.service.ts
+++ b/calendar-service/src/users/users.service.ts
@@ -9,7 +9,9 @@ import { and, desc, eq, inArray, ne, sql } from 'drizzle-orm';
 import {
   activities,
   activityCommsContacts,
+  activityFlags,
   activityStatuses,
+  ministries,
   roles,
   teams,
   userHistory,
@@ -22,6 +24,7 @@ import type {
   AddUserToTeamBody,
   CreateUserBody,
   HistoryChange,
+  RemoveUserFromTeamBody,
   TransferActivitiesBody,
   UpdateUserBody,
   UpdateUserSettingsBody,
@@ -32,13 +35,31 @@ import type {
 } from '@corpcal/shared/api/types';
 
 import { ActivityHistoryService } from '../activities/services/activity-history.service';
+import { ActivityUtilsService } from '../activities/services/activity-utils.service';
+import type { DrizzleDbExecutor } from '../database/database.provider';
 import { DatabaseService } from '../database/database.service';
+import { TeamsService } from '../teams/teams.service';
+
+/** A single comms-contact row scoped to a user + lead team, used by transfer/removal flows. */
+interface ScopedCommsRow {
+  activityId: number;
+  isLead: boolean;
+}
+
+/** Resolved lead-team context (abbreviation, ministry) used to recompute displayId on cross-team moves. */
+interface CrossTeamContext {
+  teamAbbreviation: string | null;
+  leadMinistryId: number | null;
+  ministryAbbreviation: string | null;
+}
 
 @Injectable()
 export class UsersService {
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly activityHistoryService: ActivityHistoryService
+    private readonly activityHistoryService: ActivityHistoryService,
+    private readonly activityUtilsService: ActivityUtilsService,
+    private readonly teamsService: TeamsService
   ) {}
 
   private async recordUserHistory(
@@ -522,11 +543,25 @@ export class UsersService {
     );
   }
 
+  /**
+   * Removes a user from a team.
+   *
+   * Always deletes the user's `activity_flags` for this team (`assigneeId =
+   * userId`, `teamId`), regardless of comms — flags are per-team assignments
+   * that have no meaning once the user is no longer on the team.
+   *
+   * If the user has active comms-contact rows scoped to this team
+   * (`leadTeamId === teamId`), `dto.targetUserId` is required and those
+   * activities are transferred in `removal` mode (non-lead comms are always
+   * transferred-or-deleted, never left in place — see
+   * `applyActivityCommsChanges`). Everything runs in one transaction.
+   */
   async removeUserFromTeam(
     userId: number,
     teamId: number,
-    changedByUserId: number
-  ): Promise<void> {
+    changedByUserId: number,
+    dto?: RemoveUserFromTeamBody
+  ): Promise<{ transferredCount: number }> {
     const [row] = await this.databaseService.db
       .select({ role: userTeams.role })
       .from(userTeams)
@@ -541,15 +576,113 @@ export class UsersService {
 
     if (!row) throw new NotFoundException('User is not in this team');
 
-    await this.databaseService.db
-      .update(userTeams)
-      .set({ isActive: false })
-      .where(and(eq(userTeams.userId, userId), eq(userTeams.teamId, teamId)));
+    const includeNonLead = dto?.includeNonLead ?? false;
+    const toTeamId = dto?.toTeamId ?? teamId;
+    const targetUserId = dto?.targetUserId ?? null;
 
-    await this.recordUserHistory(userId, changedByUserId, 'team_removed', [
+    const scopedRows = await this.getScopedCommsRows(userId, teamId);
+
+    if (scopedRows.length > 0 && targetUserId == null) {
+      throw new BadRequestException(
+        'This user has comms assignments on activities led by this team. ' +
+          'Provide targetUserId to transfer them before removal.'
+      );
+    }
+
+    let sourceDisplayName = '';
+    let targetDisplayName: string | null = null;
+    let crossTeamContext: CrossTeamContext | null = null;
+    let eligibleSourceOnToTeam = new Set<number>();
+    const crossTeam = toTeamId !== teamId;
+
+    if (scopedRows.length > 0) {
+      const eligibleOnToTeam =
+        await this.teamsService.getEligibleCommsUserIds(toTeamId);
+      this.validateTransferTarget(
+        scopedRows,
+        targetUserId,
+        includeNonLead,
+        eligibleOnToTeam
+      );
+      eligibleSourceOnToTeam = eligibleOnToTeam;
+
+      const displayNameById = await this.getDisplayNamesById([
+        userId,
+        targetUserId!,
+      ]);
+      sourceDisplayName = displayNameById.get(userId) ?? `User ${userId}`;
+      targetDisplayName =
+        displayNameById.get(targetUserId!) ?? `User ${targetUserId}`;
+
+      if (crossTeam) {
+        crossTeamContext = await this.resolveCrossTeamContext(toTeamId);
+      }
+    }
+
+    const transferredCount = await this.databaseService.db.transaction(
+      async (tx) => {
+        let count = 0;
+        if (scopedRows.length > 0) {
+          count = await this.applyActivityCommsChanges(tx, {
+            sourceUserId: userId,
+            targetUserId,
+            fromTeamId: teamId,
+            toTeamId,
+            rows: scopedRows,
+            includeNonLead,
+            mode: 'removal',
+            changedByUserId,
+            notes: dto?.notes,
+            sourceDisplayName,
+            targetDisplayName,
+            crossTeamContext,
+            eligibleSourceOnToTeam,
+          });
+        }
+
+        // Flags are per-team assignments; always clear them on removal (Option A),
+        // independent of whether the user had any comms assignments to transfer.
+        await tx
+          .delete(activityFlags)
+          .where(
+            and(
+              eq(activityFlags.assigneeId, userId),
+              eq(activityFlags.teamId, teamId)
+            )
+          );
+
+        await tx
+          .update(userTeams)
+          .set({ isActive: false })
+          .where(
+            and(eq(userTeams.userId, userId), eq(userTeams.teamId, teamId))
+          );
+
+        return count;
+      }
+    );
+
+    const historyChanges: HistoryChange[] = [
       { field: 'teamId', oldValue: teamId, newValue: null },
       { field: 'teamRole', oldValue: row.role, newValue: null },
-    ]);
+    ];
+    if (transferredCount > 0) {
+      historyChanges.push({
+        field: 'activityCount',
+        oldValue: null,
+        newValue: transferredCount,
+      });
+    }
+
+    await this.recordUserHistory(
+      userId,
+      changedByUserId,
+      'team_removed',
+      historyChanges,
+      dto?.notes ?? null
+    );
+
+    return { transferredCount };
   }
 
   async updateUserTeamRole(
@@ -638,25 +771,38 @@ export class UsersService {
   /**
    * Returns activities associated with the user (comms lead or contact).
    * Excludes deleted activities. Used for transfer dialog and "my activities" filters.
+   *
+   * When `fromTeamId` is provided, the list is scoped to activities where
+   * `leadTeamId === fromTeamId` — the set used by the transfer-activities and
+   * team-removal flows. Each row includes `isLead` so callers can distinguish
+   * lead vs. non-lead (contact) comms assignments.
    */
   async getActivitiesForUser(
-    userId: number
-  ): Promise<{ id: number; label: string; value: number }[]> {
+    userId: number,
+    fromTeamId?: number
+  ): Promise<{ id: number; label: string; value: number; isLead: boolean }[]> {
     const [deletedStatus] = await this.databaseService.db
       .select({ id: activityStatuses.id })
       .from(activityStatuses)
       .where(eq(activityStatuses.name, 'deleted' satisfies ActivityStatusName))
       .limit(1);
 
-    const conditions = [eq(activityCommsContacts.userId, userId)];
+    const conditions = [
+      eq(activityCommsContacts.userId, userId),
+      eq(activityCommsContacts.isActive, true),
+    ];
+    if (fromTeamId != null) {
+      conditions.push(eq(activities.leadTeamId, fromTeamId));
+    }
     if (deletedStatus?.id != null) {
       conditions.push(ne(activities.activityStatusId, deletedStatus.id));
     }
 
     const rows = await this.databaseService.db
-      .selectDistinct({
+      .select({
         id: activities.id,
         title: activities.title,
+        isLead: activityCommsContacts.isLead,
       })
       .from(activityCommsContacts)
       .innerJoin(
@@ -670,7 +816,327 @@ export class UsersService {
       id: r.id,
       label: r.title ?? `Activity ${r.id}`,
       value: r.id,
+      isLead: r.isLead,
     }));
+  }
+
+  /**
+   * Returns the source user's active comms-contact rows scoped to activities
+   * whose `leadTeamId === leadTeamId`. This is the eligible set for both
+   * `transferActivities` (fromTeamId) and `removeUserFromTeam` (team being removed).
+   */
+  private async getScopedCommsRows(
+    userId: number,
+    leadTeamId: number
+  ): Promise<ScopedCommsRow[]> {
+    const [deletedStatus] = await this.databaseService.db
+      .select({ id: activityStatuses.id })
+      .from(activityStatuses)
+      .where(eq(activityStatuses.name, 'deleted' satisfies ActivityStatusName))
+      .limit(1);
+
+    const conditions = [
+      eq(activityCommsContacts.userId, userId),
+      eq(activityCommsContacts.isActive, true),
+      eq(activities.leadTeamId, leadTeamId),
+    ];
+    if (deletedStatus?.id != null) {
+      conditions.push(ne(activities.activityStatusId, deletedStatus.id));
+    }
+
+    return this.databaseService.db
+      .select({
+        activityId: activityCommsContacts.activityId,
+        isLead: activityCommsContacts.isLead,
+      })
+      .from(activityCommsContacts)
+      .innerJoin(
+        activities,
+        eq(activityCommsContacts.activityId, activities.id)
+      )
+      .where(and(...conditions));
+  }
+
+  /** Resolves display names for history entries in a single query. */
+  private async getDisplayNamesById(
+    userIds: number[]
+  ): Promise<Map<number, string>> {
+    const uniqueIds = Array.from(new Set(userIds));
+    const rows = await this.databaseService.db
+      .select({
+        id: users.id,
+        adDisplayName: users.adDisplayName,
+        adUsername: users.adUsername,
+      })
+      .from(users)
+      .where(inArray(users.id, uniqueIds));
+
+    return new Map(
+      rows.map((u) => [u.id, u.adDisplayName || u.adUsername || `User ${u.id}`])
+    );
+  }
+
+  /**
+   * Resolves the team abbreviation and ministry context for a target lead team,
+   * mirroring the lookup `ActivitiesService.update` performs when `leadTeamId`
+   * changes, so displayId/ministry inheritance stay consistent across both paths.
+   */
+  private async resolveCrossTeamContext(
+    toTeamId: number
+  ): Promise<CrossTeamContext> {
+    const [teamRow] = await this.databaseService.db
+      .select({
+        abbreviation: teams.abbreviation,
+        ministryId: teams.ministryId,
+      })
+      .from(teams)
+      .where(eq(teams.id, toTeamId))
+      .limit(1);
+
+    if (!teamRow) {
+      throw new BadRequestException(`Team with ID ${toTeamId} not found`);
+    }
+
+    let ministryAbbreviation: string | null = null;
+    if (teamRow.ministryId != null) {
+      const [ministry] = await this.databaseService.db
+        .select({ abbreviation: ministries.abbreviation })
+        .from(ministries)
+        .where(eq(ministries.id, teamRow.ministryId))
+        .limit(1);
+      ministryAbbreviation = ministry?.abbreviation ?? null;
+    }
+
+    return {
+      teamAbbreviation: teamRow.abbreviation ?? null,
+      leadMinistryId: teamRow.ministryId ?? null,
+      ministryAbbreviation,
+    };
+  }
+
+  /**
+   * Validates that the target user is an eligible comms contact for the
+   * effective lead team, but only when comms will actually move to them
+   * (lead comms always move; non-lead only when `includeNonLead` is true).
+   */
+  private validateTransferTarget(
+    rows: ScopedCommsRow[],
+    targetUserId: number | null,
+    includeNonLead: boolean,
+    eligibleOnToTeam: Set<number>
+  ): void {
+    const willReceiveComms = rows.some((r) => r.isLead || includeNonLead);
+    if (!willReceiveComms) return;
+
+    if (targetUserId == null) {
+      throw new BadRequestException(
+        'targetUserId is required to transfer comms assignments.'
+      );
+    }
+    if (!eligibleOnToTeam.has(targetUserId)) {
+      throw new BadRequestException(
+        `Target user ${targetUserId} is not an eligible comms contact for the destination team. ` +
+          'Target must be an active member of that team with activities.edit permission.'
+      );
+    }
+  }
+
+  /**
+   * Transfers a single comms-contact row from source to target user, merging
+   * with any existing target row (OR'ing `isLead`) to avoid unique-key conflicts.
+   */
+  private async transferSingleCommsRow(
+    tx: DrizzleDbExecutor,
+    activityId: number,
+    sourceUserId: number,
+    targetUserId: number,
+    isLead: boolean
+  ): Promise<void> {
+    const [targetRow] = await tx
+      .select({ isLead: activityCommsContacts.isLead })
+      .from(activityCommsContacts)
+      .where(
+        and(
+          eq(activityCommsContacts.activityId, activityId),
+          eq(activityCommsContacts.userId, targetUserId)
+        )
+      )
+      .limit(1);
+
+    if (targetRow) {
+      await tx
+        .delete(activityCommsContacts)
+        .where(
+          and(
+            eq(activityCommsContacts.activityId, activityId),
+            eq(activityCommsContacts.userId, sourceUserId)
+          )
+        );
+      await tx
+        .update(activityCommsContacts)
+        .set({ isLead: isLead || targetRow.isLead })
+        .where(
+          and(
+            eq(activityCommsContacts.activityId, activityId),
+            eq(activityCommsContacts.userId, targetUserId)
+          )
+        );
+    } else {
+      await tx
+        .update(activityCommsContacts)
+        .set({ userId: targetUserId })
+        .where(
+          and(
+            eq(activityCommsContacts.activityId, activityId),
+            eq(activityCommsContacts.userId, sourceUserId)
+          )
+        );
+    }
+  }
+
+  /**
+   * Core per-activity engine shared by `transferActivities` (mode: 'transfer')
+   * and `removeUserFromTeam` (mode: 'removal'). Must run inside a transaction.
+   *
+   * Rules (see docs/spec for full rationale):
+   * - Lead comms always transfer to `targetUserId` when in scope/selected.
+   * - Non-lead comms transfer when `includeNonLead` is true.
+   * - Non-lead comms when `includeNonLead` is false:
+   *   - mode 'removal': always deleted (the user is leaving the team, so
+   *     leaving them attached would violate lead-team comms eligibility).
+   *   - mode 'transfer', same team: left as-is (no action).
+   *   - mode 'transfer', cross-team: left as-is if the source user remains
+   *     comms-eligible on the new lead team, otherwise deleted.
+   * - When `toTeamId !== fromTeamId`, each affected activity's `leadTeamId`
+   *   (and derived `leadMinistryId`/`displayId`) moves with it, matching the
+   *   Activity Form's lead-team-change behavior.
+   */
+  private async applyActivityCommsChanges(
+    tx: DrizzleDbExecutor,
+    params: {
+      sourceUserId: number;
+      targetUserId: number | null;
+      fromTeamId: number;
+      toTeamId: number;
+      rows: ScopedCommsRow[];
+      includeNonLead: boolean;
+      mode: 'transfer' | 'removal';
+      changedByUserId: number;
+      notes?: string;
+      sourceDisplayName: string;
+      targetDisplayName: string | null;
+      crossTeamContext: CrossTeamContext | null;
+      eligibleSourceOnToTeam: Set<number>;
+    }
+  ): Promise<number> {
+    const {
+      sourceUserId,
+      targetUserId,
+      fromTeamId,
+      toTeamId,
+      rows,
+      includeNonLead,
+      mode,
+      changedByUserId,
+      notes,
+      sourceDisplayName,
+      targetDisplayName,
+      crossTeamContext,
+      eligibleSourceOnToTeam,
+    } = params;
+
+    const crossTeam = toTeamId !== fromTeamId;
+    const trimmedNotes = notes?.trim() || undefined;
+    let count = 0;
+
+    for (const row of rows) {
+      let actionTaken = false;
+
+      if (crossTeam && crossTeamContext) {
+        const displayId =
+          this.activityUtilsService.computeDisplayIdFromLeadContext({
+            activityId: row.activityId,
+            leadMinistryId: crossTeamContext.leadMinistryId,
+            ministryAbbreviation: crossTeamContext.ministryAbbreviation,
+            teamAbbreviation: crossTeamContext.teamAbbreviation,
+          });
+
+        await tx
+          .update(activities)
+          .set({
+            leadTeamId: toTeamId,
+            leadMinistryId: crossTeamContext.leadMinistryId,
+            displayId,
+            lastUpdatedDateTime: new Date(),
+            lastUpdatedBy: changedByUserId,
+          })
+          .where(eq(activities.id, row.activityId));
+
+        await this.activityHistoryService.recordChange(
+          row.activityId,
+          changedByUserId,
+          'lead_team_changed',
+          [{ field: 'leadTeamId', oldValue: fromTeamId, newValue: toTeamId }],
+          trimmedNotes,
+          tx
+        );
+
+        actionTaken = true;
+      }
+
+      if (row.isLead) {
+        // targetUserId presence guaranteed by validateTransferTarget when any row is lead.
+        await this.transferSingleCommsRow(
+          tx,
+          row.activityId,
+          sourceUserId,
+          targetUserId!,
+          row.isLead
+        );
+        await this.activityHistoryService.recordChange(
+          row.activityId,
+          changedByUserId,
+          'comms_lead_transferred',
+          [
+            {
+              field: 'commsContactLeadId',
+              oldValue: sourceDisplayName,
+              newValue: targetDisplayName,
+            },
+          ],
+          trimmedNotes,
+          tx
+        );
+        actionTaken = true;
+      } else if (includeNonLead) {
+        await this.transferSingleCommsRow(
+          tx,
+          row.activityId,
+          sourceUserId,
+          targetUserId!,
+          row.isLead
+        );
+        actionTaken = true;
+      } else if (
+        mode === 'removal' ||
+        (crossTeam && !eligibleSourceOnToTeam.has(sourceUserId))
+      ) {
+        await tx
+          .delete(activityCommsContacts)
+          .where(
+            and(
+              eq(activityCommsContacts.activityId, row.activityId),
+              eq(activityCommsContacts.userId, sourceUserId)
+            )
+          );
+        actionTaken = true;
+      }
+      // else: transfer mode, non-lead unchecked, source remains comms-eligible -> keep, no action.
+
+      if (actionTaken) count += 1;
+    }
+
+    return count;
   }
 
   /**
@@ -719,34 +1185,39 @@ export class UsersService {
     }));
   }
 
+  /**
+   * Transfers activity comms assignments from `sourceUserId` to `dto.targetUserId`.
+   *
+   * Scope is every activity where the source user has an active comms row and
+   * `activities.leadTeamId === dto.fromTeamId`; `dto.activityIds`, if given,
+   * must be a subset of that scope. See `applyActivityCommsChanges` for the
+   * per-activity lead/non-lead and cross-team rules.
+   */
   async transferActivities(
     sourceUserId: number,
     dto: TransferActivitiesBody,
     changedByUserId: number
   ): Promise<{ transferredCount: number }> {
-    if (sourceUserId === dto.targetUserId)
+    if (sourceUserId === dto.targetUserId) {
       throw new BadRequestException('Source and target user must be different');
+    }
 
-    if (!dto.transferCommsLead && !dto.transferCommsContact)
-      throw new BadRequestException(
-        'At least one of transferCommsLead or transferCommsContact must be true'
-      );
+    const fromTeamId = dto.fromTeamId;
+    const toTeamId = dto.toTeamId ?? fromTeamId;
 
-    const leadFilter = dto.transferCommsLead && !dto.transferCommsContact;
-    const contactFilter = dto.transferCommsContact && !dto.transferCommsLead;
+    const scopedRows = await this.getScopedCommsRows(sourceUserId, fromTeamId);
+    const scopedIds = new Set(scopedRows.map((r) => r.activityId));
 
     let activityIds = dto.activityIds;
-    if (!activityIds || activityIds.length === 0) {
-      const conditions = [eq(activityCommsContacts.userId, sourceUserId)];
-      if (leadFilter) conditions.push(eq(activityCommsContacts.isLead, true));
-      if (contactFilter)
-        conditions.push(eq(activityCommsContacts.isLead, false));
-
-      const rows = await this.databaseService.db
-        .selectDistinct({ activityId: activityCommsContacts.activityId })
-        .from(activityCommsContacts)
-        .where(and(...conditions));
-      activityIds = rows.map((r) => r.activityId);
+    if (activityIds && activityIds.length > 0) {
+      const invalidIds = activityIds.filter((id) => !scopedIds.has(id));
+      if (invalidIds.length > 0) {
+        throw new BadRequestException(
+          `Activities [${invalidIds.join(', ')}] are not eligible for transfer from team ${fromTeamId}.`
+        );
+      }
+    } else {
+      activityIds = Array.from(scopedIds);
     }
 
     if (activityIds.length === 0) {
@@ -755,11 +1226,7 @@ export class UsersService {
         changedByUserId,
         'activities_transferred',
         [
-          {
-            field: 'targetUserId',
-            oldValue: null,
-            newValue: dto.targetUserId,
-          },
+          { field: 'targetUserId', oldValue: null, newValue: dto.targetUserId },
           { field: 'activityCount', oldValue: null, newValue: 0 },
         ],
         dto.notes ?? null
@@ -767,154 +1234,49 @@ export class UsersService {
       return { transferredCount: 0 };
     }
 
-    const updateConditions = [
-      eq(activityCommsContacts.userId, sourceUserId),
-      inArray(activityCommsContacts.activityId, activityIds),
-    ];
-    if (leadFilter)
-      updateConditions.push(eq(activityCommsContacts.isLead, true));
-    if (contactFilter)
-      updateConditions.push(eq(activityCommsContacts.isLead, false));
-
-    const sourceRows = await this.databaseService.db
-      .select({
-        activityId: activityCommsContacts.activityId,
-        isLead: activityCommsContacts.isLead,
-      })
-      .from(activityCommsContacts)
-      .where(and(...updateConditions));
-
-    if (sourceRows.length === 0) {
-      await this.recordUserHistory(
-        sourceUserId,
-        changedByUserId,
-        'activities_transferred',
-        [
-          {
-            field: 'targetUserId',
-            oldValue: null,
-            newValue: dto.targetUserId,
-          },
-          { field: 'activityCount', oldValue: null, newValue: 0 },
-        ],
-        dto.notes ?? null
-      );
-      return { transferredCount: 0 };
-    }
-
-    const userRowsForHistory = await this.databaseService.db
-      .select({
-        id: users.id,
-        adDisplayName: users.adDisplayName,
-        adUsername: users.adUsername,
-      })
-      .from(users)
-      .where(inArray(users.id, [sourceUserId, dto.targetUserId]));
-
-    const displayNameById = new Map(
-      userRowsForHistory.map((u) => [
-        u.id,
-        u.adDisplayName || u.adUsername || `User ${u.id}`,
-      ])
+    const rowsToProcess = scopedRows.filter((r) =>
+      activityIds.includes(r.activityId)
     );
+
+    const eligibleOnToTeam =
+      await this.teamsService.getEligibleCommsUserIds(toTeamId);
+    this.validateTransferTarget(
+      rowsToProcess,
+      dto.targetUserId,
+      dto.includeNonLead,
+      eligibleOnToTeam
+    );
+
+    const displayNameById = await this.getDisplayNamesById([
+      sourceUserId,
+      dto.targetUserId,
+    ]);
     const sourceDisplayName =
       displayNameById.get(sourceUserId) ?? `User ${sourceUserId}`;
     const targetDisplayName =
       displayNameById.get(dto.targetUserId) ?? `User ${dto.targetUserId}`;
 
-    const trimmedTransferNote = dto.notes?.trim() ?? '';
-    const activityTitleById = new Map<number, string>();
-    if (trimmedTransferNote.length > 0) {
-      const leadActivityIds = [
-        ...new Set(sourceRows.filter((r) => r.isLead).map((r) => r.activityId)),
-      ];
-      if (leadActivityIds.length > 0) {
-        const titleRows = await this.databaseService.db
-          .select({ id: activities.id, title: activities.title })
-          .from(activities)
-          .where(inArray(activities.id, leadActivityIds));
-        for (const r of titleRows) {
-          const label = r.title?.trim() || `Activity ${r.id}`;
-          activityTitleById.set(r.id, label);
-        }
-      }
-    }
+    const crossTeam = toTeamId !== fromTeamId;
+    const crossTeamContext = crossTeam
+      ? await this.resolveCrossTeamContext(toTeamId)
+      : null;
 
-    const transferredCount = await this.databaseService.db.transaction(
-      async (tx) => {
-        let count = 0;
-        for (const row of sourceRows) {
-          const [targetRow] = await tx
-            .select({
-              isLead: activityCommsContacts.isLead,
-            })
-            .from(activityCommsContacts)
-            .where(
-              and(
-                eq(activityCommsContacts.activityId, row.activityId),
-                eq(activityCommsContacts.userId, dto.targetUserId)
-              )
-            )
-            .limit(1);
-
-          if (targetRow) {
-            await tx
-              .delete(activityCommsContacts)
-              .where(
-                and(
-                  eq(activityCommsContacts.activityId, row.activityId),
-                  eq(activityCommsContacts.userId, sourceUserId)
-                )
-              );
-            await tx
-              .update(activityCommsContacts)
-              .set({
-                isLead: row.isLead || targetRow.isLead,
-              })
-              .where(
-                and(
-                  eq(activityCommsContacts.activityId, row.activityId),
-                  eq(activityCommsContacts.userId, dto.targetUserId)
-                )
-              );
-          } else {
-            await tx
-              .update(activityCommsContacts)
-              .set({ userId: dto.targetUserId })
-              .where(
-                and(
-                  eq(activityCommsContacts.activityId, row.activityId),
-                  eq(activityCommsContacts.userId, sourceUserId)
-                )
-              );
-          }
-
-          if (row.isLead) {
-            let historyNotes: string | undefined;
-            if (trimmedTransferNote.length > 0) {
-              historyNotes = `${trimmedTransferNote}`;
-            }
-
-            await this.activityHistoryService.recordChange(
-              row.activityId,
-              changedByUserId,
-              'comms_lead_transferred',
-              [
-                {
-                  field: 'commsContactLeadId',
-                  oldValue: sourceDisplayName,
-                  newValue: targetDisplayName,
-                },
-              ],
-              historyNotes,
-              tx
-            );
-          }
-
-          count += 1;
-        }
-        return count;
-      }
+    const transferredCount = await this.databaseService.db.transaction((tx) =>
+      this.applyActivityCommsChanges(tx, {
+        sourceUserId,
+        targetUserId: dto.targetUserId,
+        fromTeamId,
+        toTeamId,
+        rows: rowsToProcess,
+        includeNonLead: dto.includeNonLead,
+        mode: 'transfer',
+        changedByUserId,
+        notes: dto.notes,
+        sourceDisplayName,
+        targetDisplayName,
+        crossTeamContext,
+        eligibleSourceOnToTeam: eligibleOnToTeam,
+      })
     );
 
     await this.recordUserHistory(
@@ -923,6 +1285,8 @@ export class UsersService {
       'activities_transferred',
       [
         { field: 'targetUserId', oldValue: null, newValue: dto.targetUserId },
+        { field: 'fromTeamId', oldValue: null, newValue: fromTeamId },
+        { field: 'toTeamId', oldValue: null, newValue: toTeamId },
         { field: 'activityCount', oldValue: null, newValue: transferredCount },
         { field: 'activityIds', oldValue: null, newValue: activityIds },
       ],

--- a/calendar-ui/src/api/usersApi.ts
+++ b/calendar-ui/src/api/usersApi.ts
@@ -4,6 +4,7 @@
 import type {
   AddUserToTeamBody,
   CreateUserBody,
+  RemoveUserFromTeamBody,
   RoleOption,
   TeamListItem,
   TransferActivitiesBody,
@@ -89,11 +90,24 @@ export async function addUserToTeam(
   await api.post(`/users/${userId}/teams`, body);
 }
 
+/**
+ * Removes a user from a team.
+ *
+ * `body` is optional: omit it (or omit `targetUserId`) for a silent removal
+ * when the user has no comms assignments scoped to this team. If the user
+ * does have scoped comms assignments, the server rejects the request unless
+ * `targetUserId` is provided to transfer them.
+ */
 export async function removeUserFromTeam(
   userId: number,
-  teamId: number
-): Promise<void> {
-  await api.delete(`/users/${userId}/teams/${teamId}`);
+  teamId: number,
+  body?: RemoveUserFromTeamBody
+): Promise<{ transferredCount: number }> {
+  const response = await api.delete<{
+    success: boolean;
+    transferredCount: number;
+  }>(`/users/${userId}/teams/${teamId}`, { data: body });
+  return { transferredCount: response.data.transferredCount };
 }
 
 export async function updateUserTeamRole(
@@ -118,6 +132,7 @@ export interface UserActivityItem {
   id: number;
   label: string;
   value: number;
+  isLead: boolean;
 }
 
 export interface UserActivityCountItem {
@@ -125,13 +140,21 @@ export interface UserActivityCountItem {
   activityCount: number;
 }
 
+/**
+ * Fetches activities where the user has an active comms contact row.
+ * When `fromTeamId` is provided, scopes to activities where
+ * `leadTeamId === fromTeamId` (the set used by transfer/removal flows).
+ */
 export async function fetchUserActivities(
-  userId: number
+  userId: number,
+  fromTeamId?: number
 ): Promise<UserActivityItem[]> {
   const response = await api.get<{
     success: boolean;
     data: UserActivityItem[];
-  }>(`/users/${userId}/activities`);
+  }>(`/users/${userId}/activities`, {
+    params: fromTeamId != null ? { fromTeamId } : undefined,
+  });
   return response.data.data;
 }
 

--- a/calendar-ui/src/components/teams/AddTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/AddTeamMemberModal.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { invalidateUserCaches } from '@/lib/userQueryKeys';
 
 interface AddTeamMemberModalProps {
   open: boolean;
@@ -103,6 +104,10 @@ export function AddTeamMemberModal({
         });
       }
       void qc.invalidateQueries({ queryKey: ['team', teamId] });
+      for (const [index, result] of results.entries()) {
+        if (result.status !== 'fulfilled') continue;
+        invalidateUserCaches(qc, selectedUsers[index].id);
+      }
       onAdded();
       onClose();
     } catch (err: any) {

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -33,6 +33,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { invalidateUserCaches } from '@/lib/userQueryKeys';
 import { cn } from '@/lib/utils';
 
 interface RemoveTeamMemberTarget {
@@ -185,7 +186,9 @@ export function RemoveTeamMemberModal({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['team', teamId] });
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      if (sourceUserId != null) {
+        invalidateUserCaches(queryClient, sourceUserId);
+      }
       toast.success('Team member removed');
       onRemoved();
     },

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -1,25 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import type { UserListItem } from '@corpcal/shared/api/types';
-import {
-  fetchUserActivities,
-  fetchUsers,
-  removeUserFromTeam,
-  transferActivities,
-} from '@/api/usersApi';
+import { PERMISSIONS as SHARED_PERMISSIONS } from '@corpcal/shared';
+import { fetchUserActivities, removeUserFromTeam } from '@/api/usersApi';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
 import {
   Dialog,
   DialogContent,
@@ -27,14 +13,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+  buildRemoveUserFromTeamBody,
+  createInitialTransferDraft,
+  isTransferActivitiesDraftValid,
+  TransferActivitiesFields,
+  type TransferActivitiesDraft,
+} from '@/components/users/TransferActivitiesFields';
+import { useAuth } from '@/hooks/useAuth';
 import { invalidateUserCaches } from '@/lib/userQueryKeys';
-import { cn } from '@/lib/utils';
 
 interface RemoveTeamMemberTarget {
   userId: number;
@@ -51,25 +38,6 @@ interface RemoveTeamMemberModalProps {
   onRemoved: () => void;
 }
 
-interface UserOption {
-  id: number;
-  value: string;
-  label: string;
-}
-
-function userToOption(
-  u: UserListItem & {
-    adDisplayName?: string | null;
-    adUsername?: string | null;
-  }
-): UserOption {
-  return {
-    id: u.id,
-    value: String(u.id),
-    label: u.adDisplayName || u.adUsername || `User ${u.id}`,
-  };
-}
-
 export function RemoveTeamMemberModal({
   open,
   teamId,
@@ -79,93 +47,47 @@ export function RemoveTeamMemberModal({
   onRemoved,
 }: RemoveTeamMemberModalProps) {
   const queryClient = useQueryClient();
+  const { hasPermission } = useAuth();
+  const canTransferActivities = hasPermission(
+    SHARED_PERMISSIONS.USERS.TRANSFER_ACTIVITIES
+  );
+
   const sourceUserId = member?.userId ?? null;
-
-  const [targetUserId, setTargetUserId] = useState<number | null>(null);
-  const [targetUserLabel, setTargetUserLabel] = useState('');
-  const [transferCommsLead, setTransferCommsLead] = useState(true);
-  const [transferCommsContact, setTransferCommsContact] = useState(true);
-  const [selectedActivityIds, setSelectedActivityIds] = useState<number[]>([]);
-  const [comboboxOpen, setComboboxOpen] = useState(false);
-  const [userSearch, setUserSearch] = useState('');
-  const [activitiesDropdownOpen, setActivitiesDropdownOpen] = useState(false);
-
-  const activitiesInitializedForUser = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!open) {
-      setTargetUserId(null);
-      setTargetUserLabel('');
-      setTransferCommsLead(true);
-      setTransferCommsContact(true);
-      setSelectedActivityIds([]);
-      setComboboxOpen(false);
-      setUserSearch('');
-      setActivitiesDropdownOpen(false);
-      activitiesInitializedForUser.current = null;
-    }
-  }, [open]);
+  const [draft, setDraft] = useState<TransferActivitiesDraft>(() =>
+    createInitialTransferDraft(teamId)
+  );
 
   const {
-    data: userActivities = [],
-    isLoading: isLoadingActivities,
-    isError: isActivitiesError,
+    data: scopedActivities = [],
+    isLoading: isLoadingScopedActivities,
+    isError: isScopedActivitiesError,
   } = useQuery({
-    queryKey: ['users', sourceUserId, 'activities'],
-    queryFn: () => fetchUserActivities(sourceUserId!),
+    queryKey: ['users', sourceUserId, 'activities', teamId],
+    queryFn: () => fetchUserActivities(sourceUserId!, teamId),
     enabled: open && sourceUserId != null,
   });
 
+  const hasActivities = scopedActivities.length > 0;
+
   useEffect(() => {
-    if (
-      sourceUserId != null &&
-      userActivities.length > 0 &&
-      activitiesInitializedForUser.current !== sourceUserId
-    ) {
-      activitiesInitializedForUser.current = sourceUserId;
-      setSelectedActivityIds(userActivities.map((a) => a.id));
+    if (!open) {
+      setDraft(createInitialTransferDraft(teamId));
+    } else {
+      setDraft(createInitialTransferDraft(teamId));
     }
-  }, [sourceUserId, userActivities]);
-
-  const hasActivities = userActivities.length > 0;
-
-  const { data: searchUsers = [], isFetching: isSearchingUsers } = useQuery({
-    queryKey: ['users', 'team-member-removal', teamId, userSearch],
-    queryFn: () =>
-      fetchUsers({
-        search: userSearch.trim() || undefined,
-        teamIds: [teamId],
-      }),
-    enabled: open && hasActivities && comboboxOpen && sourceUserId != null,
-  });
-
-  const transferTargetOptions = useMemo(() => {
-    return searchUsers
-      .filter((u) => u.id !== sourceUserId && u.isActive)
-      .map((u) => userToOption(u));
-  }, [searchUsers, sourceUserId]);
-
-  const toggleActivity = (activityId: number) => {
-    setSelectedActivityIds((prev) =>
-      prev.includes(activityId)
-        ? prev.filter((id) => id !== activityId)
-        : [...prev, activityId]
-    );
-  };
-
-  const selectedCount = selectedActivityIds.length;
-  const noneSelected = selectedCount === 0;
-  const allSelected =
-    userActivities.length > 0 && selectedCount === userActivities.length;
+  }, [open, teamId]);
 
   const canSubmit =
-    !isLoadingActivities &&
     sourceUserId != null &&
+    !isLoadingScopedActivities &&
+    !isScopedActivitiesError &&
     (!hasActivities ||
-      (targetUserId != null &&
-        targetUserId !== sourceUserId &&
-        (transferCommsLead || transferCommsContact) &&
-        selectedCount > 0));
+      (canTransferActivities &&
+        isTransferActivitiesDraftValid(
+          { ...draft, fromTeamId: teamId },
+          sourceUserId,
+          hasActivities
+        )));
 
   const removeMutation = useMutation({
     mutationFn: async () => {
@@ -173,22 +95,15 @@ export function RemoveTeamMemberModal({
         throw new Error('No source user selected');
       }
 
-      if (hasActivities) {
-        await transferActivities(sourceUserId, {
-          targetUserId: targetUserId!,
-          activityIds: allSelected ? undefined : selectedActivityIds,
-          transferCommsLead,
-          transferCommsContact,
-        });
-      }
-
-      await removeUserFromTeam(sourceUserId, teamId);
+      const body = buildRemoveUserFromTeamBody(
+        { ...draft, fromTeamId: teamId },
+        hasActivities
+      );
+      return removeUserFromTeam(sourceUserId, teamId, body);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['team', teamId] });
-      if (sourceUserId != null) {
-        invalidateUserCaches(queryClient, sourceUserId);
-      }
+      invalidateUserCaches(queryClient, sourceUserId!);
       toast.success('Team member removed');
       onRemoved();
     },
@@ -212,217 +127,33 @@ export function RemoveTeamMemberModal({
             {sourceName} will be removed from {teamName} team.
           </p>
 
-          {isLoadingActivities ? (
+          {isLoadingScopedActivities && (
             <div className="flex justify-center py-2">
               <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
             </div>
-          ) : isActivitiesError ? (
-            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              Could not load assigned activities. Please try again.
-            </div>
-          ) : hasActivities ? (
-            <>
-              <div className="space-y-1">
-                <h3 className="text-lg font-semibold">Transfer activities</h3>
-                <p className="text-sm text-slate-700">
-                  {userActivities.length} active{' '}
-                  {userActivities.length === 1 ? 'activity' : 'activities'} must
-                  be transferred to another team member.
-                </p>
-              </div>
+          )}
 
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">
-                  Transfer to user{' '}
-                  <span className="text-required-field-indicator font-semibold">
-                    *
-                  </span>
-                </Label>
-                <Popover
-                  open={comboboxOpen}
-                  onOpenChange={(nextOpen) => {
-                    setComboboxOpen(nextOpen);
-                    if (!nextOpen) setUserSearch('');
-                  }}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={comboboxOpen}
-                      className="w-full justify-between font-normal"
-                    >
-                      {targetUserId != null && targetUserLabel
-                        ? targetUserLabel
-                        : 'Select user...'}
-                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-(--radix-popover-trigger-width) p-0"
-                    align="start"
-                  >
-                    <Command shouldFilter={false}>
-                      <CommandInput
-                        placeholder="Search users..."
-                        value={userSearch}
-                        onValueChange={setUserSearch}
-                      />
-                      <CommandList>
-                        {isSearchingUsers ? (
-                          <div className="flex items-center justify-center py-6">
-                            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
-                          </div>
-                        ) : (
-                          <>
-                            <CommandEmpty>No users found.</CommandEmpty>
-                            <CommandGroup>
-                              {transferTargetOptions.map((option) => {
-                                const selected = targetUserId === option.id;
-                                return (
-                                  <CommandItem
-                                    key={option.value}
-                                    value={option.value}
-                                    onSelect={() => {
-                                      setTargetUserId(option.id);
-                                      setTargetUserLabel(option.label);
-                                      setUserSearch('');
-                                      setComboboxOpen(false);
-                                    }}
-                                  >
-                                    <Check
-                                      className={cn(
-                                        'mr-2 h-4 w-4',
-                                        selected ? 'opacity-100' : 'opacity-0'
-                                      )}
-                                    />
-                                    {option.label}
-                                  </CommandItem>
-                                );
-                              })}
-                            </CommandGroup>
-                          </>
-                        )}
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+          {hasActivities &&
+            !canTransferActivities &&
+            !isLoadingScopedActivities && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                This user has comms assignments on activities led by this team.
+                You need permission to transfer activities before removing them.
               </div>
+            )}
 
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="transfer-lead"
-                    checked={transferCommsLead}
-                    onCheckedChange={(checked) =>
-                      setTransferCommsLead(checked === true)
-                    }
-                  />
-                  <Label
-                    htmlFor="transfer-lead"
-                    className="cursor-pointer text-sm font-normal"
-                  >
-                    Comms lead assignments
-                  </Label>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="transfer-contact"
-                    checked={transferCommsContact}
-                    onCheckedChange={(checked) =>
-                      setTransferCommsContact(checked === true)
-                    }
-                  />
-                  <Label
-                    htmlFor="transfer-contact"
-                    className="cursor-pointer text-sm font-normal"
-                  >
-                    Comms contact (non-lead) assignments
-                  </Label>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">
-                  Activities{' '}
-                  <span className="text-required-field-indicator font-semibold">
-                    *
-                  </span>
-                </Label>
-                <Popover
-                  open={activitiesDropdownOpen}
-                  onOpenChange={setActivitiesDropdownOpen}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={activitiesDropdownOpen}
-                      className="w-full justify-between font-normal"
-                    >
-                      {selectedCount === 0
-                        ? 'No activities selected'
-                        : `${selectedCount} activities selected`}
-                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-(--radix-popover-trigger-width) p-0"
-                    align="start"
-                  >
-                    <div className="flex flex-col">
-                      <div className="flex items-center justify-between border-b px-3 py-2 text-sm">
-                        <span className="text-muted-foreground">
-                          {noneSelected
-                            ? 'None selected'
-                            : `${selectedCount} selected`}
-                        </span>
-                        <button
-                          type="button"
-                          className="text-primary hover:underline focus:underline focus:outline-none"
-                          onClick={() => {
-                            if (noneSelected) {
-                              setSelectedActivityIds(
-                                userActivities.map((a) => a.id)
-                              );
-                            } else {
-                              setSelectedActivityIds([]);
-                            }
-                          }}
-                        >
-                          {noneSelected ? 'Select all' : 'Deselect all'}
-                        </button>
-                      </div>
-                      <div className="max-h-[240px] overflow-auto p-1">
-                        {userActivities.map((activity) => (
-                          <div
-                            key={activity.id}
-                            className="hover:bg-accent flex items-center space-x-2 rounded-sm px-2 py-1.5"
-                          >
-                            <Checkbox
-                              id={`activity-${activity.id}`}
-                              checked={selectedActivityIds.includes(
-                                activity.id
-                              )}
-                              onCheckedChange={() =>
-                                toggleActivity(activity.id)
-                              }
-                            />
-                            <Label
-                              htmlFor={`activity-${activity.id}`}
-                              className="flex-1 cursor-pointer text-sm font-normal"
-                            >
-                              {activity.label}
-                            </Label>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
-            </>
-          ) : null}
+          {sourceUserId != null && canTransferActivities && hasActivities && (
+            <TransferActivitiesFields
+              mode="removal"
+              sourceUserId={sourceUserId}
+              fromTeamOptions={[{ teamId, teamName }]}
+              fixedFromTeamId={teamId}
+              fixedFromTeamName={teamName}
+              value={{ ...draft, fromTeamId: teamId }}
+              onChange={(next) => setDraft({ ...next, fromTeamId: teamId })}
+              showNotes={false}
+            />
+          )}
         </div>
 
         <DialogFooter>
@@ -432,7 +163,7 @@ export function RemoveTeamMemberModal({
           <Button
             variant="destructive"
             disabled={
-              !canSubmit || removeMutation.isPending || isActivitiesError
+              !canSubmit || removeMutation.isPending || isScopedActivitiesError
             }
             onClick={() => removeMutation.mutate()}
           >

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -70,11 +70,7 @@ export function RemoveTeamMemberModal({
   const hasActivities = scopedActivities.length > 0;
 
   useEffect(() => {
-    if (!open) {
-      setDraft(createInitialTransferDraft(teamId));
-    } else {
-      setDraft(createInitialTransferDraft(teamId));
-    }
+    setDraft(createInitialTransferDraft(teamId));
   }, [open, teamId]);
 
   const canSubmit =

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -133,6 +133,12 @@ export function RemoveTeamMemberModal({
             </div>
           )}
 
+          {isScopedActivitiesError && !isLoadingScopedActivities && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              Could not load assigned activities. Please try again.
+            </div>
+          )}
+
           {hasActivities &&
             !canTransferActivities &&
             !isLoadingScopedActivities && (

--- a/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
+++ b/calendar-ui/src/components/teams/RemoveTeamMemberModal.tsx
@@ -150,7 +150,13 @@ export function RemoveTeamMemberModal({
               fixedFromTeamId={teamId}
               fixedFromTeamName={teamName}
               value={{ ...draft, fromTeamId: teamId }}
-              onChange={(next) => setDraft({ ...next, fromTeamId: teamId })}
+              onChange={(next) =>
+                setDraft((prev) => {
+                  const resolved =
+                    typeof next === 'function' ? next(prev) : next;
+                  return { ...resolved, fromTeamId: teamId };
+                })
+              }
               showNotes={false}
             />
           )}

--- a/calendar-ui/src/components/users/TeamsComboboxSelectAllRow.tsx
+++ b/calendar-ui/src/components/users/TeamsComboboxSelectAllRow.tsx
@@ -1,0 +1,41 @@
+import { CheckIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface TeamsComboboxSelectAllRowProps {
+  allSelected: boolean;
+  disabled?: boolean;
+  onToggleSelectAll: () => void;
+}
+
+export function TeamsComboboxSelectAllRow({
+  allSelected,
+  disabled,
+  onToggleSelectAll,
+}: TeamsComboboxSelectAllRowProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={cn(
+        'relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none',
+        disabled
+          ? 'pointer-events-none opacity-50'
+          : 'hover:bg-accent hover:text-accent-foreground'
+      )}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!disabled) onToggleSelectAll();
+      }}
+    >
+      <span className="flex-1 text-left font-medium">Select all teams</span>
+      {allSelected ? (
+        <CheckIcon
+          className="pointer-events-none absolute right-2 size-4 shrink-0"
+          aria-hidden
+        />
+      ) : null}
+    </button>
+  );
+}

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -33,6 +33,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { invalidateUserCaches } from '@/lib/userQueryKeys';
 import { cn } from '@/lib/utils';
 
 interface TransferActivitiesDialogProps {
@@ -139,7 +140,7 @@ export function TransferActivitiesDialog({
         notes: notes || undefined,
       }),
     onSuccess: (data) => {
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      invalidateUserCaches(queryClient, sourceUser.id);
       const toastId =
         targetUserId != null
           ? `activities-transferred-${sourceUser.id}-${targetUserId}`

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -100,6 +100,7 @@ export function TransferActivitiesDialog({
   const canSubmit =
     draft.fromTeamId != null &&
     fromTeamOptions.length > 0 &&
+    hasActivities &&
     !fieldsMeta.isLoading &&
     isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
     !fieldsMeta.isError;
@@ -128,6 +129,7 @@ export function TransferActivitiesDialog({
             <TransferActivitiesFields
               mode="transfer"
               sourceUserId={sourceUser.id}
+              sourceDisplayName={sourceName}
               fromTeamOptions={fromTeamOptions}
               value={
                 draft.fromTeamId == null && initialFromTeamId != null

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -16,11 +16,12 @@ import {
 import {
   buildTransferActivitiesBody,
   createInitialTransferDraft,
-  isTransferActivitiesDraftValid,
   TransferActivitiesFields,
   type TransferActivitiesDraft,
   type TransferActivitiesFieldsMeta,
 } from '@/components/users/TransferActivitiesFields';
+import { useTransferActivitiesSubmit } from '@/hooks/useTransferActivitiesSubmit';
+import { formatTransferActivitiesSuccessMessage } from '@/lib/transfer-activities-messages';
 import { invalidateUserCaches } from '@/lib/userQueryKeys';
 
 interface TransferActivitiesDialogProps {
@@ -67,6 +68,17 @@ export function TransferActivitiesDialog({
     }
   }, [initialFromTeamId, draft.fromTeamId]);
 
+  const { canSubmit, isDraftPristine, resetForm } = useTransferActivitiesSubmit(
+    {
+      sourceUserId: sourceUser.id,
+      draft,
+      fieldsMeta,
+      initialFromTeamId,
+      requireFromTeamOptions: true,
+      fromTeamOptionCount: fromTeamOptions.length,
+    }
+  );
+
   const transferMutation = useMutation({
     mutationFn: () => {
       const body = buildTransferActivitiesBody(
@@ -81,9 +93,12 @@ export function TransferActivitiesDialog({
         draft.targetUserId != null
           ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
-      toast.success(`Transferred ${data.transferredCount} assignment(s)`, {
-        id: toastId,
-      });
+      toast.success(
+        formatTransferActivitiesSuccessMessage(data.transferredCount),
+        {
+          id: toastId,
+        }
+      );
       onTransferred();
     },
     onError: (err: Error) => {
@@ -94,16 +109,6 @@ export function TransferActivitiesDialog({
       toast.error(err.message || 'Transfer failed', { id: toastId });
     },
   });
-
-  const hasActivities = fieldsMeta.activities.length > 0;
-
-  const canSubmit =
-    draft.fromTeamId != null &&
-    fromTeamOptions.length > 0 &&
-    hasActivities &&
-    !fieldsMeta.isLoading &&
-    isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
-    !fieldsMeta.isError;
 
   const sourceName =
     sourceUser.adDisplayName ||
@@ -144,6 +149,19 @@ export function TransferActivitiesDialog({
         <DialogFooter>
           <Button variant="secondary" onClick={onClose}>
             Cancel
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => setDraft(resetForm())}
+            disabled={
+              transferMutation.isPending ||
+              fieldsMeta.isLoading ||
+              isDraftPristine ||
+              isLoadingUser ||
+              fromTeamOptions.length === 0
+            }
+          >
+            Reset
           </Button>
           <Button
             disabled={

--- a/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesDialog.tsx
@@ -1,25 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { UserListItem } from '@corpcal/shared/api/types';
-import { USER_NOTES_MAX_LENGTH } from '@corpcal/shared/schemas';
-import {
-  fetchUserActivities,
-  fetchUsers,
-  transferActivities,
-} from '@/api/usersApi';
+import { fetchUser, transferActivities } from '@/api/usersApi';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
 import {
   Dialog,
   DialogContent,
@@ -27,14 +13,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+  buildTransferActivitiesBody,
+  createInitialTransferDraft,
+  isTransferActivitiesDraftValid,
+  TransferActivitiesFields,
+  type TransferActivitiesDraft,
+  type TransferActivitiesFieldsMeta,
+} from '@/components/users/TransferActivitiesFields';
 import { invalidateUserCaches } from '@/lib/userQueryKeys';
-import { cn } from '@/lib/utils';
 
 interface TransferActivitiesDialogProps {
   sourceUser: UserListItem;
@@ -42,108 +29,57 @@ interface TransferActivitiesDialogProps {
   onTransferred: () => void;
 }
 
-interface UserOption {
-  id: number;
-  label: string;
-  value: string;
-}
-
-function userToOption(
-  u: UserListItem & {
-    adDisplayName?: string | null;
-    adUsername?: string | null;
-  }
-): UserOption {
-  return {
-    id: u.id,
-    value: String(u.id),
-    label: u.adDisplayName || u.adUsername || `User ${u.id}`,
-  };
-}
-
 export function TransferActivitiesDialog({
   sourceUser,
   onClose,
   onTransferred,
 }: TransferActivitiesDialogProps) {
-  const [targetUserId, setTargetUserId] = useState<number | null>(null);
-  const [targetUserLabel, setTargetUserLabel] = useState<string>('');
-  const [transferCommsLead, setTransferCommsLead] = useState(true);
-  const [transferCommsContact, setTransferCommsContact] = useState(true);
-  const [selectedActivityIds, setSelectedActivityIds] = useState<number[]>([]);
-  const [notes, setNotes] = useState('');
-  const [comboboxOpen, setComboboxOpen] = useState(false);
-  const [userSearch, setUserSearch] = useState('');
-  const [activitiesDropdownOpen, setActivitiesDropdownOpen] = useState(false);
-  const activitiesInitializedForUser = useRef<number | null>(null);
-
   const queryClient = useQueryClient();
 
-  const { data: searchUsers = [], isFetching: isSearching } = useQuery({
-    queryKey: ['users', userSearch],
-    queryFn: () => fetchUsers({ search: userSearch.trim() || undefined }),
-    enabled: comboboxOpen,
+  const { data: userDetail, isLoading: isLoadingUser } = useQuery({
+    queryKey: ['users', sourceUser.id, 'detail-for-transfer'],
+    queryFn: () => fetchUser(sourceUser.id),
   });
 
-  const userOptions: UserOption[] = useMemo(() => {
-    return searchUsers
-      .filter((u) => u.id !== sourceUser.id && u.isActive)
-      .map((u) => userToOption(u));
-  }, [searchUsers, sourceUser.id]);
+  const fromTeamOptions = useMemo(
+    () =>
+      (userDetail?.teams ?? []).map((t) => ({
+        teamId: t.teamId,
+        teamName: t.teamName,
+      })),
+    [userDetail?.teams]
+  );
 
-  const { data: userActivities = [] } = useQuery({
-    queryKey: ['users', sourceUser.id, 'activities'],
-    queryFn: () => fetchUserActivities(sourceUser.id),
+  const initialFromTeamId = fromTeamOptions[0]?.teamId ?? null;
+
+  const [draft, setDraft] = useState<TransferActivitiesDraft>(() =>
+    createInitialTransferDraft(initialFromTeamId)
+  );
+  const [fieldsMeta, setFieldsMeta] = useState<TransferActivitiesFieldsMeta>({
+    activities: [],
+    isLoading: false,
+    isError: false,
   });
 
   useEffect(() => {
-    if (
-      userActivities.length > 0 &&
-      activitiesInitializedForUser.current !== sourceUser.id
-    ) {
-      activitiesInitializedForUser.current = sourceUser.id;
-      setSelectedActivityIds(userActivities.map((a) => a.id));
+    if (initialFromTeamId != null && draft.fromTeamId == null) {
+      setDraft(createInitialTransferDraft(initialFromTeamId));
     }
-  }, [sourceUser.id, userActivities]);
-
-  const toggleActivity = (activityId: number) => {
-    setSelectedActivityIds((prev) =>
-      prev.includes(activityId)
-        ? prev.filter((id) => id !== activityId)
-        : [...prev, activityId]
-    );
-  };
-
-  const selectAllActivities = () => {
-    setSelectedActivityIds(userActivities.map((a) => a.id));
-  };
-
-  const deselectAllActivities = () => {
-    setSelectedActivityIds([]);
-  };
-
-  const selectedCount = selectedActivityIds.length;
-  const allSelected =
-    userActivities.length > 0 && selectedCount === userActivities.length;
-  const noneSelected = selectedCount === 0;
+  }, [initialFromTeamId, draft.fromTeamId]);
 
   const transferMutation = useMutation({
-    mutationFn: () =>
-      transferActivities(sourceUser.id, {
-        targetUserId: targetUserId!,
-        activityIds:
-          allSelected || userActivities.length === 0
-            ? undefined
-            : selectedActivityIds,
-        transferCommsLead,
-        transferCommsContact,
-        notes: notes || undefined,
-      }),
+    mutationFn: () => {
+      const body = buildTransferActivitiesBody(
+        draft,
+        fieldsMeta.activities.map((a) => a.id)
+      );
+      return transferActivities(sourceUser.id, body);
+    },
     onSuccess: (data) => {
       invalidateUserCaches(queryClient, sourceUser.id);
       const toastId =
-        targetUserId != null
-          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+        draft.targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
       toast.success(`Transferred ${data.transferredCount} assignment(s)`, {
         id: toastId,
@@ -152,18 +88,21 @@ export function TransferActivitiesDialog({
     },
     onError: (err: Error) => {
       const toastId =
-        targetUserId != null
-          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+        draft.targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
       toast.error(err.message || 'Transfer failed', { id: toastId });
     },
   });
 
+  const hasActivities = fieldsMeta.activities.length > 0;
+
   const canSubmit =
-    targetUserId != null &&
-    sourceUser.id !== targetUserId &&
-    (transferCommsLead || transferCommsContact) &&
-    (userActivities.length === 0 || selectedCount > 0);
+    draft.fromTeamId != null &&
+    fromTeamOptions.length > 0 &&
+    !fieldsMeta.isLoading &&
+    isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
+    !fieldsMeta.isError;
 
   const sourceName =
     sourceUser.adDisplayName ||
@@ -177,205 +116,40 @@ export function TransferActivitiesDialog({
           <DialogTitle>Transfer activities from {sourceName}</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4">
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Transfer to user</Label>
-            <Popover
-              open={comboboxOpen}
-              onOpenChange={(open) => {
-                setComboboxOpen(open);
-                if (!open) setUserSearch('');
-              }}
-            >
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={comboboxOpen}
-                  className="w-full justify-between font-normal"
-                >
-                  {targetUserId != null && targetUserLabel
-                    ? targetUserLabel
-                    : 'Select user...'}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent
-                className="w-(--radix-popover-trigger-width) p-0"
-                align="start"
-              >
-                <Command shouldFilter={false}>
-                  <CommandInput
-                    placeholder="Search users..."
-                    value={userSearch}
-                    onValueChange={setUserSearch}
-                  />
-                  <CommandList>
-                    {isSearching ? (
-                      <div className="flex items-center justify-center py-6">
-                        <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-                      </div>
-                    ) : (
-                      <>
-                        <CommandEmpty>No users found.</CommandEmpty>
-                        <CommandGroup>
-                          {userOptions.map((option) => {
-                            const isSelected = targetUserId === option.id;
-                            return (
-                              <CommandItem
-                                key={option.value}
-                                value={option.value}
-                                onSelect={() => {
-                                  setTargetUserId(option.id);
-                                  setTargetUserLabel(option.label);
-                                  setUserSearch('');
-                                  setComboboxOpen(false);
-                                }}
-                              >
-                                <Check
-                                  className={cn(
-                                    'mr-2 h-4 w-4',
-                                    isSelected ? 'opacity-100' : 'opacity-0'
-                                  )}
-                                />
-                                {option.label}
-                              </CommandItem>
-                            );
-                          })}
-                        </CommandGroup>
-                      </>
-                    )}
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium">Transfer</span>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="transfer-lead"
-                  checked={transferCommsLead}
-                  onCheckedChange={(checked) =>
-                    setTransferCommsLead(checked === true)
-                  }
-                />
-                <Label
-                  htmlFor="transfer-lead"
-                  className="cursor-pointer text-sm font-normal"
-                >
-                  Comms lead assignments
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="transfer-contact"
-                  checked={transferCommsContact}
-                  onCheckedChange={(checked) =>
-                    setTransferCommsContact(checked === true)
-                  }
-                />
-                <Label
-                  htmlFor="transfer-contact"
-                  className="cursor-pointer text-sm font-normal"
-                >
-                  Comms contact (non-lead) assignments
-                </Label>
-              </div>
+          {isLoadingUser ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
             </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Activities</Label>
-            <Popover
-              open={activitiesDropdownOpen}
-              onOpenChange={setActivitiesDropdownOpen}
-            >
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={activitiesDropdownOpen}
-                  className="w-full justify-between font-normal"
-                >
-                  {selectedCount === 0
-                    ? 'No activities selected'
-                    : `${selectedCount} activities selected`}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent
-                className="w-(--radix-popover-trigger-width) p-0"
-                align="start"
-              >
-                <div className="flex flex-col">
-                  <div className="flex items-center justify-between border-b px-3 py-2 text-sm">
-                    <span className="text-muted-foreground">
-                      {noneSelected
-                        ? 'None selected'
-                        : `${selectedCount} selected`}
-                    </span>
-                    <button
-                      type="button"
-                      className="text-primary hover:underline focus:underline focus:outline-none"
-                      onClick={() => {
-                        if (noneSelected) selectAllActivities();
-                        else deselectAllActivities();
-                      }}
-                    >
-                      {noneSelected ? 'Select all' : 'Deselect all'}
-                    </button>
-                  </div>
-                  <div className="max-h-[240px] overflow-auto p-1">
-                    {userActivities.length === 0 ? (
-                      <div className="text-muted-foreground py-4 text-center text-sm">
-                        No activities associated with this user
-                      </div>
-                    ) : (
-                      userActivities.map((activity) => (
-                        <div
-                          key={activity.id}
-                          className="hover:bg-accent flex items-center space-x-2 rounded-sm px-2 py-1.5"
-                        >
-                          <Checkbox
-                            id={`activity-${activity.id}`}
-                            checked={selectedActivityIds.includes(activity.id)}
-                            onCheckedChange={() => toggleActivity(activity.id)}
-                          />
-                          <Label
-                            htmlFor={`activity-${activity.id}`}
-                            className="flex-1 cursor-pointer text-sm font-normal"
-                          >
-                            {activity.label}
-                          </Label>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                </div>
-              </PopoverContent>
-            </Popover>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <Label className="text-sm text-slate-600">Notes (optional)</Label>
-            <textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              maxLength={USER_NOTES_MAX_LENGTH}
-              placeholder="Reason for transfer..."
-              className="min-h-[60px] rounded border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:ring-1 focus:ring-slate-400 focus:outline-none"
-              rows={2}
+          ) : fromTeamOptions.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              This user is not on any teams.
+            </p>
+          ) : (
+            <TransferActivitiesFields
+              mode="transfer"
+              sourceUserId={sourceUser.id}
+              fromTeamOptions={fromTeamOptions}
+              value={
+                draft.fromTeamId == null && initialFromTeamId != null
+                  ? { ...draft, fromTeamId: initialFromTeamId }
+                  : draft
+              }
+              onChange={setDraft}
+              onMetaChange={setFieldsMeta}
             />
-          </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>
           <Button
-            disabled={!canSubmit || transferMutation.isPending}
+            disabled={
+              !canSubmit ||
+              transferMutation.isPending ||
+              isLoadingUser ||
+              fromTeamOptions.length === 0
+            }
             onClick={() => transferMutation.mutate()}
           >
             {transferMutation.isPending ? (

--- a/calendar-ui/src/components/users/TransferActivitiesFields.test.ts
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type { UserActivityItem } from '@/api/usersApi';
+import {
+  buildRemoveUserFromTeamBody,
+  buildTransferActivitiesBody,
+  createInitialTransferDraft,
+  isTransferActivitiesDraftPristine,
+  isTransferActivitiesDraftValid,
+  wouldTransferDraftHaveEffect,
+} from '@/components/users/TransferActivitiesFields';
+
+const scopedActivities: UserActivityItem[] = [
+  { id: 10, label: 'Alpha', value: 10, isLead: true },
+  { id: 11, label: 'Beta', value: 11, isLead: false },
+];
+
+describe('buildTransferActivitiesBody', () => {
+  it('omits activityIds when every scoped activity is selected', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 2,
+      selectedActivityIds: [10, 11],
+      includeNonLead: false,
+    };
+    const body = buildTransferActivitiesBody(draft, [10, 11]);
+    expect(body.activityIds).toBeUndefined();
+    expect(body.fromTeamId).toBe(1);
+    expect(body.targetUserId).toBe(2);
+  });
+
+  it('sends a partial activityIds list when subset selected', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 2,
+      selectedActivityIds: [10],
+      includeNonLead: true,
+    };
+    const body = buildTransferActivitiesBody(draft, [10, 11]);
+    expect(body.activityIds).toEqual([10]);
+  });
+
+  it('throws when no activities are selected', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 2,
+      selectedActivityIds: [],
+      includeNonLead: false,
+    };
+    expect(() => buildTransferActivitiesBody(draft, [10, 11])).toThrow(
+      /at least one activity/i
+    );
+  });
+});
+
+describe('isTransferActivitiesDraftValid', () => {
+  it('allows removal flow when there are no scoped activities', () => {
+    expect(
+      isTransferActivitiesDraftValid(createInitialTransferDraft(1), 1, false)
+    ).toBe(true);
+  });
+
+  it('requires target user and selection when activities exist', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      selectedActivityIds: [10],
+      includeNonLead: false,
+    };
+    expect(isTransferActivitiesDraftValid(draft, 1, true)).toBe(false);
+    expect(
+      isTransferActivitiesDraftValid({ ...draft, targetUserId: 2 }, 1, true)
+    ).toBe(true);
+  });
+});
+
+describe('isTransferActivitiesDraftPristine', () => {
+  it('is pristine after default load selection', () => {
+    const draft = {
+      ...createInitialTransferDraft(2),
+      selectedActivityIds: [10, 11],
+      includeNonLead: false,
+    };
+    expect(isTransferActivitiesDraftPristine(draft, [10, 11])).toBe(true);
+  });
+
+  it('is not pristine when notes were added', () => {
+    const draft = {
+      ...createInitialTransferDraft(2),
+      selectedActivityIds: [10, 11],
+      notes: 'handover',
+    };
+    expect(isTransferActivitiesDraftPristine(draft, [10, 11])).toBe(false);
+  });
+});
+
+describe('wouldTransferDraftHaveEffect', () => {
+  it('is false for non-lead-only selection without includeNonLead on same team', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 2,
+      selectedActivityIds: [11],
+      includeNonLead: false,
+    };
+    expect(wouldTransferDraftHaveEffect(draft, scopedActivities)).toBe(false);
+  });
+
+  it('is true when a lead activity is selected', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 2,
+      selectedActivityIds: [10],
+      includeNonLead: false,
+    };
+    expect(wouldTransferDraftHaveEffect(draft, scopedActivities)).toBe(true);
+  });
+
+  it('is true for cross-team transfer even when only non-lead is selected', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      toTeamId: 3,
+      targetUserId: 2,
+      selectedActivityIds: [11],
+      includeNonLead: false,
+    };
+    expect(wouldTransferDraftHaveEffect(draft, scopedActivities)).toBe(true);
+  });
+});
+
+describe('buildRemoveUserFromTeamBody', () => {
+  it('returns undefined when there are no scoped activities', () => {
+    expect(
+      buildRemoveUserFromTeamBody(createInitialTransferDraft(1), false)
+    ).toBe(undefined);
+  });
+
+  it('builds body when comms assignments must transfer on removal', () => {
+    const draft = {
+      ...createInitialTransferDraft(1),
+      targetUserId: 5,
+      includeNonLead: true,
+    };
+    expect(buildRemoveUserFromTeamBody(draft, true)).toEqual({
+      targetUserId: 5,
+      includeNonLead: true,
+    });
+  });
+});

--- a/calendar-ui/src/components/users/TransferActivitiesFields.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.tsx
@@ -1,0 +1,576 @@
+import { useQuery } from '@tanstack/react-query';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  RemoveUserFromTeamBody,
+  TransferActivitiesBody,
+  UserListItem,
+} from '@corpcal/shared/api/types';
+import {
+  fetchTeams,
+  fetchUserActivities,
+  fetchUsers,
+  type UserActivityItem,
+} from '@/api/usersApi';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+export type TransferActivitiesMode = 'transfer' | 'removal';
+
+export interface FromTeamOption {
+  teamId: number;
+  teamName: string;
+}
+
+export interface TransferActivitiesDraft {
+  fromTeamId: number | null;
+  /** Null means "same as fromTeamId" until the user explicitly picks a different team. */
+  toTeamId: number | null;
+  targetUserId: number | null;
+  targetUserLabel: string;
+  selectedActivityIds: number[];
+  includeNonLead: boolean;
+  notes: string;
+}
+
+export function createInitialTransferDraft(
+  fromTeamId: number | null = null
+): TransferActivitiesDraft {
+  return {
+    fromTeamId,
+    toTeamId: null,
+    targetUserId: null,
+    targetUserLabel: '',
+    selectedActivityIds: [],
+    includeNonLead: false,
+    notes: '',
+  };
+}
+
+export interface TransferActivitiesFieldsMeta {
+  activities: UserActivityItem[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+interface TransferActivitiesFieldsProps {
+  mode: TransferActivitiesMode;
+  sourceUserId: number;
+  /** Teams the source user can transfer from (transfer mode). Ignored when `fixedFromTeamId` is set. */
+  fromTeamOptions: FromTeamOption[];
+  /** Locks the "from team" picker (removal mode: the team being removed). */
+  fixedFromTeamId?: number;
+  fixedFromTeamName?: string;
+  value: TransferActivitiesDraft;
+  onChange: (next: TransferActivitiesDraft) => void;
+  /** Show the free-text notes field. Defaults to true for transfer mode, false for removal. */
+  showNotes?: boolean;
+  onMetaChange?: (meta: TransferActivitiesFieldsMeta) => void;
+}
+
+function userToOption(u: UserListItem) {
+  return {
+    id: u.id,
+    value: String(u.id),
+    label: u.adDisplayName || u.adUsername || `User ${u.id}`,
+  };
+}
+
+/**
+ * Shared "transfer activities" form fragment used by the RemoveTeamMemberModal
+ * (removal mode) and UserTransferTabContent / TransferActivitiesDialog (transfer
+ * mode). Owns the from/to team pickers, target-user search, scoped activities
+ * list, and the "include non-lead" toggle. Callers own submit/cancel actions
+ * and read `value` to build the API payload (see `buildTransferActivitiesBody`
+ * / `buildRemoveUserFromTeamBody`).
+ */
+export function TransferActivitiesFields({
+  mode,
+  sourceUserId,
+  fromTeamOptions,
+  fixedFromTeamId,
+  fixedFromTeamName,
+  value,
+  onChange,
+  showNotes = mode === 'transfer',
+  onMetaChange,
+}: TransferActivitiesFieldsProps) {
+  const isRemoval = mode === 'removal';
+  const fromTeamId = fixedFromTeamId ?? value.fromTeamId;
+  const toTeamId = value.toTeamId ?? fromTeamId;
+  const crossTeam =
+    toTeamId != null && fromTeamId != null && toTeamId !== fromTeamId;
+
+  const [comboboxOpen, setComboboxOpen] = useState(false);
+  const [userSearch, setUserSearch] = useState('');
+  const [activitiesDropdownOpen, setActivitiesDropdownOpen] = useState(false);
+  const initializedForKey = useRef<string | null>(null);
+
+  const {
+    data: userActivities = [],
+    isLoading: isLoadingActivities,
+    isError: isActivitiesError,
+  } = useQuery({
+    queryKey: ['users', sourceUserId, 'activities', fromTeamId],
+    queryFn: () => fetchUserActivities(sourceUserId, fromTeamId ?? undefined),
+    enabled: fromTeamId != null,
+  });
+
+  useEffect(() => {
+    onMetaChange?.({
+      activities: userActivities,
+      isLoading: isLoadingActivities,
+      isError: isActivitiesError,
+    });
+    // onMetaChange identity is expected to be stable from the caller.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userActivities, isLoadingActivities, isActivitiesError]);
+
+  // (Re)select every scoped activity whenever the from-team (and therefore the
+  // scoped activity set) changes. Removal mode keeps all activities selected
+  // permanently (selection is not user-editable there).
+  useEffect(() => {
+    if (fromTeamId == null) return;
+    const key = String(fromTeamId);
+    if (!isRemoval && initializedForKey.current === key) return;
+    initializedForKey.current = key;
+    onChange({
+      ...value,
+      selectedActivityIds: userActivities.map((a) => a.id),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fromTeamId, userActivities, isRemoval]);
+
+  const { data: allTeams = [] } = useQuery({
+    queryKey: ['teams', 'all-for-transfer'],
+    queryFn: fetchTeams,
+  });
+
+  const { data: searchUsers = [], isFetching: isSearchingUsers } = useQuery({
+    queryKey: ['users', 'transfer-target', toTeamId, userSearch],
+    queryFn: () =>
+      fetchUsers({
+        search: userSearch.trim() || undefined,
+        teamIds: toTeamId != null ? [toTeamId] : undefined,
+      }),
+    enabled: comboboxOpen && toTeamId != null,
+  });
+
+  const targetOptions = useMemo(
+    () =>
+      searchUsers
+        .filter((u) => u.id !== sourceUserId && u.isActive)
+        .map(userToOption),
+    [searchUsers, sourceUserId]
+  );
+
+  const hasActivities = userActivities.length > 0;
+  const selectedCount = value.selectedActivityIds.length;
+  const noneSelected = selectedCount === 0;
+
+  const toggleActivity = (activityId: number) => {
+    if (isRemoval) return;
+    const next = value.selectedActivityIds.includes(activityId)
+      ? value.selectedActivityIds.filter((id) => id !== activityId)
+      : [...value.selectedActivityIds, activityId];
+    onChange({ ...value, selectedActivityIds: next });
+  };
+
+  const toTeamOptions =
+    allTeams.length > 0
+      ? allTeams.map((t) => ({
+          teamId: t.id,
+          teamName: t.displayName || t.name,
+        }))
+      : fromTeamOptions;
+
+  if (fromTeamId == null) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {!fixedFromTeamId && fromTeamOptions.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">
+            Transfer from team{' '}
+            <span className="text-required-field-indicator font-semibold">
+              *
+            </span>
+          </Label>
+          <Select
+            value={String(fromTeamId)}
+            onValueChange={(v) => {
+              initializedForKey.current = null;
+              onChange({
+                ...createInitialTransferDraft(Number(v)),
+                notes: value.notes,
+              });
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select team..." />
+            </SelectTrigger>
+            <SelectContent>
+              {fromTeamOptions.map((t) => (
+                <SelectItem key={t.teamId} value={String(t.teamId)}>
+                  {t.teamName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {fixedFromTeamId != null && fixedFromTeamName && (
+        <p className="text-sm text-slate-700">
+          Removing from <span className="font-medium">{fixedFromTeamName}</span>
+          .
+        </p>
+      )}
+
+      {isLoadingActivities ? (
+        <div className="flex justify-center py-2">
+          <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+        </div>
+      ) : isActivitiesError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          Could not load assigned activities. Please try again.
+        </div>
+      ) : hasActivities ? (
+        <>
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Transfer activities</h3>
+            <p className="text-sm text-slate-700">
+              {userActivities.length} active{' '}
+              {userActivities.length === 1 ? 'activity is' : 'activities are'}{' '}
+              led by this team.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Transfer to team</Label>
+            <Select
+              value={String(toTeamId)}
+              onValueChange={(v) =>
+                onChange({
+                  ...value,
+                  toTeamId: Number(v),
+                  targetUserId: null,
+                  targetUserLabel: '',
+                })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select team..." />
+              </SelectTrigger>
+              <SelectContent>
+                {toTeamOptions.map((t) => (
+                  <SelectItem key={t.teamId} value={String(t.teamId)}>
+                    {t.teamName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {crossTeam && (
+              <p className="text-xs text-amber-700">
+                Moving to a different team updates each affected activity&apos;s
+                lead team (and its ministry / display ID). Visibility and
+                sharing are unchanged.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Transfer to user{' '}
+              <span className="text-required-field-indicator font-semibold">
+                *
+              </span>
+            </Label>
+            <Popover
+              open={comboboxOpen}
+              onOpenChange={(nextOpen) => {
+                setComboboxOpen(nextOpen);
+                if (!nextOpen) setUserSearch('');
+              }}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={comboboxOpen}
+                  className="w-full justify-between font-normal"
+                >
+                  {value.targetUserId != null && value.targetUserLabel
+                    ? value.targetUserLabel
+                    : 'Select user...'}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-(--radix-popover-trigger-width) p-0"
+                align="start"
+              >
+                <Command shouldFilter={false}>
+                  <CommandInput
+                    placeholder="Search users..."
+                    value={userSearch}
+                    onValueChange={setUserSearch}
+                  />
+                  <CommandList>
+                    {isSearchingUsers ? (
+                      <div className="flex items-center justify-center py-6">
+                        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+                      </div>
+                    ) : (
+                      <>
+                        <CommandEmpty>No users found.</CommandEmpty>
+                        <CommandGroup>
+                          {targetOptions.map((option) => {
+                            const selected = value.targetUserId === option.id;
+                            return (
+                              <CommandItem
+                                key={option.value}
+                                value={option.value}
+                                onSelect={() => {
+                                  onChange({
+                                    ...value,
+                                    targetUserId: option.id,
+                                    targetUserLabel: option.label,
+                                  });
+                                  setUserSearch('');
+                                  setComboboxOpen(false);
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    'mr-2 h-4 w-4',
+                                    selected ? 'opacity-100' : 'opacity-0'
+                                  )}
+                                />
+                                {option.label}
+                              </CommandItem>
+                            );
+                          })}
+                        </CommandGroup>
+                      </>
+                    )}
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="include-non-lead"
+              checked={value.includeNonLead}
+              onCheckedChange={(checked) =>
+                onChange({ ...value, includeNonLead: checked === true })
+              }
+            />
+            <Label
+              htmlFor="include-non-lead"
+              className="cursor-pointer text-sm font-normal"
+            >
+              Include non-lead (comms contact) assignments
+            </Label>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            {isRemoval
+              ? 'Lead assignments always transfer. Non-lead assignments transfer when checked, otherwise they are removed.'
+              : 'Lead assignments always transfer for selected activities. Non-lead assignments transfer when checked, otherwise they are left as-is (or removed if no longer eligible after a cross-team move).'}
+          </p>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Activities{' '}
+              <span className="text-required-field-indicator font-semibold">
+                *
+              </span>
+            </Label>
+            <Popover
+              open={activitiesDropdownOpen}
+              onOpenChange={setActivitiesDropdownOpen}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={activitiesDropdownOpen}
+                  className="w-full justify-between font-normal"
+                  disabled={isRemoval}
+                >
+                  {isRemoval
+                    ? `All ${userActivities.length} activities (required)`
+                    : selectedCount === 0
+                      ? 'No activities selected'
+                      : `${selectedCount} activities selected`}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-(--radix-popover-trigger-width) p-0"
+                align="start"
+              >
+                <div className="flex flex-col">
+                  {!isRemoval && (
+                    <div className="flex items-center justify-between border-b px-3 py-2 text-sm">
+                      <span className="text-muted-foreground">
+                        {noneSelected
+                          ? 'None selected'
+                          : `${selectedCount} selected`}
+                      </span>
+                      <button
+                        type="button"
+                        className="text-primary hover:underline focus:underline focus:outline-none"
+                        onClick={() =>
+                          onChange({
+                            ...value,
+                            selectedActivityIds: noneSelected
+                              ? userActivities.map((a) => a.id)
+                              : [],
+                          })
+                        }
+                      >
+                        {noneSelected ? 'Select all' : 'Deselect all'}
+                      </button>
+                    </div>
+                  )}
+                  <div className="max-h-[240px] overflow-auto p-1">
+                    {userActivities.map((activity) => (
+                      <div
+                        key={activity.id}
+                        className="hover:bg-accent flex items-center space-x-2 rounded-sm px-2 py-1.5"
+                      >
+                        <Checkbox
+                          id={`activity-${activity.id}`}
+                          checked={
+                            isRemoval ||
+                            value.selectedActivityIds.includes(activity.id)
+                          }
+                          disabled={isRemoval}
+                          onCheckedChange={() => toggleActivity(activity.id)}
+                        />
+                        <Label
+                          htmlFor={`activity-${activity.id}`}
+                          className="flex flex-1 cursor-pointer items-center gap-2 text-sm font-normal"
+                        >
+                          <span className="flex-1">{activity.label}</span>
+                          {activity.isLead && (
+                            <Badge variant="secondary" className="shrink-0">
+                              Lead
+                            </Badge>
+                          )}
+                        </Label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          {showNotes && (
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Notes</Label>
+              <Textarea
+                value={value.notes}
+                onChange={(e) => onChange({ ...value, notes: e.target.value })}
+                placeholder="Reason for transfer..."
+                className="min-h-[120px]"
+              />
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/** True when the current draft satisfies the minimum requirements to submit. */
+export function isTransferActivitiesDraftValid(
+  draft: TransferActivitiesDraft,
+  sourceUserId: number,
+  hasActivities: boolean
+): boolean {
+  if (!hasActivities) return true;
+  if (draft.fromTeamId == null) return false;
+  if (draft.targetUserId == null || draft.targetUserId === sourceUserId) {
+    return false;
+  }
+  return draft.selectedActivityIds.length > 0;
+}
+
+/** Builds the POST /users/:id/transfer-activities request body from a draft. */
+export function buildTransferActivitiesBody(
+  draft: TransferActivitiesDraft,
+  allScopedActivityIds: number[]
+): TransferActivitiesBody {
+  if (draft.fromTeamId == null || draft.targetUserId == null) {
+    throw new Error(
+      'fromTeamId and targetUserId are required to transfer activities'
+    );
+  }
+  const toTeamId = draft.toTeamId ?? draft.fromTeamId;
+  const allSelected =
+    allScopedActivityIds.length > 0 &&
+    draft.selectedActivityIds.length === allScopedActivityIds.length;
+
+  return {
+    targetUserId: draft.targetUserId,
+    fromTeamId: draft.fromTeamId,
+    toTeamId: toTeamId !== draft.fromTeamId ? toTeamId : undefined,
+    activityIds: allSelected ? undefined : draft.selectedActivityIds,
+    includeNonLead: draft.includeNonLead,
+    notes: draft.notes.trim() || undefined,
+  };
+}
+
+/**
+ * Builds the DELETE /users/:id/teams/:teamId request body from a draft.
+ * Returns `undefined` for a silent removal (no scoped comms assignments).
+ */
+export function buildRemoveUserFromTeamBody(
+  draft: TransferActivitiesDraft,
+  hasActivities: boolean
+): RemoveUserFromTeamBody | undefined {
+  if (!hasActivities) return undefined;
+  if (draft.fromTeamId == null || draft.targetUserId == null) {
+    throw new Error('targetUserId is required to transfer comms assignments');
+  }
+  const toTeamId = draft.toTeamId ?? draft.fromTeamId;
+
+  return {
+    targetUserId: draft.targetUserId,
+    toTeamId: toTeamId !== draft.fromTeamId ? toTeamId : undefined,
+    includeNonLead: draft.includeNonLead,
+    notes: draft.notes.trim() || undefined,
+  };
+}

--- a/calendar-ui/src/components/users/TransferActivitiesFields.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.tsx
@@ -91,6 +91,8 @@ interface TransferActivitiesFieldsProps {
   /** Show the free-text notes field. Defaults to true for transfer mode, false for removal. */
   showNotes?: boolean;
   onMetaChange?: (meta: TransferActivitiesFieldsMeta) => void;
+  /** Used for empty-state copy when the user has no scoped comms assignments (transfer mode). */
+  sourceDisplayName?: string;
 }
 
 function userToOption(u: UserListItem) {
@@ -119,6 +121,7 @@ export function TransferActivitiesFields({
   onChange,
   showNotes = mode === 'transfer',
   onMetaChange,
+  sourceDisplayName,
 }: TransferActivitiesFieldsProps) {
   const isRemoval = mode === 'removal';
   const fromTeamId = fixedFromTeamId ?? value.fromTeamId;
@@ -209,6 +212,10 @@ export function TransferActivitiesFields({
         }))
       : fromTeamOptions;
 
+  const fromTeamName =
+    fixedFromTeamName ??
+    fromTeamOptions.find((t) => t.teamId === fromTeamId)?.teamName;
+
   if (fromTeamId == null) {
     return null;
   }
@@ -268,8 +275,8 @@ export function TransferActivitiesFields({
             <h3 className="text-base font-semibold">Transfer activities</h3>
             <p className="text-sm text-slate-700">
               {userActivities.length} active{' '}
-              {userActivities.length === 1 ? 'activity is' : 'activities are'}{' '}
-              led by this team.
+              {userActivities.length === 1 ? 'activity' : 'activities'} led by{' '}
+              {fromTeamName ?? 'this team'} where this user is a comms contact.
             </p>
           </div>
 
@@ -509,7 +516,16 @@ export function TransferActivitiesFields({
             </div>
           )}
         </>
-      ) : null}
+      ) : (
+        !isRemoval &&
+        sourceDisplayName &&
+        fromTeamName && (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            No activities to transfer. {sourceDisplayName} is not comms contact
+            on any {fromTeamName} activities.
+          </p>
+        )
+      )}
     </div>
   );
 }
@@ -526,6 +542,30 @@ export function isTransferActivitiesDraftValid(
     return false;
   }
   return draft.selectedActivityIds.length > 0;
+}
+
+/** True when the draft matches the default state after load or reset for the current scope. */
+export function isTransferActivitiesDraftPristine(
+  draft: TransferActivitiesDraft,
+  scopedActivityIds: number[]
+): boolean {
+  if (draft.fromTeamId == null) return true;
+
+  const effectiveToTeamId = draft.toTeamId ?? draft.fromTeamId;
+  if (effectiveToTeamId !== draft.fromTeamId) return false;
+  if (draft.targetUserId != null || draft.targetUserLabel !== '') return false;
+  if (draft.includeNonLead) return false;
+  if (draft.notes.trim() !== '') return false;
+
+  if (scopedActivityIds.length === 0) {
+    return draft.selectedActivityIds.length === 0;
+  }
+
+  if (draft.selectedActivityIds.length !== scopedActivityIds.length) {
+    return false;
+  }
+  const scopedSet = new Set(scopedActivityIds);
+  return draft.selectedActivityIds.every((id) => scopedSet.has(id));
 }
 
 /** Builds the POST /users/:id/transfer-activities request body from a draft. */

--- a/calendar-ui/src/components/users/TransferActivitiesFields.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.tsx
@@ -7,6 +7,7 @@ import type {
   TransferActivitiesBody,
   UserListItem,
 } from '@corpcal/shared/api/types';
+import { USER_NOTES_MAX_LENGTH } from '@corpcal/shared/schemas';
 import {
   fetchTeams,
   fetchUserActivities,
@@ -516,6 +517,7 @@ export function TransferActivitiesFields({
                 onChange={(e) => onChange({ ...value, notes: e.target.value })}
                 placeholder="Reason for transfer..."
                 className="min-h-[120px]"
+                maxLength={USER_NOTES_MAX_LENGTH}
               />
             </div>
           )}

--- a/calendar-ui/src/components/users/TransferActivitiesFields.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.tsx
@@ -78,6 +78,10 @@ export interface TransferActivitiesFieldsMeta {
   isError: boolean;
 }
 
+export type TransferActivitiesDraftUpdater =
+  | TransferActivitiesDraft
+  | ((prev: TransferActivitiesDraft) => TransferActivitiesDraft);
+
 interface TransferActivitiesFieldsProps {
   mode: TransferActivitiesMode;
   sourceUserId: number;
@@ -87,7 +91,7 @@ interface TransferActivitiesFieldsProps {
   fixedFromTeamId?: number;
   fixedFromTeamName?: string;
   value: TransferActivitiesDraft;
-  onChange: (next: TransferActivitiesDraft) => void;
+  onChange: (next: TransferActivitiesDraftUpdater) => void;
   /** Show the free-text notes field. Defaults to true for transfer mode, false for removal. */
   showNotes?: boolean;
   onMetaChange?: (meta: TransferActivitiesFieldsMeta) => void;
@@ -162,10 +166,10 @@ export function TransferActivitiesFields({
     const key = String(fromTeamId);
     if (!isRemoval && initializedForKey.current === key) return;
     initializedForKey.current = key;
-    onChange({
-      ...value,
+    onChange((prev) => ({
+      ...prev,
       selectedActivityIds: userActivities.map((a) => a.id),
-    });
+    }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fromTeamId, userActivities, isRemoval]);
 
@@ -544,6 +548,23 @@ export function isTransferActivitiesDraftValid(
   return draft.selectedActivityIds.length > 0;
 }
 
+/** True when the selected activities/options would change comms or lead team. */
+export function wouldTransferDraftHaveEffect(
+  draft: TransferActivitiesDraft,
+  scopedActivities: UserActivityItem[]
+): boolean {
+  if (draft.fromTeamId == null || draft.selectedActivityIds.length === 0) {
+    return false;
+  }
+  const toTeamId = draft.toTeamId ?? draft.fromTeamId;
+  const crossTeam = toTeamId !== draft.fromTeamId;
+  const selected = new Set(draft.selectedActivityIds);
+  const rows = scopedActivities.filter((a) => selected.has(a.id));
+  if (rows.length === 0) return false;
+  if (crossTeam) return true;
+  return rows.some((row) => row.isLead || draft.includeNonLead);
+}
+
 /** True when the draft matches the default state after load or reset for the current scope. */
 export function isTransferActivitiesDraftPristine(
   draft: TransferActivitiesDraft,
@@ -577,6 +598,12 @@ export function buildTransferActivitiesBody(
     throw new Error(
       'fromTeamId and targetUserId are required to transfer activities'
     );
+  }
+  if (
+    allScopedActivityIds.length > 0 &&
+    draft.selectedActivityIds.length === 0
+  ) {
+    throw new Error('At least one activity must be selected to transfer');
   }
   const toTeamId = draft.toTeamId ?? draft.fromTeamId;
   const allSelected =

--- a/calendar-ui/src/components/users/TransferActivitiesFields.tsx
+++ b/calendar-ui/src/components/users/TransferActivitiesFields.tsx
@@ -5,13 +5,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   RemoveUserFromTeamBody,
   TransferActivitiesBody,
-  UserListItem,
 } from '@corpcal/shared/api/types';
 import { USER_NOTES_MAX_LENGTH } from '@corpcal/shared/schemas';
 import {
   fetchTeams,
   fetchUserActivities,
-  fetchUsers,
   type UserActivityItem,
 } from '@/api/usersApi';
 import { Badge } from '@/components/ui/badge';
@@ -39,6 +37,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { useCommsContactCandidates } from '@/hooks/useCommsContactCandidates';
 import { cn } from '@/lib/utils';
 
 export type TransferActivitiesMode = 'transfer' | 'removal';
@@ -98,14 +97,6 @@ interface TransferActivitiesFieldsProps {
   onMetaChange?: (meta: TransferActivitiesFieldsMeta) => void;
   /** Used for empty-state copy when the user has no scoped comms assignments (transfer mode). */
   sourceDisplayName?: string;
-}
-
-function userToOption(u: UserListItem) {
-  return {
-    id: u.id,
-    value: String(u.id),
-    label: u.adDisplayName || u.adUsername || `User ${u.id}`,
-  };
 }
 
 /**
@@ -179,23 +170,21 @@ export function TransferActivitiesFields({
     queryFn: fetchTeams,
   });
 
-  const { data: searchUsers = [], isFetching: isSearchingUsers } = useQuery({
-    queryKey: ['users', 'transfer-target', toTeamId, userSearch],
-    queryFn: () =>
-      fetchUsers({
-        search: userSearch.trim() || undefined,
-        teamIds: toTeamId != null ? [toTeamId] : undefined,
-      }),
-    enabled: comboboxOpen && toTeamId != null,
-  });
+  const {
+    data: eligibleCandidates = [],
+    isFetching: isSearchingUsers,
+    isError: isCandidatesError,
+  } = useCommsContactCandidates(toTeamId ?? undefined, comboboxOpen);
 
-  const targetOptions = useMemo(
-    () =>
-      searchUsers
-        .filter((u) => u.id !== sourceUserId && u.isActive)
-        .map(userToOption),
-    [searchUsers, sourceUserId]
-  );
+  const targetOptions = useMemo(() => {
+    const normalizedSearch = userSearch.trim().toLocaleLowerCase();
+    return eligibleCandidates.filter(
+      (candidate) =>
+        candidate.id !== sourceUserId &&
+        (normalizedSearch === '' ||
+          candidate.label.toLocaleLowerCase().includes(normalizedSearch))
+    );
+  }, [eligibleCandidates, sourceUserId, userSearch]);
 
   const hasActivities = userActivities.length > 0;
   const selectedCount = value.selectedActivityIds.length;
@@ -360,6 +349,10 @@ export function TransferActivitiesFields({
                       <div className="flex items-center justify-center py-6">
                         <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
                       </div>
+                    ) : isCandidatesError ? (
+                      <div className="text-destructive px-3 py-6 text-center text-sm">
+                        Could not load eligible users. Please try again.
+                      </div>
                     ) : (
                       <>
                         <CommandEmpty>No users found.</CommandEmpty>
@@ -368,8 +361,8 @@ export function TransferActivitiesFields({
                             const selected = value.targetUserId === option.id;
                             return (
                               <CommandItem
-                                key={option.value}
-                                value={option.value}
+                                key={option.id}
+                                value={String(option.value)}
                                 onSelect={() => {
                                   onChange({
                                     ...value,

--- a/calendar-ui/src/components/users/UserChangeLogTabContent.tsx
+++ b/calendar-ui/src/components/users/UserChangeLogTabContent.tsx
@@ -7,6 +7,7 @@ import type { UserHistoryEntry } from '@corpcal/shared/api/types';
 import { fetchRoles, fetchTeams, fetchUserHistory } from '@/api/usersApi';
 import { buildUserHistoryChangeMessage } from '@/components/users/userHistoryFormatting';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
+import { userQueryKeys } from '@/lib/userQueryKeys';
 
 interface UserChangeLogTabContentProps {
   userId: number;
@@ -52,7 +53,7 @@ export function UserChangeLogTabContent({
   });
 
   const { data: history = [], isLoading } = useQuery({
-    queryKey: ['userHistory', userId],
+    queryKey: userQueryKeys.history(userId),
     queryFn: () => fetchUserHistory(userId),
     enabled: userId > 0,
   });

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -23,6 +23,7 @@ import {
   ComboboxEmpty,
   ComboboxItem,
   ComboboxList,
+  ComboboxSeparator,
   ComboboxValue,
   useComboboxAnchor,
 } from '@/components/ui/combobox';
@@ -50,6 +51,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { TeamsComboboxSelectAllRow } from '@/components/users/TeamsComboboxSelectAllRow';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 import { userQueryKeys } from '@/lib/userQueryKeys';
 import type { OptionItem } from '@/schemas/types';
@@ -339,6 +341,12 @@ export function UserCreateModal({
                 const selectedOptions = teamOptions.filter((o) =>
                   currentValues.includes(o.value)
                 );
+                const allTeamIds = teamOptions.map((o) =>
+                  parseInt(o.value, 10)
+                );
+                const allTeamsSelected =
+                  allTeamIds.length > 0 &&
+                  allTeamIds.every((id) => field.value.includes(id));
                 return (
                   <FormItem>
                     <FormLabel showDirtyIndicator={false}>Teams</FormLabel>
@@ -374,16 +382,30 @@ export function UserCreateModal({
                         <ComboboxContent
                           anchor={teamsAnchorRef}
                           container={dialogContentRef}
-                          className="max-h-72"
+                          className="popover-list-scroll flex max-h-[min(var(--popover-list-max-height),24rem)] flex-col overflow-x-hidden overflow-y-auto p-0"
                         >
-                          <ComboboxEmpty>No teams found.</ComboboxEmpty>
-                          <ComboboxList>
-                            {(option: OptionItem) => (
-                              <ComboboxItem key={option.value} value={option}>
-                                {option.label}
-                              </ComboboxItem>
-                            )}
-                          </ComboboxList>
+                          <div className="bg-popover px-1 py-1">
+                            <TeamsComboboxSelectAllRow
+                              allSelected={allTeamsSelected}
+                              disabled={teamOptions.length === 0}
+                              onToggleSelectAll={() => {
+                                field.onChange(
+                                  allTeamsSelected ? [] : allTeamIds
+                                );
+                              }}
+                            />
+                            {teamOptions.length > 0 ? (
+                              <ComboboxSeparator className="my-1" />
+                            ) : null}
+                            <ComboboxEmpty>No teams found.</ComboboxEmpty>
+                            <ComboboxList className="max-h-none scroll-py-1 overflow-visible p-0 data-empty:p-0">
+                              {(option: OptionItem) => (
+                                <ComboboxItem key={option.value} value={option}>
+                                  {option.label}
+                                </ComboboxItem>
+                              )}
+                            </ComboboxList>
+                          </div>
                         </ComboboxContent>
                       </Combobox>
                     </FormControl>

--- a/calendar-ui/src/components/users/UserCreateModal.tsx
+++ b/calendar-ui/src/components/users/UserCreateModal.tsx
@@ -51,6 +51,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
+import { userQueryKeys } from '@/lib/userQueryKeys';
 import type { OptionItem } from '@/schemas/types';
 
 const createUserFormSchema = z.object({
@@ -123,7 +124,7 @@ export function UserCreateModal({
   const createMutation = useMutation({
     mutationFn: (body: CreateUserBody) => createUser(body),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.list() });
       toast.success('User created');
       form.reset(defaultValues);
       onSaved?.();

--- a/calendar-ui/src/components/users/UserEditModal.tsx
+++ b/calendar-ui/src/components/users/UserEditModal.tsx
@@ -22,6 +22,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/hooks/useAuth';
+import { invalidateUserCaches, userQueryKeys } from '@/lib/userQueryKeys';
 
 interface UserEditModalProps {
   user: UserListItem;
@@ -54,7 +55,7 @@ export function UserEditModal({ user, onClose, onSaved }: UserEditModalProps) {
     currentUser?.roleId === SYSTEM_ROLE_IDS.SYSTEM_ADMIN;
 
   const { data: detail, isLoading } = useQuery<UserDetail | null>({
-    queryKey: ['user', user.id],
+    queryKey: userQueryKeys.detail(user.id),
     queryFn: () => fetchUser(user.id),
     enabled: !!user.id,
   });
@@ -78,8 +79,7 @@ export function UserEditModal({ user, onClose, onSaved }: UserEditModalProps) {
   const updateMutation = useMutation({
     mutationFn: (body: UpdateUserBody) => updateUser(user.id, body),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['user', user.id] });
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      invalidateUserCaches(queryClient, user.id);
       toast.success('User updated', { id: `user-updated-${user.id}` });
       onSaved();
     },

--- a/calendar-ui/src/components/users/UserHistoryDrawer.tsx
+++ b/calendar-ui/src/components/users/UserHistoryDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { buildUserHistoryChangeMessage } from '@/components/users/userHistoryFormatting';
 import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
+import { userQueryKeys } from '@/lib/userQueryKeys';
 
 interface UserHistoryDrawerProps {
   user: UserListItem;
@@ -63,7 +64,7 @@ export function UserHistoryDrawer({
   });
 
   const { data: history = [], isLoading } = useQuery({
-    queryKey: ['userHistory', user.id],
+    queryKey: userQueryKeys.history(user.id),
     queryFn: () => fetchUserHistory(user.id),
     enabled: open && !!user.id,
   });

--- a/calendar-ui/src/components/users/UserTransferTabContent.tsx
+++ b/calendar-ui/src/components/users/UserTransferTabContent.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import {
   buildTransferActivitiesBody,
   createInitialTransferDraft,
+  isTransferActivitiesDraftPristine,
   isTransferActivitiesDraftValid,
   TransferActivitiesFields,
   type TransferActivitiesDraft,
@@ -56,8 +57,13 @@ export function UserTransferTabContent({
   });
 
   const resetForm = () => {
-    setDraft(createInitialTransferDraft(initialFromTeamId));
+    setDraft(createInitialTransferDraft(draft.fromTeamId ?? initialFromTeamId));
   };
+
+  const sourceDisplayName =
+    sourceUser.adDisplayName ||
+    sourceUser.adUsername ||
+    `User ${sourceUser.id}`;
 
   const transferMutation = useMutation({
     mutationFn: () => {
@@ -88,10 +94,19 @@ export function UserTransferTabContent({
   });
 
   const hasActivities = fieldsMeta.activities.length > 0;
+  const scopedActivityIds = useMemo(
+    () => fieldsMeta.activities.map((a) => a.id),
+    [fieldsMeta.activities]
+  );
+  const isDraftPristine = isTransferActivitiesDraftPristine(
+    draft,
+    scopedActivityIds
+  );
 
   const canSubmit =
     canTransfer &&
     draft.fromTeamId != null &&
+    hasActivities &&
     !fieldsMeta.isLoading &&
     isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
     !fieldsMeta.isError;
@@ -118,6 +133,7 @@ export function UserTransferTabContent({
       <TransferActivitiesFields
         mode="transfer"
         sourceUserId={sourceUser.id}
+        sourceDisplayName={sourceDisplayName}
         fromTeamOptions={fromTeamOptions}
         value={draft}
         onChange={setDraft}
@@ -128,9 +144,13 @@ export function UserTransferTabContent({
         <Button
           variant="secondary"
           onClick={resetForm}
-          disabled={transferMutation.isPending}
+          disabled={
+            transferMutation.isPending ||
+            fieldsMeta.isLoading ||
+            isDraftPristine
+          }
         >
-          Cancel
+          Reset
         </Button>
         <Button
           disabled={!canSubmit || transferMutation.isPending}

--- a/calendar-ui/src/components/users/UserTransferTabContent.tsx
+++ b/calendar-ui/src/components/users/UserTransferTabContent.tsx
@@ -9,12 +9,12 @@ import { Button } from '@/components/ui/button';
 import {
   buildTransferActivitiesBody,
   createInitialTransferDraft,
-  isTransferActivitiesDraftPristine,
-  isTransferActivitiesDraftValid,
   TransferActivitiesFields,
   type TransferActivitiesDraft,
   type TransferActivitiesFieldsMeta,
 } from '@/components/users/TransferActivitiesFields';
+import { useTransferActivitiesSubmit } from '@/hooks/useTransferActivitiesSubmit';
+import { formatTransferActivitiesSuccessMessage } from '@/lib/transfer-activities-messages';
 import { invalidateUserCaches } from '@/lib/userQueryKeys';
 
 interface UserTransferTabContentProps {
@@ -56,14 +56,20 @@ export function UserTransferTabContent({
     isError: false,
   });
 
-  const resetForm = () => {
-    setDraft(createInitialTransferDraft(draft.fromTeamId ?? initialFromTeamId));
-  };
-
   const sourceDisplayName =
     sourceUser.adDisplayName ||
     sourceUser.adUsername ||
     `User ${sourceUser.id}`;
+
+  const { canSubmit, isDraftPristine, resetForm } = useTransferActivitiesSubmit(
+    {
+      sourceUserId: sourceUser.id,
+      draft,
+      fieldsMeta,
+      initialFromTeamId,
+      canTransfer,
+    }
+  );
 
   const transferMutation = useMutation({
     mutationFn: () => {
@@ -79,10 +85,13 @@ export function UserTransferTabContent({
         draft.targetUserId != null
           ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
-      toast.success(`Transferred ${data.transferredCount} assignment(s)`, {
-        id: toastId,
-      });
-      resetForm();
+      toast.success(
+        formatTransferActivitiesSuccessMessage(data.transferredCount),
+        {
+          id: toastId,
+        }
+      );
+      setDraft(resetForm());
     },
     onError: (err: Error) => {
       const toastId =
@@ -92,24 +101,6 @@ export function UserTransferTabContent({
       toast.error(err.message || 'Transfer failed', { id: toastId });
     },
   });
-
-  const hasActivities = fieldsMeta.activities.length > 0;
-  const scopedActivityIds = useMemo(
-    () => fieldsMeta.activities.map((a) => a.id),
-    [fieldsMeta.activities]
-  );
-  const isDraftPristine = isTransferActivitiesDraftPristine(
-    draft,
-    scopedActivityIds
-  );
-
-  const canSubmit =
-    canTransfer &&
-    draft.fromTeamId != null &&
-    hasActivities &&
-    !fieldsMeta.isLoading &&
-    isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
-    !fieldsMeta.isError;
 
   if (!canTransfer) {
     return (
@@ -143,7 +134,7 @@ export function UserTransferTabContent({
       <div className="flex justify-end gap-2 pt-2">
         <Button
           variant="secondary"
-          onClick={resetForm}
+          onClick={() => setDraft(resetForm())}
           disabled={
             transferMutation.isPending ||
             fieldsMeta.isLoading ||

--- a/calendar-ui/src/components/users/UserTransferTabContent.tsx
+++ b/calendar-ui/src/components/users/UserTransferTabContent.tsx
@@ -26,6 +26,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Textarea } from '@/components/ui/textarea';
+import { invalidateUserCaches } from '@/lib/userQueryKeys';
 import { cn } from '@/lib/utils';
 
 interface UserTransferTabContentProps {
@@ -147,8 +148,7 @@ export function UserTransferTabContent({
         notes: notes || undefined,
       }),
     onSuccess: (data) => {
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
-      void queryClient.invalidateQueries({ queryKey: ['user', sourceUser.id] });
+      invalidateUserCaches(queryClient, sourceUser.id);
       const toastId =
         targetUserId != null
           ? `activities-transferred-${sourceUser.id}-${targetUserId}`

--- a/calendar-ui/src/components/users/UserTransferTabContent.tsx
+++ b/calendar-ui/src/components/users/UserTransferTabContent.tsx
@@ -1,157 +1,77 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { UserListItem } from '@corpcal/shared/api/types';
-import {
-  fetchUserActivities,
-  fetchUsers,
-  transferActivities,
-} from '@/api/usersApi';
+import { transferActivities } from '@/api/usersApi';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { Label } from '@/components/ui/label';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { Textarea } from '@/components/ui/textarea';
+  buildTransferActivitiesBody,
+  createInitialTransferDraft,
+  isTransferActivitiesDraftValid,
+  TransferActivitiesFields,
+  type TransferActivitiesDraft,
+  type TransferActivitiesFieldsMeta,
+} from '@/components/users/TransferActivitiesFields';
 import { invalidateUserCaches } from '@/lib/userQueryKeys';
-import { cn } from '@/lib/utils';
 
 interface UserTransferTabContentProps {
-  sourceUser: Pick<UserListItem, 'id' | 'adDisplayName' | 'adUsername'>;
-  canTransfer: boolean;
-}
-
-interface UserOption {
-  id: number;
-  label: string;
-  value: string;
-}
-
-function userToOption(
-  u: UserListItem & {
-    adDisplayName?: string | null;
-    adUsername?: string | null;
-  }
-): UserOption {
-  return {
-    id: u.id,
-    value: String(u.id),
-    label: u.adDisplayName || u.adUsername || `User ${u.id}`,
+  sourceUser: Pick<UserListItem, 'id' | 'adDisplayName' | 'adUsername'> & {
+    teams: { teamId: number; teamName: string }[];
   };
+  canTransfer: boolean;
 }
 
 export function UserTransferTabContent({
   sourceUser,
   canTransfer,
 }: UserTransferTabContentProps) {
-  const [targetUserId, setTargetUserId] = useState<number | null>(null);
-  const [targetUserLabel, setTargetUserLabel] = useState<string>('');
-  const [transferCommsLead, setTransferCommsLead] = useState(true);
-  const [transferCommsContact, setTransferCommsContact] = useState(true);
-  const [selectedActivityIds, setSelectedActivityIds] = useState<number[]>([]);
-  const [notes, setNotes] = useState('');
-  const [comboboxOpen, setComboboxOpen] = useState(false);
-  const [userSearch, setUserSearch] = useState('');
-  const [activitiesDropdownOpen, setActivitiesDropdownOpen] = useState(false);
-  const activitiesInitializedForUser = useRef<number | null>(null);
-
   const queryClient = useQueryClient();
 
-  const { data: searchUsers = [], isFetching: isSearching } = useQuery({
-    queryKey: ['users', 'transfer-tab', sourceUser.id, userSearch],
-    queryFn: () => fetchUsers({ search: userSearch.trim() || undefined }),
-    enabled: canTransfer && comboboxOpen,
-  });
+  const fromTeamOptions = useMemo(
+    () =>
+      sourceUser.teams.map((t) => ({
+        teamId: t.teamId,
+        teamName: t.teamName,
+      })),
+    [sourceUser.teams]
+  );
 
-  const userOptions: UserOption[] = useMemo(() => {
-    return searchUsers
-      .filter((u) => u.id !== sourceUser.id && u.isActive)
-      .map((u) => userToOption(u));
-  }, [searchUsers, sourceUser.id]);
+  const initialFromTeamId = fromTeamOptions[0]?.teamId ?? null;
 
-  const {
-    data: userActivities = [],
-    isLoading: isLoadingActivities,
-    isError: isActivitiesError,
-  } = useQuery({
-    queryKey: ['users', sourceUser.id, 'activities'],
-    queryFn: () => fetchUserActivities(sourceUser.id),
-    enabled: canTransfer,
-  });
+  const [draft, setDraft] = useState<TransferActivitiesDraft>(() =>
+    createInitialTransferDraft(initialFromTeamId)
+  );
 
   useEffect(() => {
-    if (
-      userActivities.length > 0 &&
-      activitiesInitializedForUser.current !== sourceUser.id
-    ) {
-      activitiesInitializedForUser.current = sourceUser.id;
-      setSelectedActivityIds(userActivities.map((a) => a.id));
+    if (initialFromTeamId != null && draft.fromTeamId == null) {
+      setDraft(createInitialTransferDraft(initialFromTeamId));
     }
-  }, [sourceUser.id, userActivities]);
-
-  const toggleActivity = (activityId: number) => {
-    setSelectedActivityIds((prev) =>
-      prev.includes(activityId)
-        ? prev.filter((id) => id !== activityId)
-        : [...prev, activityId]
-    );
-  };
-
-  const selectAllActivities = () => {
-    setSelectedActivityIds(userActivities.map((a) => a.id));
-  };
-
-  const deselectAllActivities = () => {
-    setSelectedActivityIds([]);
-  };
+  }, [initialFromTeamId, draft.fromTeamId]);
+  const [fieldsMeta, setFieldsMeta] = useState<TransferActivitiesFieldsMeta>({
+    activities: [],
+    isLoading: false,
+    isError: false,
+  });
 
   const resetForm = () => {
-    setTargetUserId(null);
-    setTargetUserLabel('');
-    setTransferCommsLead(true);
-    setTransferCommsContact(true);
-    setNotes('');
-    setComboboxOpen(false);
-    setUserSearch('');
-    setActivitiesDropdownOpen(false);
-    setSelectedActivityIds(userActivities.map((a) => a.id));
+    setDraft(createInitialTransferDraft(initialFromTeamId));
   };
 
-  const selectedCount = selectedActivityIds.length;
-  const allSelected =
-    userActivities.length > 0 && selectedCount === userActivities.length;
-  const noneSelected = selectedCount === 0;
-
   const transferMutation = useMutation({
-    mutationFn: () =>
-      transferActivities(sourceUser.id, {
-        targetUserId: targetUserId!,
-        activityIds:
-          allSelected || userActivities.length === 0
-            ? undefined
-            : selectedActivityIds,
-        transferCommsLead,
-        transferCommsContact,
-        notes: notes || undefined,
-      }),
+    mutationFn: () => {
+      const body = buildTransferActivitiesBody(
+        draft,
+        fieldsMeta.activities.map((a) => a.id)
+      );
+      return transferActivities(sourceUser.id, body);
+    },
     onSuccess: (data) => {
       invalidateUserCaches(queryClient, sourceUser.id);
       const toastId =
-        targetUserId != null
-          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+        draft.targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
       toast.success(`Transferred ${data.transferredCount} assignment(s)`, {
         id: toastId,
@@ -160,19 +80,21 @@ export function UserTransferTabContent({
     },
     onError: (err: Error) => {
       const toastId =
-        targetUserId != null
-          ? `activities-transferred-${sourceUser.id}-${targetUserId}`
+        draft.targetUserId != null
+          ? `activities-transferred-${sourceUser.id}-${draft.targetUserId}`
           : 'activities-transferred';
       toast.error(err.message || 'Transfer failed', { id: toastId });
     },
   });
 
+  const hasActivities = fieldsMeta.activities.length > 0;
+
   const canSubmit =
     canTransfer &&
-    targetUserId != null &&
-    sourceUser.id !== targetUserId &&
-    (transferCommsLead || transferCommsContact) &&
-    (userActivities.length === 0 || selectedCount > 0);
+    draft.fromTeamId != null &&
+    !fieldsMeta.isLoading &&
+    isTransferActivitiesDraftValid(draft, sourceUser.id, hasActivities) &&
+    !fieldsMeta.isError;
 
   if (!canTransfer) {
     return (
@@ -182,209 +104,25 @@ export function UserTransferTabContent({
     );
   }
 
+  if (fromTeamOptions.length === 0) {
+    return (
+      <p className="text-muted-foreground py-6 text-sm">
+        This user is not on any teams. Add a team before transferring
+        activities.
+      </p>
+    );
+  }
+
   return (
     <div className="max-w-2xl space-y-4 py-4">
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">
-          Transfer to user{' '}
-          <span className="text-required-field-indicator font-semibold">*</span>
-        </Label>
-        <Popover
-          open={comboboxOpen}
-          onOpenChange={(open) => {
-            setComboboxOpen(open);
-            if (!open) setUserSearch('');
-          }}
-        >
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              role="combobox"
-              aria-expanded={comboboxOpen}
-              className="w-full justify-between font-normal"
-            >
-              {targetUserId != null && targetUserLabel
-                ? targetUserLabel
-                : 'Select user...'}
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            className="w-(--radix-popover-trigger-width) p-0"
-            align="start"
-          >
-            <Command shouldFilter={false}>
-              <CommandInput
-                placeholder="Search users..."
-                value={userSearch}
-                onValueChange={setUserSearch}
-              />
-              <CommandList>
-                {isSearching ? (
-                  <div className="flex items-center justify-center py-6">
-                    <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-                  </div>
-                ) : (
-                  <>
-                    <CommandEmpty>No users found.</CommandEmpty>
-                    <CommandGroup>
-                      {userOptions.map((option) => {
-                        const isSelected = targetUserId === option.id;
-                        return (
-                          <CommandItem
-                            key={option.value}
-                            value={option.value}
-                            onSelect={() => {
-                              setTargetUserId(option.id);
-                              setTargetUserLabel(option.label);
-                              setUserSearch('');
-                              setComboboxOpen(false);
-                            }}
-                          >
-                            <Check
-                              className={cn(
-                                'mr-2 h-4 w-4',
-                                isSelected ? 'opacity-100' : 'opacity-0'
-                              )}
-                            />
-                            {option.label}
-                          </CommandItem>
-                        );
-                      })}
-                    </CommandGroup>
-                  </>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-sm font-medium">Transfer</span>
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="transfer-lead"
-              checked={transferCommsLead}
-              onCheckedChange={(checked) =>
-                setTransferCommsLead(checked === true)
-              }
-            />
-            <Label
-              htmlFor="transfer-lead"
-              className="cursor-pointer text-sm font-normal"
-            >
-              Comms lead assignments
-            </Label>
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="transfer-contact"
-              checked={transferCommsContact}
-              onCheckedChange={(checked) =>
-                setTransferCommsContact(checked === true)
-              }
-            />
-            <Label
-              htmlFor="transfer-contact"
-              className="cursor-pointer text-sm font-normal"
-            >
-              Comms contact (non-lead) assignments
-            </Label>
-          </div>
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">
-          Select activities{' '}
-          <span className="text-required-field-indicator font-semibold">*</span>
-        </Label>
-        <Popover
-          open={activitiesDropdownOpen}
-          onOpenChange={setActivitiesDropdownOpen}
-        >
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              role="combobox"
-              aria-expanded={activitiesDropdownOpen}
-              className="w-full justify-between font-normal"
-              disabled={isLoadingActivities || isActivitiesError}
-            >
-              {isLoadingActivities
-                ? 'Loading activities...'
-                : selectedCount === 0
-                  ? 'No activities selected'
-                  : `${selectedCount} activities selected`}
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            className="w-(--radix-popover-trigger-width) p-0"
-            align="start"
-          >
-            <div className="flex flex-col">
-              <div className="flex items-center justify-between border-b px-3 py-2 text-sm">
-                <span className="text-muted-foreground">
-                  {noneSelected ? 'None selected' : `${selectedCount} selected`}
-                </span>
-                <button
-                  type="button"
-                  className="text-primary hover:underline focus:underline focus:outline-none"
-                  onClick={() => {
-                    if (noneSelected) selectAllActivities();
-                    else deselectAllActivities();
-                  }}
-                >
-                  {noneSelected ? 'Select all' : 'Deselect all'}
-                </button>
-              </div>
-              <div className="max-h-[240px] overflow-auto p-1">
-                {isActivitiesError ? (
-                  <div className="text-destructive py-4 text-center text-sm">
-                    Failed to load activities
-                  </div>
-                ) : userActivities.length === 0 ? (
-                  <div className="text-muted-foreground py-4 text-center text-sm">
-                    No activities associated with this user
-                  </div>
-                ) : (
-                  userActivities.map((activity) => (
-                    <div
-                      key={activity.id}
-                      className="hover:bg-accent flex items-center space-x-2 rounded-sm px-2 py-1.5"
-                    >
-                      <Checkbox
-                        id={`activity-${activity.id}`}
-                        checked={selectedActivityIds.includes(activity.id)}
-                        onCheckedChange={() => toggleActivity(activity.id)}
-                      />
-                      <Label
-                        htmlFor={`activity-${activity.id}`}
-                        className="flex-1 cursor-pointer text-sm font-normal"
-                      >
-                        {activity.label}
-                      </Label>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Notes</Label>
-        <Textarea
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          placeholder="Reason for transfer..."
-          className="min-h-[120px]"
-        />
-      </div>
+      <TransferActivitiesFields
+        mode="transfer"
+        sourceUserId={sourceUser.id}
+        fromTeamOptions={fromTeamOptions}
+        value={draft}
+        onChange={setDraft}
+        onMetaChange={setFieldsMeta}
+      />
 
       <div className="flex justify-end gap-2 pt-2">
         <Button

--- a/calendar-ui/src/components/users/userHistoryFormatting.test.ts
+++ b/calendar-ui/src/components/users/userHistoryFormatting.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildUserHistoryChangeMessage } from '@/components/users/userHistoryFormatting';
+
+describe('buildUserHistoryChangeMessage activityIds', () => {
+  const lookups = {
+    roleNamesById: {},
+    teamNamesById: {},
+    activityTitlesById: { 10: 'Town hall', 11: 'Newsletter' },
+  };
+
+  it('lists activity titles when known', () => {
+    const message = buildUserHistoryChangeMessage(
+      { field: 'activityIds', oldValue: null, newValue: [10, 11] },
+      lookups
+    );
+    expect(message).toContain('2 activities');
+    expect(message).toContain('Town hall');
+    expect(message).toContain('Newsletter');
+  });
+
+  it('falls back to numeric ids when titles are unknown', () => {
+    const message = buildUserHistoryChangeMessage(
+      { field: 'activityIds', oldValue: null, newValue: [42] },
+      { roleNamesById: {}, teamNamesById: {} }
+    );
+    expect(message).toContain('#42');
+  });
+});

--- a/calendar-ui/src/components/users/userHistoryFormatting.ts
+++ b/calendar-ui/src/components/users/userHistoryFormatting.ts
@@ -3,6 +3,7 @@ import type { HistoryChange } from '@corpcal/shared/api/types';
 interface UserHistoryLookups {
   roleNamesById: Record<number, string>;
   teamNamesById: Record<number, string>;
+  activityTitlesById?: Record<number, string>;
 }
 
 const USER_HISTORY_FIELD_LABELS: Record<string, string> = {
@@ -27,7 +28,7 @@ const USER_HISTORY_FIELD_LABELS: Record<string, string> = {
   targetUserId: 'Transfer target',
   fromTeamId: 'From team',
   toTeamId: 'To team',
-  activityCount: 'Activities transferred',
+  activityCount: 'Activities affected',
   activityIds: 'Activities',
 };
 
@@ -101,7 +102,19 @@ function formatHistoryValue(
   }
 
   if (field === 'activityIds' && Array.isArray(value)) {
-    return `${value.length} activit${value.length === 1 ? 'y' : 'ies'}`;
+    const ids = value
+      .map((entry) => parseNumericId(entry))
+      .filter((id): id is number => id != null);
+    if (ids.length === 0) return 'none';
+    const labels = ids.map(
+      (id) => lookups.activityTitlesById?.[id] ?? `#${id}`
+    );
+    const countLabel = `${ids.length} activit${ids.length === 1 ? 'y' : 'ies'}`;
+    const maxListed = 5;
+    if (labels.length <= maxListed) {
+      return `${countLabel}: ${labels.join(', ')}`;
+    }
+    return `${countLabel}: ${labels.slice(0, maxListed).join(', ')}, …`;
   }
 
   if (typeof value === 'boolean') return formatBooleanValue(field, value);

--- a/calendar-ui/src/components/users/userHistoryFormatting.ts
+++ b/calendar-ui/src/components/users/userHistoryFormatting.ts
@@ -23,6 +23,12 @@ const USER_HISTORY_FIELD_LABELS: Record<string, string> = {
   directLoginEnabled: 'Direct login enabled',
   notes: 'Notes',
   flagColour: 'Flag colour',
+  teamRole: 'Team role',
+  targetUserId: 'Transfer target',
+  fromTeamId: 'From team',
+  toTeamId: 'To team',
+  activityCount: 'Activities transferred',
+  activityIds: 'Activities',
 };
 
 function toLabelFromField(field: string): string {
@@ -80,6 +86,22 @@ function formatHistoryValue(
     if (teamId != null) {
       return lookups.teamNamesById[teamId] ?? `Team ${teamId}`;
     }
+  }
+
+  if (field === 'fromTeamId' || field === 'toTeamId') {
+    const teamId = parseNumericId(value);
+    if (teamId != null) {
+      return lookups.teamNamesById[teamId] ?? `Team ${teamId}`;
+    }
+  }
+
+  if (field === 'targetUserId') {
+    const id = parseNumericId(value);
+    if (id != null) return `User ${id}`;
+  }
+
+  if (field === 'activityIds' && Array.isArray(value)) {
+    return `${value.length} activit${value.length === 1 ? 'y' : 'ies'}`;
   }
 
   if (typeof value === 'boolean') return formatBooleanValue(field, value);

--- a/calendar-ui/src/hooks/useCommsContactCandidates.ts
+++ b/calendar-ui/src/hooks/useCommsContactCandidates.ts
@@ -8,9 +8,8 @@ import { lookupQueryKeys } from '../lib/lookupQueryKeys';
 /**
  * Eligible comms contact candidates for a given lead team.
  * Returns active team members whose role grants activities.edit.
- * Re-fetches when `teamId` changes; disabled when teamId is falsy / 0 or when
- * `fetchEnabled` is false (e.g. caller is not on that team and lacks
- * activities.create.any — matches GET /teams/:id/comms-contact-candidates).
+ * Re-fetches when `teamId` changes; disabled when teamId is falsy / 0 or
+ * `fetchEnabled` is false.
  */
 export function useCommsContactCandidates(
   teamId: number | undefined,

--- a/calendar-ui/src/hooks/useTransferActivitiesSubmit.ts
+++ b/calendar-ui/src/hooks/useTransferActivitiesSubmit.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+
+import {
+  createInitialTransferDraft,
+  isTransferActivitiesDraftPristine,
+  isTransferActivitiesDraftValid,
+  wouldTransferDraftHaveEffect,
+  type TransferActivitiesDraft,
+  type TransferActivitiesFieldsMeta,
+} from '@/components/users/TransferActivitiesFields';
+
+interface UseTransferActivitiesSubmitOptions {
+  sourceUserId: number;
+  draft: TransferActivitiesDraft;
+  fieldsMeta: TransferActivitiesFieldsMeta;
+  initialFromTeamId: number | null;
+  /** When false, submit stays disabled (user transfer tab). Defaults to true. */
+  canTransfer?: boolean;
+  /** When true, require at least one from-team option (transfer dialog). */
+  requireFromTeamOptions?: boolean;
+  fromTeamOptionCount?: number;
+}
+
+export function useTransferActivitiesSubmit({
+  sourceUserId,
+  draft,
+  fieldsMeta,
+  initialFromTeamId,
+  canTransfer = true,
+  requireFromTeamOptions = false,
+  fromTeamOptionCount = 1,
+}: UseTransferActivitiesSubmitOptions) {
+  const hasActivities = fieldsMeta.activities.length > 0;
+  const scopedActivityIds = useMemo(
+    () => fieldsMeta.activities.map((a) => a.id),
+    [fieldsMeta.activities]
+  );
+
+  const isDraftPristine = isTransferActivitiesDraftPristine(
+    draft,
+    scopedActivityIds
+  );
+
+  const hasTransferEffect = wouldTransferDraftHaveEffect(
+    draft,
+    fieldsMeta.activities
+  );
+
+  const canSubmit =
+    canTransfer &&
+    draft.fromTeamId != null &&
+    (!requireFromTeamOptions || fromTeamOptionCount > 0) &&
+    hasActivities &&
+    hasTransferEffect &&
+    !fieldsMeta.isLoading &&
+    isTransferActivitiesDraftValid(draft, sourceUserId, hasActivities) &&
+    !fieldsMeta.isError;
+
+  const resetForm = () => {
+    return createInitialTransferDraft(draft.fromTeamId ?? initialFromTeamId);
+  };
+
+  return {
+    canSubmit,
+    hasActivities,
+    isDraftPristine,
+    resetForm,
+    scopedActivityIds,
+  };
+}

--- a/calendar-ui/src/lib/transfer-activities-messages.ts
+++ b/calendar-ui/src/lib/transfer-activities-messages.ts
@@ -1,0 +1,6 @@
+/** Success toast after POST /users/:id/transfer-activities (transferredCount = activities affected). */
+export function formatTransferActivitiesSuccessMessage(
+  activitiesAffected: number
+): string {
+  return `${activitiesAffected} activit${activitiesAffected === 1 ? 'y' : 'ies'} updated`;
+}

--- a/calendar-ui/src/lib/userQueryKeys.ts
+++ b/calendar-ui/src/lib/userQueryKeys.ts
@@ -1,0 +1,28 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Centralized React Query key factory for user detail, list, and change-log history.
+ *
+ * `list()` uses the `['users']` prefix so invalidation also refreshes nested keys
+ * such as `['users', search]` and `['users', userId, 'activities']`.
+ */
+
+export const userQueryKeys = {
+  detail: (userId: number) => ['user', userId] as const,
+  history: (userId: number) => ['userHistory', userId] as const,
+  list: () => ['users'] as const,
+} as const;
+
+/** Refetch user detail, list, and change-log after a mutation that updates user data. */
+export function invalidateUserCaches(
+  queryClient: QueryClient,
+  userId: number
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: userQueryKeys.detail(userId),
+  });
+  void queryClient.invalidateQueries({ queryKey: userQueryKeys.list() });
+  void queryClient.invalidateQueries({
+    queryKey: userQueryKeys.history(userId),
+  });
+}

--- a/calendar-ui/src/pages/UserDetailPage.tsx
+++ b/calendar-ui/src/pages/UserDetailPage.tsx
@@ -356,7 +356,14 @@ export default function UserDetailPage() {
   };
 
   const handleTeamSelectionChange = async (selected: OptionItem[]) => {
-    if (!canEdit || !userDetail || isProcessingTeamRemove) return;
+    if (
+      !canEdit ||
+      !userDetail ||
+      isProcessingTeamRemove ||
+      teamRemovalModal != null
+    ) {
+      return;
+    }
 
     const newIds = selected.map((o) => parseInt(o.value, 10));
     const removed = localTeamIds.filter((id) => !newIds.includes(id));
@@ -609,7 +616,11 @@ export default function UserDetailPage() {
                       void handleTeamSelectionChange(selected);
                     }}
                     itemToStringValue={(o: OptionItem) => o.label}
-                    disabled={!canEdit || isProcessingTeamRemove}
+                    disabled={
+                      !canEdit ||
+                      isProcessingTeamRemove ||
+                      teamRemovalModal != null
+                    }
                   >
                     <ComboboxChips
                       ref={teamsComboboxAnchorRef}

--- a/calendar-ui/src/pages/UserDetailPage.tsx
+++ b/calendar-ui/src/pages/UserDetailPage.tsx
@@ -20,10 +20,13 @@ import {
 import type { UserDetail } from '@corpcal/shared/api/types';
 import { fetchRolesPermissionsMap } from '@/api/lookupsApi';
 import {
+  addUserToTeam,
   fetchRolePermissions,
   fetchRoles,
+  fetchTeams,
   fetchUser,
   initiatePasswordReset,
+  removeUserFromTeam,
   updateUser,
   updateUserSettings,
 } from '@/api/usersApi';
@@ -32,6 +35,19 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 // removed PageHeader to use a compact header with a Go back link
 import { Button } from '@/components/ui/button';
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxSeparator,
+  ComboboxValue,
+  useComboboxAnchor,
+} from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -44,11 +60,14 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { TeamsComboboxSelectAllRow } from '@/components/users/TeamsComboboxSelectAllRow';
 import { UserChangeLogTabContent } from '@/components/users/UserChangeLogTabContent';
 import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserTransferTabContent } from '@/components/users/UserTransferTabContent';
 import { useAuth } from '@/hooks/useAuth';
+import { lookupQueryKeys } from '@/lib/lookupQueryKeys';
 import { invalidateUserCaches, userQueryKeys } from '@/lib/userQueryKeys';
+import type { OptionItem } from '@/schemas/types';
 
 // Permissions are authoritative from the backend; no frontend fallback maintained.
 
@@ -73,6 +92,8 @@ export default function UserDetailPage() {
 
   const [localNotes, setLocalNotes] = useState<string>('');
   const [selectedRoleId, setSelectedRoleId] = useState<number | null>(null);
+  const [localTeamIds, setLocalTeamIds] = useState<number[]>([]);
+  const teamsComboboxAnchorRef = useComboboxAnchor();
 
   // Seed the editable fields only once per user. React Query refetches the
   // user (e.g. on window focus, reconnect, or cache invalidation) and returns
@@ -89,7 +110,45 @@ export default function UserDetailPage() {
     setSelectedRoleId(userDetail.roleId ?? null);
     setDirectLoginEnabled(Boolean(userDetail.directLoginEnabled));
     setFlagColour(userDetail.flagColour ?? null);
+    setLocalTeamIds(userDetail.teams.map((t) => t.teamId));
   }, [userDetail, userId]);
+
+  const { data: teams = [] } = useQuery({
+    queryKey: lookupQueryKeys.teams(),
+    queryFn: fetchTeams,
+    enabled: !!userId && !!userDetail,
+  });
+
+  const teamOptions = useMemo((): OptionItem[] => {
+    const fromLookup = teams.map((t) => ({
+      value: String(t.id),
+      label: t.displayName ?? t.name ?? `Team ${t.id}`,
+    }));
+    const knownValues = new Set(fromLookup.map((o) => o.value));
+    for (const membership of userDetail?.teams ?? []) {
+      const value = String(membership.teamId);
+      if (!knownValues.has(value)) {
+        fromLookup.push({ value, label: membership.teamName });
+        knownValues.add(value);
+      }
+    }
+    return fromLookup;
+  }, [teams, userDetail?.teams]);
+
+  const selectedTeamOptions = useMemo(
+    () =>
+      teamOptions.filter((o) => localTeamIds.includes(parseInt(o.value, 10))),
+    [teamOptions, localTeamIds]
+  );
+
+  const allSelectableTeamIds = useMemo(
+    () => teamOptions.map((o) => parseInt(o.value, 10)),
+    [teamOptions]
+  );
+
+  const allTeamsSelected =
+    allSelectableTeamIds.length > 0 &&
+    allSelectableTeamIds.every((id) => localTeamIds.includes(id));
 
   const mutation = useMutation({
     mutationFn: (payload: { roleId?: number; notes?: string | null }) =>
@@ -260,6 +319,40 @@ export default function UserDetailPage() {
     ));
   }, [visibleRows]);
 
+  const syncTeamMembership = async (): Promise<boolean> => {
+    if (!userDetail) return true;
+
+    const serverTeamIds = new Set(userDetail.teams.map((t) => t.teamId));
+    const localIds = new Set(localTeamIds);
+    const toAdd = localTeamIds.filter((id) => !serverTeamIds.has(id));
+    const toRemove = userDetail.teams
+      .filter((t) => !localIds.has(t.teamId))
+      .map((t) => t.teamId);
+
+    if (toAdd.length === 0 && toRemove.length === 0) return true;
+
+    const results = await Promise.allSettled([
+      ...toAdd.map((teamId) =>
+        addUserToTeam(userId, { teamId, role: 'member' })
+      ),
+      ...toRemove.map((teamId) => removeUserFromTeam(userId, teamId)),
+    ]);
+
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    invalidateUserCaches(queryClient, userId);
+
+    if (failed > 0) {
+      toast.error(
+        failed === results.length
+          ? 'Failed to update team membership'
+          : `${failed} team change${failed > 1 ? 's' : ''} failed`
+      );
+      return false;
+    }
+
+    return true;
+  };
+
   const handleSave = async () => {
     const body: { roleId?: number; notes?: string | null } = {};
     if (selectedRoleId != null) body.roleId = selectedRoleId;
@@ -274,6 +367,9 @@ export default function UserDetailPage() {
       if (userDetail && serverDirectLoginEnabled !== directLoginEnabled) {
         await settingsMutation.mutateAsync({ directLoginEnabled });
       }
+
+      const teamsSaved = await syncTeamMembership();
+      if (!teamsSaved) return;
 
       void navigate('/users');
     } catch {
@@ -448,6 +544,70 @@ export default function UserDetailPage() {
                   <div className="text-sm text-slate-500">
                     Flag colour for this user
                   </div>
+                </div>
+              </div>
+
+              <div className="max-w-2xl bg-transparent p-0">
+                <Label className="text-base font-semibold">Teams</Label>
+                <div className="mt-2">
+                  <Combobox
+                    items={teamOptions}
+                    multiple
+                    value={selectedTeamOptions}
+                    onValueChange={(selected: OptionItem[]) => {
+                      if (!canEdit) return;
+                      setLocalTeamIds(
+                        selected.map((o) => parseInt(o.value, 10))
+                      );
+                    }}
+                    itemToStringValue={(o: OptionItem) => o.label}
+                    disabled={!canEdit}
+                  >
+                    <ComboboxChips
+                      ref={teamsComboboxAnchorRef}
+                      className="w-full"
+                    >
+                      <ComboboxValue>
+                        {(values: OptionItem[]) => (
+                          <>
+                            {values.map((option) => (
+                              <ComboboxChip key={option.value}>
+                                {option.label}
+                              </ComboboxChip>
+                            ))}
+                            <ComboboxChipsInput placeholder="Select teams..." />
+                          </>
+                        )}
+                      </ComboboxValue>
+                    </ComboboxChips>
+                    <ComboboxContent
+                      anchor={teamsComboboxAnchorRef}
+                      className="popover-list-scroll flex max-h-[min(var(--popover-list-max-height),24rem)] flex-col overflow-x-hidden overflow-y-auto p-0"
+                    >
+                      <div className="bg-popover px-1 py-1">
+                        <TeamsComboboxSelectAllRow
+                          allSelected={allTeamsSelected}
+                          disabled={!canEdit || teamOptions.length === 0}
+                          onToggleSelectAll={() => {
+                            setLocalTeamIds(
+                              allTeamsSelected ? [] : allSelectableTeamIds
+                            );
+                          }}
+                        />
+                        {teamOptions.length > 0 ? (
+                          <ComboboxSeparator className="my-1" />
+                        ) : null}
+                        <ComboboxEmpty>No teams found.</ComboboxEmpty>
+                        <ComboboxList className="max-h-none scroll-py-1 overflow-visible p-0 data-empty:p-0">
+                          {(option: OptionItem) => (
+                            <ComboboxItem key={option.value} value={option}>
+                              {option.label}
+                            </ComboboxItem>
+                          )}
+                        </ComboboxList>
+                      </div>
+                    </ComboboxContent>
+                  </Combobox>
                 </div>
               </div>
 

--- a/calendar-ui/src/pages/UserDetailPage.tsx
+++ b/calendar-ui/src/pages/UserDetailPage.tsx
@@ -48,6 +48,7 @@ import { UserChangeLogTabContent } from '@/components/users/UserChangeLogTabCont
 import { UserEditModal } from '@/components/users/UserEditModal';
 import { UserTransferTabContent } from '@/components/users/UserTransferTabContent';
 import { useAuth } from '@/hooks/useAuth';
+import { invalidateUserCaches, userQueryKeys } from '@/lib/userQueryKeys';
 
 // Permissions are authoritative from the backend; no frontend fallback maintained.
 
@@ -58,7 +59,7 @@ export default function UserDetailPage() {
   const { hasPermission, user: currentUser } = useAuth();
 
   const { data: userDetail, isLoading } = useQuery<UserDetail | null>({
-    queryKey: ['user', userId],
+    queryKey: userQueryKeys.detail(userId),
     queryFn: () => fetchUser(userId),
     enabled: !!userId,
   });
@@ -94,8 +95,7 @@ export default function UserDetailPage() {
     mutationFn: (payload: { roleId?: number; notes?: string | null }) =>
       updateUser(userId, payload),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['user', userId] });
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      invalidateUserCaches(queryClient, userId);
     },
     onError: (err: Error) => {
       toast.error(err.message || 'Failed to update user');
@@ -137,8 +137,7 @@ export default function UserDetailPage() {
         directLoginEnabled: body.directLoginEnabled,
       }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['user', userId] });
-      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      invalidateUserCaches(queryClient, userId);
     },
     onError: (err: Error) => {
       toast.error(err.message || 'Failed to update user settings');
@@ -555,13 +554,7 @@ export default function UserDetailPage() {
             <UserEditModal
               user={userDetail}
               onClose={() => setShowEditModal(false)}
-              onSaved={() => {
-                void queryClient.invalidateQueries({
-                  queryKey: ['user', userId],
-                });
-                void queryClient.invalidateQueries({ queryKey: ['users'] });
-                setShowEditModal(false);
-              }}
+              onSaved={() => setShowEditModal(false)}
             />
           )}
         </div>

--- a/calendar-ui/src/pages/UserDetailPage.tsx
+++ b/calendar-ui/src/pages/UserDetailPage.tsx
@@ -25,12 +25,14 @@ import {
   fetchRoles,
   fetchTeams,
   fetchUser,
+  fetchUserActivities,
   initiatePasswordReset,
   removeUserFromTeam,
   updateUser,
   updateUserSettings,
 } from '@/api/usersApi';
 import { PageContainer } from '@/components/layout/PageContainer';
+import RemoveTeamMemberModal from '@/components/teams/RemoveTeamMemberModal';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 // removed PageHeader to use a compact header with a Go back link
@@ -171,6 +173,13 @@ export default function UserDetailPage() {
     code: string;
     expiresInHours?: number;
   } | null>(null);
+
+  const [teamRemovalModal, setTeamRemovalModal] = useState<{
+    teamId: number;
+    teamName: string;
+    teamIdsBeforeRemove: number[];
+  } | null>(null);
+  const [isProcessingTeamRemove, setIsProcessingTeamRemove] = useState(false);
 
   const resetMutation = useMutation({
     mutationFn: () => initiatePasswordReset(userId),
@@ -323,20 +332,13 @@ export default function UserDetailPage() {
     if (!userDetail) return true;
 
     const serverTeamIds = new Set(userDetail.teams.map((t) => t.teamId));
-    const localIds = new Set(localTeamIds);
     const toAdd = localTeamIds.filter((id) => !serverTeamIds.has(id));
-    const toRemove = userDetail.teams
-      .filter((t) => !localIds.has(t.teamId))
-      .map((t) => t.teamId);
 
-    if (toAdd.length === 0 && toRemove.length === 0) return true;
+    if (toAdd.length === 0) return true;
 
-    const results = await Promise.allSettled([
-      ...toAdd.map((teamId) =>
-        addUserToTeam(userId, { teamId, role: 'member' })
-      ),
-      ...toRemove.map((teamId) => removeUserFromTeam(userId, teamId)),
-    ]);
+    const results = await Promise.allSettled(
+      toAdd.map((teamId) => addUserToTeam(userId, { teamId, role: 'member' }))
+    );
 
     const failed = results.filter((r) => r.status === 'rejected').length;
     invalidateUserCaches(queryClient, userId);
@@ -351,6 +353,55 @@ export default function UserDetailPage() {
     }
 
     return true;
+  };
+
+  const handleTeamSelectionChange = async (selected: OptionItem[]) => {
+    if (!canEdit || !userDetail || isProcessingTeamRemove) return;
+
+    const newIds = selected.map((o) => parseInt(o.value, 10));
+    const removed = localTeamIds.filter((id) => !newIds.includes(id));
+    const added = newIds.filter((id) => !localTeamIds.includes(id));
+
+    if (removed.length === 0) {
+      setLocalTeamIds(newIds);
+      return;
+    }
+
+    if (removed.length > 1 || added.length > 0) {
+      toast.error('Remove one team at a time using the team chips.');
+      return;
+    }
+
+    const teamId = removed[0];
+    const teamName =
+      teamOptions.find((o) => parseInt(o.value, 10) === teamId)?.label ??
+      `Team ${teamId}`;
+
+    const teamIdsBeforeRemove = localTeamIds;
+    setLocalTeamIds(newIds);
+    setIsProcessingTeamRemove(true);
+
+    try {
+      const activities = await fetchUserActivities(userId, teamId);
+      if (activities.length === 0) {
+        await removeUserFromTeam(userId, teamId);
+        invalidateUserCaches(queryClient, userId);
+        toast.success('Removed from team');
+      } else {
+        setTeamRemovalModal({
+          teamId,
+          teamName,
+          teamIdsBeforeRemove,
+        });
+      }
+    } catch (err) {
+      setLocalTeamIds(teamIdsBeforeRemove);
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to remove from team'
+      );
+    } finally {
+      setIsProcessingTeamRemove(false);
+    }
   };
 
   const handleSave = async () => {
@@ -555,13 +606,10 @@ export default function UserDetailPage() {
                     multiple
                     value={selectedTeamOptions}
                     onValueChange={(selected: OptionItem[]) => {
-                      if (!canEdit) return;
-                      setLocalTeamIds(
-                        selected.map((o) => parseInt(o.value, 10))
-                      );
+                      void handleTeamSelectionChange(selected);
                     }}
                     itemToStringValue={(o: OptionItem) => o.label}
-                    disabled={!canEdit}
+                    disabled={!canEdit || isProcessingTeamRemove}
                   >
                     <ComboboxChips
                       ref={teamsComboboxAnchorRef}
@@ -589,9 +637,13 @@ export default function UserDetailPage() {
                           allSelected={allTeamsSelected}
                           disabled={!canEdit || teamOptions.length === 0}
                           onToggleSelectAll={() => {
-                            setLocalTeamIds(
-                              allTeamsSelected ? [] : allSelectableTeamIds
-                            );
+                            if (allTeamsSelected) {
+                              toast.error(
+                                'Remove one team at a time using the team chips.'
+                              );
+                              return;
+                            }
+                            setLocalTeamIds(allSelectableTeamIds);
                           }}
                         />
                         {teamOptions.length > 0 ? (
@@ -715,6 +767,30 @@ export default function UserDetailPage() {
               user={userDetail}
               onClose={() => setShowEditModal(false)}
               onSaved={() => setShowEditModal(false)}
+            />
+          )}
+
+          {teamRemovalModal && userDetail && (
+            <RemoveTeamMemberModal
+              open
+              teamId={teamRemovalModal.teamId}
+              teamName={teamRemovalModal.teamName}
+              member={{
+                userId,
+                userName:
+                  userDetail.adDisplayName ||
+                  userDetail.adUsername ||
+                  `User ${userId}`,
+                adEmail: userDetail.adEmail,
+              }}
+              onClose={() => {
+                setLocalTeamIds(teamRemovalModal.teamIdsBeforeRemove);
+                setTeamRemovalModal(null);
+              }}
+              onRemoved={() => {
+                setTeamRemovalModal(null);
+                invalidateUserCaches(queryClient, userId);
+              }}
             />
           )}
         </div>

--- a/calendar-ui/src/pages/__tests__/UserDetailPage.permissions.unit.test.tsx
+++ b/calendar-ui/src/pages/__tests__/UserDetailPage.permissions.unit.test.tsx
@@ -28,9 +28,11 @@ vi.mock('@/api/usersApi', () => ({
     isActive: true,
     notes: null,
     directLoginEnabled: false,
+    teams: [],
   }),
   fetchRoles: vi.fn().mockResolvedValue([{ id: 2, name: 'Editor' }]),
   fetchRolePermissions: vi.fn().mockResolvedValue([]),
+  fetchTeams: vi.fn().mockResolvedValue([]),
 }));
 
 describe('UserDetailPage permissions (unit)', () => {

--- a/calendar-ui/src/pages/__tests__/permissions-visibility.e2e.test.tsx
+++ b/calendar-ui/src/pages/__tests__/permissions-visibility.e2e.test.tsx
@@ -67,9 +67,11 @@ vi.mock('@/api/usersApi', () => ({
     isActive: true,
     notes: null,
     directLoginEnabled: false,
+    teams: [],
   }),
   fetchRoles: vi.fn().mockResolvedValue([{ id: 2, name: 'Editor' }]),
   fetchRolePermissions: vi.fn().mockResolvedValue([]),
+  fetchTeams: vi.fn().mockResolvedValue([]),
 }));
 
 describe('Permissions visibility integration', () => {

--- a/packages/shared/src/api/types.ts
+++ b/packages/shared/src/api/types.ts
@@ -53,6 +53,7 @@ export type {
   AddUserToTeamBody,
   UpdateUserTeamRoleBody,
   TransferActivitiesBody,
+  RemoveUserFromTeamBody,
 } from '../schemas/user.schema';
 
 // Team CRUD API types

--- a/packages/shared/src/schemas/user.schema.spec.ts
+++ b/packages/shared/src/schemas/user.schema.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   addUserToTeamBodySchema,
   createUserBodySchema,
+  removeUserFromTeamBodySchema,
   TEAM_ROLES,
   transferActivitiesBodySchema,
   updateUserBodySchema,
@@ -192,41 +193,88 @@ describe('updateUserBodySchema', () => {
 });
 
 describe('transferActivitiesBodySchema', () => {
-  it('accepts valid transfer body with at least one flag true', () => {
+  it('accepts a valid transfer body', () => {
     const result = transferActivitiesBodySchema.parse({
       targetUserId: 2,
-      transferCommsLead: true,
-      transferCommsContact: false,
+      fromTeamId: 1,
+      includeNonLead: false,
     });
     expect(result.targetUserId).toBe(2);
-    expect(result.transferCommsLead).toBe(true);
+    expect(result.fromTeamId).toBe(1);
+    expect(result.toTeamId).toBeUndefined();
+    expect(result.includeNonLead).toBe(false);
   });
 
-  it('accepts optional activityIds', () => {
+  it('accepts optional toTeamId and activityIds', () => {
     const result = transferActivitiesBodySchema.parse({
       targetUserId: 2,
-      transferCommsLead: true,
-      transferCommsContact: true,
+      fromTeamId: 1,
+      toTeamId: 3,
+      includeNonLead: true,
       activityIds: [1, 2, 3],
     });
+    expect(result.toTeamId).toBe(3);
     expect(result.activityIds).toEqual([1, 2, 3]);
+  });
+
+  it('requires fromTeamId', () => {
+    expect(() =>
+      transferActivitiesBodySchema.parse({
+        targetUserId: 2,
+        includeNonLead: true,
+      })
+    ).toThrow();
   });
 
   it('enforces notes max length (1000)', () => {
     transferActivitiesBodySchema.parse({
       targetUserId: 2,
-      transferCommsLead: true,
-      transferCommsContact: true,
+      fromTeamId: 1,
+      includeNonLead: true,
       notes: 'n'.repeat(1000),
     });
 
     expect(() =>
       transferActivitiesBodySchema.parse({
         targetUserId: 2,
-        transferCommsLead: true,
-        transferCommsContact: true,
+        fromTeamId: 1,
+        includeNonLead: true,
         notes: 'n'.repeat(1001),
       })
+    ).toThrow();
+  });
+});
+
+describe('removeUserFromTeamBodySchema', () => {
+  it('defaults to an empty, valid body when omitted', () => {
+    const result = removeUserFromTeamBodySchema.parse(undefined);
+    expect(result).toEqual({ includeNonLead: false });
+  });
+
+  it('accepts an empty object (silent removal, no comms to transfer)', () => {
+    const result = removeUserFromTeamBodySchema.parse({});
+    expect(result.targetUserId).toBeUndefined();
+    expect(result.includeNonLead).toBe(false);
+  });
+
+  it('accepts a full transfer payload', () => {
+    const result = removeUserFromTeamBodySchema.parse({
+      targetUserId: 2,
+      toTeamId: 3,
+      includeNonLead: true,
+      notes: 'reason',
+    });
+    expect(result).toEqual({
+      targetUserId: 2,
+      toTeamId: 3,
+      includeNonLead: true,
+      notes: 'reason',
+    });
+  });
+
+  it('enforces notes max length (1000)', () => {
+    expect(() =>
+      removeUserFromTeamBodySchema.parse({ notes: 'n'.repeat(1001) })
     ).toThrow();
   });
 });

--- a/packages/shared/src/schemas/user.schema.spec.ts
+++ b/packages/shared/src/schemas/user.schema.spec.ts
@@ -217,6 +217,17 @@ describe('transferActivitiesBodySchema', () => {
     expect(result.activityIds).toEqual([1, 2, 3]);
   });
 
+  it('rejects an explicit empty activityIds array', () => {
+    expect(() =>
+      transferActivitiesBodySchema.parse({
+        targetUserId: 2,
+        fromTeamId: 1,
+        includeNonLead: false,
+        activityIds: [],
+      })
+    ).toThrow();
+  });
+
   it('requires fromTeamId', () => {
     expect(() =>
       transferActivitiesBodySchema.parse({

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -193,17 +193,51 @@ export type UpdateUserTeamRoleBody = z.infer<
 
 /**
  * POST /users/:sourceUserId/transfer-activities - Transfer activities between users.
+ *
+ * Scope: activities where the source user has an active comms contact row AND
+ * `activities.leadTeamId === fromTeamId`. Lead comms are always transferred for
+ * every activity in scope/selected; `includeNonLead` controls whether non-lead
+ * (contact) comms move with them. When `toTeamId` differs from `fromTeamId`,
+ * each affected activity's lead team (and derived ministry/displayId) moves too.
  */
 export const transferActivitiesBodySchema = z.object({
   targetUserId: z.number().int(),
+  fromTeamId: z.number().int(),
+  /** Defaults to `fromTeamId` (same-team transfer) when omitted. */
+  toTeamId: z.number().int().optional(),
+  /** Omit to operate on every scoped activity for `fromTeamId`. */
   activityIds: z.array(z.number().int()).optional(),
-  transferCommsLead: z.boolean(),
-  transferCommsContact: z.boolean(),
+  /** When false, non-lead comms are left in place (or dropped if they become ineligible after a cross-team move). */
+  includeNonLead: z.boolean(),
   notes: z.string().max(USER_NOTES_MAX_LENGTH).optional(),
 });
 
 export type TransferActivitiesBody = z.infer<
   typeof transferActivitiesBodySchema
+>;
+
+/**
+ * DELETE /users/:id/teams/:teamId - Remove a user from a team.
+ *
+ * Optional body: when the user has comms contact rows scoped to this team
+ * (`leadTeamId === teamId`), `targetUserId` must be provided to transfer them;
+ * the server rejects the removal otherwise. When there are no scoped comms
+ * rows, the body may be omitted entirely (silent removal). Regardless of
+ * comms, all `activity_flags` for `(assigneeId = user, teamId)` are deleted.
+ */
+export const removeUserFromTeamBodySchema = z.preprocess(
+  (value) => value ?? {},
+  z.object({
+    targetUserId: z.number().int().optional(),
+    /** Defaults to the team being removed when omitted. */
+    toTeamId: z.number().int().optional(),
+    includeNonLead: z.boolean().optional().default(false),
+    notes: z.string().max(USER_NOTES_MAX_LENGTH).optional(),
+  })
+);
+
+export type RemoveUserFromTeamBody = z.infer<
+  typeof removeUserFromTeamBodySchema
 >;
 
 // ============================================

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -205,7 +205,10 @@ export const transferActivitiesBodySchema = z.object({
   fromTeamId: z.number().int(),
   /** Defaults to `fromTeamId` (same-team transfer) when omitted. */
   toTeamId: z.number().int().optional(),
-  /** Omit to operate on every scoped activity for `fromTeamId`. */
+  /**
+   * Omit to operate on every scoped activity for `fromTeamId`.
+   * An explicit empty array is rejected (it does not mean "transfer none").
+   */
   activityIds: z.array(z.number().int()).optional(),
   /** When false, non-lead comms are left in place (or dropped if they become ineligible after a cross-team move). */
   includeNonLead: z.boolean(),
@@ -249,6 +252,7 @@ export type RemoveUserFromTeamBody = z.infer<
  */
 export const transferActivitiesResponseSchema = z.object({
   success: z.literal(true),
+  /** Number of activities affected (comms change and/or cross-team lead move). */
   transferredCount: z.number().int(),
 });
 

--- a/packages/shared/src/schemas/user.schema.ts
+++ b/packages/shared/src/schemas/user.schema.ts
@@ -209,7 +209,7 @@ export const transferActivitiesBodySchema = z.object({
    * Omit to operate on every scoped activity for `fromTeamId`.
    * An explicit empty array is rejected (it does not mean "transfer none").
    */
-  activityIds: z.array(z.number().int()).optional(),
+  activityIds: z.array(z.number().int()).min(1).optional(),
   /** When false, non-lead comms are left in place (or dropped if they become ineligible after a cross-team move). */
   includeNonLead: z.boolean(),
   notes: z.string().max(USER_NOTES_MAX_LENGTH).optional(),


### PR DESCRIPTION
# PR: fix/CORPCAL-284-update-user-views-c

## Summary

Adds cache invalidation to user change log page. Additionally add the "teams" field to user detail page UI to match mocks. Updates activity transfer form to support teams field.

Transfer activity updated form:
<img width="726" height="694" alt="Screenshot 2026-08-07 at 10 36 29 AM" src="https://github.com/user-attachments/assets/cf9d59c6-41db-44ed-9be6-f1f8cab92bd0" />

## Important

- `npm run build:packages` (shared schema/types changed)
- `GET /teams/:teamId/comms-contact-candidates` now allows callers with `users.transfer_activities` (not only team edit), so transfer targets can load for any destination team

## Changes

1. **Shared:** Team-scoped transfer and remove-from-team request schemas.
   - `fromTeamId`, optional `toTeamId`, `includeNonLead`; optional remove body.
   - Reject empty `activityIds` when the field is sent.

2. **API:** Team-scoped transfer and removal in users service/controller.
   - Scoped activity list (`fromTeamId`); optional body on DELETE membership.
   - Stricter transfer validation; reactivate merged comms rows; active-only activity counts.
   - Document transfer/removal in `calendar-service/API.md`.

3. **Teams API:** Comms contact candidates for transfer picker auth.
   - Transfer permission can fetch candidates for any team.

4. **UI:** Transfer and remove-member flows.
   - Shared `TransferActivitiesFields`, submit hook, comms-candidates target picker.
   - User detail: one team removal at a time; history formatting for transfers.
   - Empty states, Reset, notes limit, load-error handling.

5. **UI infra:** User query cache invalidation and teams combobox fix.
   - `userQueryKeys` / `invalidateUserCaches` after user mutations.

6. **Tests:** Service/controller and UI unit coverage for schemas, transfer helpers, and history formatting.

## Testing

- `npm run test -w packages/shared -- --run user.schema.spec.ts` (33 passed)
- `npm run test -w calendar-ui -- --run TransferActivitiesFields.test.ts userHistoryFormatting.test.ts` (14 passed)
- `npm run test -w calendar-service -- users.service.spec.ts users.controller.spec.ts teams.controller.spec.ts` (recommended before merge)
- Manual: user Transfer tab and remove-from-team with/without activities; cross-team transfer; verify change log entries
