### PR TITLE
Fix/corpcal 000 direct login improvements c

### DIFF
--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -370,6 +370,13 @@ export class AuthController {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Azure login failed during callback: ${message}`);
+
+      if (/deactivated/i.test(message)) {
+        return res.redirect('/login?error=azure_deactivated');
+      }
+      if (/password reset is required/i.test(message)) {
+        return res.redirect('/login?error=azure_reset_required');
+      }
       return res.redirect('/login?error=azure_no_account');
     }
   }

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -212,6 +212,7 @@ export class AuthController {
 
   @Public()
   @Get('azure')
+  @Throttle({ default: { limit: 20, ttl: 900_000 } })
   @ApiOperation({
     summary: 'Start Azure AD login',
     description: 'Initiates OIDC auth flow and redirects to Microsoft login',
@@ -238,6 +239,8 @@ export class AuthController {
         state,
         nonce,
         response_type: 'code',
+        // Force account picker — avoids silent sign-in as the wrong user on shared browsers.
+        prompt: 'select_account',
       });
 
       return res.redirect(redirectUrl.href);
@@ -250,6 +253,7 @@ export class AuthController {
 
   @Public()
   @Get('azure/callback')
+  @Throttle({ default: { limit: 20, ttl: 900_000 } })
   @ApiOperation({
     summary: 'Azure AD callback',
     description: 'Handles OIDC callback and signs user into local app session',

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -405,6 +405,19 @@ describe('AuthService — local auth methods', () => {
         'active'
       );
     });
+
+    it('rejects active IDIR user with no passwordHash when directLoginEnabled is false', async () => {
+      vi.mocked(findUserByEmailLocal).mockResolvedValue(
+        makeLocalUser({
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: false,
+        })
+      );
+      await expect(
+        service.setPassword('test@example.com', 'ValidPass1!')
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -75,7 +75,9 @@ vi.mock('./strategies/local.strategy', () => ({
 
 vi.mock('./strategies/ad.strategy', () => ({
   findUserByEmail: vi.fn(),
+  findUserByEmailAnyStatus: vi.fn(),
   findUserByExternalId: vi.fn(),
+  findUserByExternalIdAnyStatus: vi.fn(),
   syncAzureIdentity: vi.fn(),
 }));
 
@@ -251,6 +253,8 @@ describe('AuthService — local auth methods', () => {
     vi.mocked(updateUserPassword).mockResolvedValue(undefined);
     vi.mocked(updateUserStatus).mockResolvedValue(undefined);
     vi.mocked(updateLastLogin).mockResolvedValue(undefined);
+    vi.mocked(adStrategy.findUserByExternalIdAnyStatus).mockResolvedValue(null);
+    vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(null);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -691,6 +695,25 @@ describe('AuthService — local auth methods', () => {
       expect(adStrategy.findUserByEmail).not.toHaveBeenCalled();
     });
 
+    it('rejects deactivated user matched by externalId (isActive=false)', async () => {
+      vi.mocked(adStrategy.findUserByExternalIdAnyStatus).mockResolvedValue(
+        makeLocalUser({
+          id: 7,
+          isActive: false,
+          status: 'active',
+        })
+      );
+
+      await expect(
+        service.loginWithAzureClaims({
+          externalId: 'azure-deactivated',
+          email: 'deactivated@example.com',
+        })
+      ).rejects.toThrow(/deactivated/i);
+
+      expect(adStrategy.findUserByExternalId).not.toHaveBeenCalled();
+    });
+
     it('rejects when no active account matches externalId or email', async () => {
       vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
       vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
@@ -704,8 +727,10 @@ describe('AuthService — local auth methods', () => {
     });
 
     it('rejects inactive-status user matched by email', async () => {
-      vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(
+      vi.mocked(adStrategy.findUserByExternalIdAnyStatus).mockResolvedValue(
+        null
+      );
+      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
         makeLocalUser({
           id: 5,
           status: 'inactive',
@@ -718,6 +743,8 @@ describe('AuthService — local auth methods', () => {
           email: 'inactive@example.com',
         })
       ).rejects.toThrow(/deactivated/i);
+
+      expect(adStrategy.findUserByEmail).not.toHaveBeenCalled();
     });
 
     it('rejects password_reset_required user matched by email', async () => {

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -13,6 +13,7 @@ import type { Mock } from 'vitest';
 import { DatabaseService } from '../database/database.service';
 import { PolicyService } from '../policy/policy.service';
 import { AuthService } from './auth.service';
+import * as adStrategy from './strategies/ad.strategy';
 import {
   findUserByEmailLocal,
   findUserByIdLocal,
@@ -70,6 +71,14 @@ vi.mock('./strategies/local.strategy', () => ({
   updateLastLogin: vi.fn(),
   updateUserPassword: vi.fn(),
   updateUserStatus: vi.fn(),
+}));
+
+vi.mock('./strategies/ad.strategy', () => ({
+  findUserByEmailAnyStatus: vi.fn(),
+  findUserByEmail: vi.fn(),
+  findUserByExternalId: vi.fn(),
+  findUserByExternalIdAnyStatus: vi.fn(),
+  syncAzureIdentity: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -565,6 +574,47 @@ describe('AuthService — local auth methods', () => {
       vi.mocked(findUserByIdLocal).mockResolvedValue(makeLocalUser());
       const token = await service.createPasswordResetToken(1);
       expect(token).toMatch(/^[0-9a-f]{32}$/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loginWithAzureClaims()
+  // -------------------------------------------------------------------------
+
+  describe('loginWithAzureClaims()', () => {
+    it('allows a pending user to sign in with Microsoft using email match', async () => {
+      vi.mocked(adStrategy.findUserByExternalId)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          makeLocalUser({
+            id: 42,
+            status: 'active',
+            isActive: true,
+            passwordHash: null,
+            adEmail: 'new.user@example.com',
+          })
+        );
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+        makeLocalUser({
+          id: 42,
+          status: 'pending',
+          isActive: true,
+          passwordHash: null,
+        })
+      );
+
+      const result = await service.loginWithAzureClaims({
+        externalId: 'azure-123',
+        email: 'new.user@example.com',
+        username: 'new.user@example.com',
+        displayName: 'New User',
+      });
+
+      expect(adStrategy.findUserByEmailAnyStatus).toHaveBeenCalledTimes(1);
+      expect(adStrategy.syncAzureIdentity).toHaveBeenCalledTimes(1);
+      expect(result.user.id).toBe(42);
+      expect(result.user.email).toBe('new.user@example.com');
     });
   });
 });

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -612,6 +612,11 @@ describe('AuthService — local auth methods', () => {
       });
 
       expect(adStrategy.findUserByEmailAnyStatus).toHaveBeenCalledTimes(1);
+      expect(updateUserStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        42,
+        'active'
+      );
       expect(adStrategy.syncAzureIdentity).toHaveBeenCalledTimes(1);
       expect(result.user.id).toBe(42);
       expect(result.user.email).toBe('new.user@example.com');

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -240,6 +240,11 @@ describe('AuthService — local auth methods', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     localMockDb = makeChain();
+    localMockDb.transaction = vi
+      .fn()
+      .mockImplementation(
+        async (fn: (tx: typeof localMockDb) => Promise<void>) => fn(localMockDb)
+      );
 
     vi.mocked(bcrypt.hash).mockResolvedValue('hashed-value' as never);
     vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
@@ -695,7 +700,7 @@ describe('AuthService — local auth methods', () => {
           externalId: 'azure-456',
           email: 'missing@example.com',
         })
-      ).rejects.toThrow(/No active local account found/i);
+      ).rejects.toThrow(/No Corporate Calendar account found/i);
     });
 
     it('rejects inactive-status user matched by email', async () => {

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -74,10 +74,8 @@ vi.mock('./strategies/local.strategy', () => ({
 }));
 
 vi.mock('./strategies/ad.strategy', () => ({
-  findUserByEmailAnyStatus: vi.fn(),
   findUserByEmail: vi.fn(),
   findUserByExternalId: vi.fn(),
-  findUserByExternalIdAnyStatus: vi.fn(),
   syncAzureIdentity: vi.fn(),
 }));
 
@@ -628,18 +626,14 @@ describe('AuthService — local auth methods', () => {
           makeLocalUser({
             id: 42,
             status: 'active',
-            isActive: true,
-            passwordHash: null,
             adEmail: 'new.user@example.com',
           })
         );
-      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(
         makeLocalUser({
           id: 42,
           status: 'pending',
-          isActive: true,
-          passwordHash: null,
+          adEmail: 'new.user@example.com',
         })
       );
 
@@ -650,7 +644,7 @@ describe('AuthService — local auth methods', () => {
         displayName: 'New User',
       });
 
-      expect(adStrategy.findUserByEmailAnyStatus).toHaveBeenCalledTimes(1);
+      expect(adStrategy.findUserByEmail).toHaveBeenCalledTimes(1);
       expect(updateUserStatus).toHaveBeenCalledWith(
         expect.anything(),
         42,
@@ -661,14 +655,55 @@ describe('AuthService — local auth methods', () => {
       expect(result.user.email).toBe('new.user@example.com');
     });
 
-    it('rejects inactive user matched by email', async () => {
+    it('allows a pending user matched by externalId without changing lookup path', async () => {
+      vi.mocked(adStrategy.findUserByExternalId)
+        .mockResolvedValueOnce(
+          makeLocalUser({
+            id: 43,
+            status: 'pending',
+            adEmail: 'linked@example.com',
+          })
+        )
+        .mockResolvedValueOnce(
+          makeLocalUser({
+            id: 43,
+            status: 'active',
+            adEmail: 'linked@example.com',
+          })
+        );
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
+
+      await service.loginWithAzureClaims({
+        externalId: 'azure-pending',
+        email: 'linked@example.com',
+      });
+
+      expect(updateUserStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        43,
+        'active'
+      );
+      expect(adStrategy.findUserByEmail).not.toHaveBeenCalled();
+    });
+
+    it('rejects when no active account matches externalId or email', async () => {
       vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
       vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+
+      await expect(
+        service.loginWithAzureClaims({
+          externalId: 'azure-456',
+          email: 'missing@example.com',
+        })
+      ).rejects.toThrow(/No active local account found/i);
+    });
+
+    it('rejects inactive-status user matched by email', async () => {
+      vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(
         makeLocalUser({
           id: 5,
           status: 'inactive',
-          isActive: false,
         })
       );
 
@@ -677,17 +712,15 @@ describe('AuthService — local auth methods', () => {
           externalId: 'azure-456',
           email: 'inactive@example.com',
         })
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(/deactivated/i);
     });
 
     it('rejects password_reset_required user matched by email', async () => {
       vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(
         makeLocalUser({
           id: 6,
           status: 'password_reset_required',
-          isActive: true,
         })
       );
 
@@ -709,12 +742,10 @@ describe('AuthService — local auth methods', () => {
             adEmail: 'linked@example.com',
           })
         );
-      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
-      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(
         makeLocalUser({
           id: 99,
           status: 'active',
-          isActive: true,
           adEmail: 'linked@example.com',
         })
       );

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -213,6 +213,7 @@ describe('AuthService — local auth methods', () => {
       passwordHash: string | null;
       status: string;
       isActive: boolean;
+      directLoginEnabled: boolean;
     }> = {}
   ) {
     return {
@@ -224,6 +225,7 @@ describe('AuthService — local auth methods', () => {
       passwordHash: 'existing-hash',
       status: 'active',
       isActive: true,
+      directLoginEnabled: false,
       ...overrides,
     };
   }
@@ -325,6 +327,30 @@ describe('AuthService — local auth methods', () => {
       expect(result.status).toBe('active');
       expect((result as { email?: string }).email).toBe('test@example.com');
     });
+
+    it('returns inactive for an IDIR-only account (active, no passwordHash, directLogin disabled)', async () => {
+      vi.mocked(findUserByEmailLocal).mockResolvedValue(
+        makeLocalUser({
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: false,
+        })
+      );
+      const result = await service.checkEmail('test@example.com');
+      expect(result.status).toBe('inactive');
+    });
+
+    it('returns pending for an IDIR account with direct login enabled but no password set', async () => {
+      vi.mocked(findUserByEmailLocal).mockResolvedValue(
+        makeLocalUser({
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: true,
+        })
+      );
+      const result = await service.checkEmail('test@example.com');
+      expect(result.status).toBe('pending');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -351,6 +377,24 @@ describe('AuthService — local auth methods', () => {
     it('hashes the password and marks the account active on success', async () => {
       vi.mocked(findUserByEmailLocal).mockResolvedValue(
         makeLocalUser({ status: 'pending' })
+      );
+      await service.setPassword('test@example.com', 'ValidPass1!');
+      expect(bcrypt.hash).toHaveBeenCalledWith('ValidPass1!', 12);
+      expect(updateUserPassword).toHaveBeenCalledWith(
+        localMockDb,
+        1,
+        'hashed-value',
+        'active'
+      );
+    });
+
+    it('allows active IDIR user with directLoginEnabled and no password to set a password', async () => {
+      vi.mocked(findUserByEmailLocal).mockResolvedValue(
+        makeLocalUser({
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: true,
+        })
       );
       await service.setPassword('test@example.com', 'ValidPass1!');
       expect(bcrypt.hash).toHaveBeenCalledWith('ValidPass1!', 12);
@@ -487,13 +531,12 @@ describe('AuthService — local auth methods', () => {
       );
     });
 
-    it('throws BadRequestException for an SSO-only user (active, no passwordHash)', async () => {
+    it('generates a token for an IDIR user (active, no passwordHash) — direct login can be set up', async () => {
       vi.mocked(findUserByIdLocal).mockResolvedValue(
         makeLocalUser({ isActive: true, status: 'active', passwordHash: null })
       );
-      await expect(service.createPasswordResetToken(1)).rejects.toThrow(
-        BadRequestException
-      );
+      const token = await service.createPasswordResetToken(1);
+      expect(token).toMatch(/^[0-9a-f]{32}$/);
     });
 
     it('throws BadRequestException for an inactive user', async () => {

--- a/calendar-service/src/auth/auth.service.spec.ts
+++ b/calendar-service/src/auth/auth.service.spec.ts
@@ -337,7 +337,7 @@ describe('AuthService — local auth methods', () => {
       expect((result as { email?: string }).email).toBe('test@example.com');
     });
 
-    it('returns inactive for an IDIR-only account (active, no passwordHash, directLogin disabled)', async () => {
+    it('returns sso_recommended for an IDIR-only account (active, no passwordHash, directLogin disabled)', async () => {
       vi.mocked(findUserByEmailLocal).mockResolvedValue(
         makeLocalUser({
           status: 'active',
@@ -346,7 +346,7 @@ describe('AuthService — local auth methods', () => {
         })
       );
       const result = await service.checkEmail('test@example.com');
-      expect(result.status).toBe('inactive');
+      expect(result.status).toBe('sso_recommended');
     });
 
     it('returns pending for an IDIR account with direct login enabled but no password set', async () => {
@@ -463,6 +463,26 @@ describe('AuthService — local auth methods', () => {
 
       expect(updateLastLogin).not.toHaveBeenCalled();
     });
+
+    it('returns requiresPasswordSetup for active user with directLoginEnabled and no password', async () => {
+      vi.mocked(findUserByEmailLocal).mockResolvedValue(
+        makeLocalUser({
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: true,
+        })
+      );
+
+      const result = await service.login({
+        username: 'test@example.com',
+        password: 'AnyPass1!',
+      });
+
+      expect(result).toEqual({
+        requiresPasswordSetup: true,
+        email: 'test@example.com',
+      });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -553,12 +573,31 @@ describe('AuthService — local auth methods', () => {
       );
     });
 
-    it('generates a token for an IDIR user (active, no passwordHash) — direct login can be set up', async () => {
+    it('allows reset for active user with directLoginEnabled and no password', async () => {
       vi.mocked(findUserByIdLocal).mockResolvedValue(
-        makeLocalUser({ isActive: true, status: 'active', passwordHash: null })
+        makeLocalUser({
+          isActive: true,
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: true,
+        })
       );
       const token = await service.createPasswordResetToken(1);
       expect(token).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('rejects SSO-only user (no password, directLogin disabled)', async () => {
+      vi.mocked(findUserByIdLocal).mockResolvedValue(
+        makeLocalUser({
+          isActive: true,
+          status: 'active',
+          passwordHash: null,
+          directLoginEnabled: false,
+        })
+      );
+      await expect(service.createPasswordResetToken(1)).rejects.toThrow(
+        BadRequestException
+      );
     });
 
     it('throws BadRequestException for an inactive user', async () => {
@@ -620,6 +659,77 @@ describe('AuthService — local auth methods', () => {
       expect(adStrategy.syncAzureIdentity).toHaveBeenCalledTimes(1);
       expect(result.user.id).toBe(42);
       expect(result.user.email).toBe('new.user@example.com');
+    });
+
+    it('rejects inactive user matched by email', async () => {
+      vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+        makeLocalUser({
+          id: 5,
+          status: 'inactive',
+          isActive: false,
+        })
+      );
+
+      await expect(
+        service.loginWithAzureClaims({
+          externalId: 'azure-456',
+          email: 'inactive@example.com',
+        })
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects password_reset_required user matched by email', async () => {
+      vi.mocked(adStrategy.findUserByExternalId).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+        makeLocalUser({
+          id: 6,
+          status: 'password_reset_required',
+          isActive: true,
+        })
+      );
+
+      await expect(
+        service.loginWithAzureClaims({
+          externalId: 'azure-789',
+          email: 'reset@example.com',
+        })
+      ).rejects.toThrow(/password reset is required/i);
+    });
+
+    it('signs in active user matched by email without changing status', async () => {
+      vi.mocked(adStrategy.findUserByExternalId)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          makeLocalUser({
+            id: 99,
+            status: 'active',
+            adEmail: 'linked@example.com',
+          })
+        );
+      vi.mocked(adStrategy.findUserByEmail).mockResolvedValue(null);
+      vi.mocked(adStrategy.findUserByEmailAnyStatus).mockResolvedValue(
+        makeLocalUser({
+          id: 99,
+          status: 'active',
+          isActive: true,
+          adEmail: 'linked@example.com',
+        })
+      );
+
+      await service.loginWithAzureClaims({
+        externalId: 'azure-linked',
+        email: 'linked@example.com',
+      });
+
+      expect(updateUserStatus).not.toHaveBeenCalled();
+      expect(adStrategy.syncAzureIdentity).toHaveBeenCalledWith(
+        expect.anything(),
+        99,
+        expect.objectContaining({ externalId: 'azure-linked' })
+      );
     });
   });
 });

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -136,7 +136,7 @@ export class AuthService {
 
       if (anyStatus?.status === 'pending') {
         throw new UnauthorizedException(
-          'Your account has not been activated yet. Please sign in with your email and password to complete account setup.'
+          'Your account has not been activated yet. Sign in with Microsoft using the email on your account, or contact your administrator.'
         );
       }
 
@@ -183,6 +183,8 @@ export class AuthService {
   /**
    * Step 1: Check the status of a local account by email.
    * Called before prompting for a password so the UI can branch on account state.
+   *
+   * See CheckEmailStatus in @corpcal/shared for the response contract (anti-enumeration).
    */
   async checkEmail(email: string): Promise<CheckEmailResponse> {
     const dbUser = await findUserByEmailLocal(
@@ -211,13 +213,15 @@ export class AuthService {
       };
     }
 
-    // Active user with no password hash: only show the set-password flow when
-    // the admin has explicitly enabled direct login for them.
+    // Active user with no password hash: direct-login setup vs SSO-only.
     if (!dbUser.passwordHash) {
       if (dbUser.directLoginEnabled) {
         return { status: 'pending', email: dbUser.adEmail ?? undefined };
       }
-      return { status: 'inactive' };
+      return {
+        status: 'sso_recommended',
+        email: dbUser.adEmail ?? undefined,
+      };
     }
 
     return { status: 'active', email: dbUser.adEmail ?? undefined };
@@ -263,6 +267,12 @@ export class AuthService {
     }
 
     if (!dbUser.passwordHash) {
+      if (dbUser.status === 'active' && dbUser.directLoginEnabled) {
+        return {
+          requiresPasswordSetup: true as const,
+          email: dbUser.adEmail ?? email.trim(),
+        };
+      }
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -472,10 +482,10 @@ export class AuthService {
    * Create a temporary reset token for an admin-triggered password reset.
    * Sets the user's status to password_reset_required and returns the plaintext code.
    *
-   * Allowed for any active user, including IDIR-only accounts that have no
-   * password yet. Issuing a token sets status to password_reset_required so
-   * the user is routed through the reset flow to establish their direct-login
-   * credentials. Inactive users are still rejected.
+   * Allowed for active users with an existing password or with direct login
+   * enabled (including IDIR accounts establishing a local password). SSO-only
+   * users (no password, directLogin disabled) are rejected to avoid blocking
+   * Microsoft sign-in via password_reset_required. Inactive users are rejected.
    */
   async createPasswordResetToken(userId: number): Promise<string> {
     const dbUser = await findUserByIdLocal(this.databaseService.db, userId);
@@ -488,6 +498,13 @@ export class AuthService {
     if (!dbUser.isActive || dbUser.status === 'inactive') {
       throw new BadRequestException(
         'Cannot initiate a password reset for an inactive user.'
+      );
+    }
+
+    const canReset = dbUser.passwordHash !== null || dbUser.directLoginEnabled;
+    if (!canReset) {
+      throw new BadRequestException(
+        'This user signs in via Microsoft (SSO) only. Enable direct login before issuing a password reset.'
       );
     }
 

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -106,15 +106,25 @@ export class AuthService {
       );
 
       if (anyStatusByEmail) {
-        if (
-          !anyStatusByEmail.isActive ||
-          anyStatusByEmail.status === 'inactive'
-        ) {
+        if (!anyStatusByEmail.isActive || anyStatusByEmail.status === 'inactive') {
           throw new UnauthorizedException(
             'This account is deactivated. Please contact your administrator.'
           );
         }
 
+        if (anyStatusByEmail.status === 'pending') {
+          throw new UnauthorizedException(
+            'Your account has not been activated yet. Please sign in with your email and password to complete account setup.'
+          );
+        }
+
+        if (anyStatusByEmail.status === 'password_reset_required') {
+          throw new UnauthorizedException(
+            'A password reset is required before you can sign in. Please use the email/password flow and follow the reset instructions.'
+          );
+        }
+
+        // At this point the account is active; proceed.
         dbUser = anyStatusByEmail;
       }
     }

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -29,7 +29,9 @@ import type { AuthResponseDto } from './dto/auth-response.dto';
 import type { LoginDto } from './dto/login.dto';
 import {
   findUserByEmail,
+  findUserByEmailAnyStatus,
   findUserByExternalId,
+  findUserByExternalIdAnyStatus,
   syncAzureIdentity,
   type AuthDbUser,
 } from './strategies/ad.strategy';
@@ -88,6 +90,31 @@ export class AuthService {
     displayName?: string;
     email?: string;
   }): Promise<AuthResponseDto> {
+    const deactivatedByExternalId = await findUserByExternalIdAnyStatus(
+      this.databaseService.db,
+      claims.externalId
+    );
+    if (
+      deactivatedByExternalId &&
+      this.isAccountDeactivated(deactivatedByExternalId)
+    ) {
+      throw new UnauthorizedException(
+        'This account is deactivated. Please contact your administrator.'
+      );
+    }
+
+    if (claims.email?.trim()) {
+      const deactivatedByEmail = await findUserByEmailAnyStatus(
+        this.databaseService.db,
+        claims.email
+      );
+      if (deactivatedByEmail && this.isAccountDeactivated(deactivatedByEmail)) {
+        throw new UnauthorizedException(
+          'This account is deactivated. Please contact your administrator.'
+        );
+      }
+    }
+
     let dbUser = await findUserByExternalId(
       this.databaseService.db,
       claims.externalId
@@ -103,7 +130,7 @@ export class AuthService {
       );
     }
 
-    if (dbUser.status === 'inactive') {
+    if (this.isAccountDeactivated(dbUser)) {
       throw new UnauthorizedException(
         'This account is deactivated. Please contact your administrator.'
       );
@@ -130,6 +157,13 @@ export class AuthService {
       )) ?? dbUser;
 
     return this.buildAuthResponse(syncedUser);
+  }
+
+  private isAccountDeactivated(user: {
+    isActive?: boolean;
+    status: string;
+  }): boolean {
+    return user.isActive === false || user.status === 'inactive';
   }
 
   private async loginMock(username: string): Promise<AuthResponseDto> {

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -106,7 +106,10 @@ export class AuthService {
       );
 
       if (anyStatusByEmail) {
-        if (!anyStatusByEmail.isActive || anyStatusByEmail.status === 'inactive') {
+        if (
+          !anyStatusByEmail.isActive ||
+          anyStatusByEmail.status === 'inactive'
+        ) {
           throw new UnauthorizedException(
             'This account is deactivated. Please contact your administrator.'
           );
@@ -152,6 +155,10 @@ export class AuthService {
       throw new UnauthorizedException(
         'No active local account found for this Azure AD user.'
       );
+    }
+
+    if (dbUser.status !== 'active') {
+      await updateUserStatus(this.databaseService.db, dbUser.id, 'active');
     }
 
     await syncAzureIdentity(this.databaseService.db, dbUser.id, claims);

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -179,6 +179,15 @@ export class AuthService {
       };
     }
 
+    // Active user with no password hash: only show the set-password flow when
+    // the admin has explicitly enabled direct login for them.
+    if (!dbUser.passwordHash) {
+      if (dbUser.directLoginEnabled) {
+        return { status: 'pending', email: dbUser.adEmail ?? undefined };
+      }
+      return { status: 'inactive' };
+    }
+
     return { status: 'active', email: dbUser.adEmail ?? undefined };
   }
 
@@ -256,7 +265,12 @@ export class AuthService {
       throw new BadRequestException('Account not found');
     }
 
-    if (dbUser.status !== 'pending') {
+    const canSetPassword =
+      dbUser.status === 'pending' ||
+      (dbUser.status === 'active' &&
+        dbUser.directLoginEnabled &&
+        !dbUser.passwordHash);
+    if (!canSetPassword) {
       throw new BadRequestException(
         'Account has already been activated. Please use the login page.'
       );
@@ -436,14 +450,6 @@ export class AuthService {
 
     if (!dbUser) {
       throw new BadRequestException('User not found');
-    }
-
-    // Reject SSO-only users: active account with no password hash means they
-    // have never used local auth and are not expected to.
-    if (dbUser.isActive && dbUser.status === 'active' && !dbUser.passwordHash) {
-      throw new BadRequestException(
-        'This user signs in via Microsoft (SSO) and is not eligible for a local password reset.'
-      );
     }
 
     // Inactive users cannot be given a reset token.

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -29,9 +29,7 @@ import type { AuthResponseDto } from './dto/auth-response.dto';
 import type { LoginDto } from './dto/login.dto';
 import {
   findUserByEmail,
-  findUserByEmailAnyStatus,
   findUserByExternalId,
-  findUserByExternalIdAnyStatus,
   syncAzureIdentity,
   type AuthDbUser,
 } from './strategies/ad.strategy';
@@ -99,58 +97,25 @@ export class AuthService {
       dbUser = await findUserByEmail(this.databaseService.db, claims.email);
     }
 
-    if (!dbUser && claims.email?.trim()) {
-      const anyStatusByEmail = await findUserByEmailAnyStatus(
-        this.databaseService.db,
-        claims.email
-      );
-
-      if (anyStatusByEmail) {
-        if (
-          !anyStatusByEmail.isActive ||
-          anyStatusByEmail.status === 'inactive'
-        ) {
-          throw new UnauthorizedException(
-            'This account is deactivated. Please contact your administrator.'
-          );
-        }
-
-        if (anyStatusByEmail.status === 'password_reset_required') {
-          throw new UnauthorizedException(
-            'A password reset is required before you can sign in. Please use the email/password flow and follow the reset instructions.'
-          );
-        }
-
-        // Pending users are promoted to active explicitly below.
-        dbUser = anyStatusByEmail;
-      }
-    }
-
     if (!dbUser) {
-      // Check whether the account exists but has a non-active status so we can
-      // return a meaningful error instead of the generic "no account" message.
-      const anyStatus = await findUserByExternalIdAnyStatus(
-        this.databaseService.db,
-        claims.externalId
-      );
-
-      if (anyStatus?.status === 'pending') {
-        throw new UnauthorizedException(
-          'Your account has not been activated yet. Sign in with Microsoft using the email on your account, or contact your administrator.'
-        );
-      }
-
-      if (anyStatus?.status === 'password_reset_required') {
-        throw new UnauthorizedException(
-          'A password reset is required before you can sign in. Please use the email/password flow and follow the reset instructions.'
-        );
-      }
-
       throw new UnauthorizedException(
         'No active local account found for this Azure AD user.'
       );
     }
 
+    if (dbUser.status === 'inactive') {
+      throw new UnauthorizedException(
+        'This account is deactivated. Please contact your administrator.'
+      );
+    }
+
+    if (dbUser.status === 'password_reset_required') {
+      throw new UnauthorizedException(
+        'A password reset is required before you can sign in. Please use the email/password flow and follow the reset instructions.'
+      );
+    }
+
+    // Admin-created users start as pending; promote on first successful SSO.
     if (dbUser.status !== 'active') {
       await updateUserStatus(this.databaseService.db, dbUser.id, 'active');
     }

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -115,19 +115,13 @@ export class AuthService {
           );
         }
 
-        if (anyStatusByEmail.status === 'pending') {
-          throw new UnauthorizedException(
-            'Your account has not been activated yet. Please sign in with your email and password to complete account setup.'
-          );
-        }
-
         if (anyStatusByEmail.status === 'password_reset_required') {
           throw new UnauthorizedException(
             'A password reset is required before you can sign in. Please use the email/password flow and follow the reset instructions.'
           );
         }
 
-        // At this point the account is active; proceed.
+        // Pending users are promoted to active explicitly below.
         dbUser = anyStatusByEmail;
       }
     }

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -29,6 +29,7 @@ import type { AuthResponseDto } from './dto/auth-response.dto';
 import type { LoginDto } from './dto/login.dto';
 import {
   findUserByEmail,
+  findUserByEmailAnyStatus,
   findUserByExternalId,
   findUserByExternalIdAnyStatus,
   syncAzureIdentity,
@@ -96,6 +97,26 @@ export class AuthService {
 
     if (!dbUser && claims.email?.trim()) {
       dbUser = await findUserByEmail(this.databaseService.db, claims.email);
+    }
+
+    if (!dbUser && claims.email?.trim()) {
+      const anyStatusByEmail = await findUserByEmailAnyStatus(
+        this.databaseService.db,
+        claims.email
+      );
+
+      if (anyStatusByEmail) {
+        if (
+          !anyStatusByEmail.isActive ||
+          anyStatusByEmail.status === 'inactive'
+        ) {
+          throw new UnauthorizedException(
+            'This account is deactivated. Please contact your administrator.'
+          );
+        }
+
+        dbUser = anyStatusByEmail;
+      }
     }
 
     if (!dbUser) {

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -440,10 +440,10 @@ export class AuthService {
    * Create a temporary reset token for an admin-triggered password reset.
    * Sets the user's status to password_reset_required and returns the plaintext code.
    *
-   * Only allowed for users who are local-auth eligible: accounts that are
-   * pending, active with a password hash, or already in password_reset_required.
-   * Pure Azure-SSO accounts (no password_hash, status=active) are rejected to
-   * avoid silently forcing them down the local password path.
+   * Allowed for any active user, including IDIR-only accounts that have no
+   * password yet. Issuing a token sets status to password_reset_required so
+   * the user is routed through the reset flow to establish their direct-login
+   * credentials. Inactive users are still rejected.
    */
   async createPasswordResetToken(userId: number): Promise<string> {
     const dbUser = await findUserByIdLocal(this.databaseService.db, userId);

--- a/calendar-service/src/auth/auth.service.ts
+++ b/calendar-service/src/auth/auth.service.ts
@@ -99,7 +99,7 @@ export class AuthService {
 
     if (!dbUser) {
       throw new UnauthorizedException(
-        'No active local account found for this Azure AD user.'
+        'No Corporate Calendar account found for this Microsoft identity.'
       );
     }
 
@@ -116,11 +116,12 @@ export class AuthService {
     }
 
     // Admin-created users start as pending; promote on first successful SSO.
-    if (dbUser.status !== 'active') {
-      await updateUserStatus(this.databaseService.db, dbUser.id, 'active');
-    }
-
-    await syncAzureIdentity(this.databaseService.db, dbUser.id, claims);
+    await this.databaseService.db.transaction(async (tx) => {
+      if (dbUser.status !== 'active') {
+        await updateUserStatus(tx, dbUser.id, 'active');
+      }
+      await syncAzureIdentity(tx, dbUser.id, claims);
+    });
 
     const syncedUser =
       (await findUserByExternalId(

--- a/calendar-service/src/auth/strategies/ad.strategy.ts
+++ b/calendar-service/src/auth/strategies/ad.strategy.ts
@@ -16,6 +16,10 @@ export interface AuthDbUser {
   status: string;
 }
 
+export interface AuthDbUserWithActive extends AuthDbUser {
+  isActive: boolean;
+}
+
 const authUserSelection = {
   id: users.id,
   roleId: users.roleId,
@@ -23,6 +27,11 @@ const authUserSelection = {
   adDisplayName: users.adDisplayName,
   adEmail: users.adEmail,
   status: users.status,
+};
+
+const authUserWithActiveSelection = {
+  ...authUserSelection,
+  isActive: users.isActive,
 };
 
 export async function findUserByExternalId(
@@ -33,6 +42,19 @@ export async function findUserByExternalId(
     .select(authUserSelection)
     .from(users)
     .where(and(eq(users.externalId, externalId), eq(users.isActive, true)))
+    .limit(1);
+
+  return row ?? null;
+}
+
+export async function findUserByExternalIdAnyStatus(
+  db: Database,
+  externalId: string
+): Promise<AuthDbUserWithActive | null> {
+  const [row] = await db
+    .select(authUserWithActiveSelection)
+    .from(users)
+    .where(eq(users.externalId, externalId))
     .limit(1);
 
   return row ?? null;
@@ -53,6 +75,21 @@ export async function findUserByEmail(
         eq(users.isActive, true)
       )
     )
+    .limit(1);
+
+  return row ?? null;
+}
+
+export async function findUserByEmailAnyStatus(
+  db: Database,
+  email: string
+): Promise<AuthDbUserWithActive | null> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const [row] = await db
+    .select(authUserWithActiveSelection)
+    .from(users)
+    .where(sql`lower(${users.adEmail}) = ${normalizedEmail}`)
     .limit(1);
 
   return row ?? null;

--- a/calendar-service/src/auth/strategies/ad.strategy.ts
+++ b/calendar-service/src/auth/strategies/ad.strategy.ts
@@ -115,7 +115,6 @@ export async function syncAzureIdentity(
       adUsername: identity.username?.trim() || null,
       adDisplayName: identity.displayName?.trim() || null,
       adEmail: identity.email?.trim().toLowerCase() || null,
-      status: 'active',
       lastLoginDateTime: new Date(),
       lastUpdatedDateTime: new Date(),
     })

--- a/calendar-service/src/auth/strategies/ad.strategy.ts
+++ b/calendar-service/src/auth/strategies/ad.strategy.ts
@@ -62,6 +62,25 @@ export async function findUserByEmail(
   return row ?? null;
 }
 
+export interface AuthDbUserWithActivity extends AuthDbUser {
+  isActive: boolean;
+}
+
+export async function findUserByEmailAnyStatus(
+  db: Database,
+  email: string
+): Promise<AuthDbUserWithActivity | null> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const [row] = await db
+    .select({ ...authUserSelection, isActive: users.isActive })
+    .from(users)
+    .where(sql`lower(${users.adEmail}) = ${normalizedEmail}`)
+    .limit(1);
+
+  return row ?? null;
+}
+
 /**
  * Looks up a user by externalId regardless of status — used to produce a
  * more informative error when the account exists but is pending/reset-required.
@@ -96,6 +115,7 @@ export async function syncAzureIdentity(
       adUsername: identity.username?.trim() || null,
       adDisplayName: identity.displayName?.trim() || null,
       adEmail: identity.email?.trim().toLowerCase() || null,
+      status: 'active',
       lastLoginDateTime: new Date(),
       lastUpdatedDateTime: new Date(),
     })

--- a/calendar-service/src/auth/strategies/ad.strategy.ts
+++ b/calendar-service/src/auth/strategies/ad.strategy.ts
@@ -29,13 +29,7 @@ export async function findUserByExternalId(
   const [row] = await db
     .select(authUserSelection)
     .from(users)
-    .where(
-      and(
-        eq(users.externalId, externalId),
-        eq(users.isActive, true),
-        eq(users.status, 'active')
-      )
-    )
+    .where(and(eq(users.externalId, externalId), eq(users.isActive, true)))
     .limit(1);
 
   return row ?? null;
@@ -53,8 +47,7 @@ export async function findUserByEmail(
     .where(
       and(
         sql`lower(${users.adEmail}) = ${normalizedEmail}`,
-        eq(users.isActive, true),
-        eq(users.status, 'active')
+        eq(users.isActive, true)
       )
     )
     .limit(1);

--- a/calendar-service/src/auth/strategies/ad.strategy.ts
+++ b/calendar-service/src/auth/strategies/ad.strategy.ts
@@ -2,7 +2,10 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { users } from '@corpcal/database/schema';
 
-import type { Database } from '../../database/database.provider';
+import type {
+  Database,
+  DrizzleDbExecutor,
+} from '../../database/database.provider';
 
 export interface AuthDbUser {
   id: number;
@@ -55,44 +58,8 @@ export async function findUserByEmail(
   return row ?? null;
 }
 
-export interface AuthDbUserWithActivity extends AuthDbUser {
-  isActive: boolean;
-}
-
-export async function findUserByEmailAnyStatus(
-  db: Database,
-  email: string
-): Promise<AuthDbUserWithActivity | null> {
-  const normalizedEmail = email.trim().toLowerCase();
-
-  const [row] = await db
-    .select({ ...authUserSelection, isActive: users.isActive })
-    .from(users)
-    .where(sql`lower(${users.adEmail}) = ${normalizedEmail}`)
-    .limit(1);
-
-  return row ?? null;
-}
-
-/**
- * Looks up a user by externalId regardless of status — used to produce a
- * more informative error when the account exists but is pending/reset-required.
- */
-export async function findUserByExternalIdAnyStatus(
-  db: Database,
-  externalId: string
-): Promise<Pick<AuthDbUser, 'status'> | null> {
-  const [row] = await db
-    .select({ status: users.status })
-    .from(users)
-    .where(and(eq(users.externalId, externalId), eq(users.isActive, true)))
-    .limit(1);
-
-  return row ?? null;
-}
-
 export async function syncAzureIdentity(
-  db: Database,
+  db: DrizzleDbExecutor,
   userId: number,
   identity: {
     externalId: string;

--- a/calendar-service/src/auth/strategies/local.strategy.ts
+++ b/calendar-service/src/auth/strategies/local.strategy.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from 'drizzle-orm';
 
-import { users } from '@corpcal/database/schema';
+import { users, userSettings } from '@corpcal/database/schema';
 
 import type { Database } from '../../database/database.provider';
 import type { AuthDbUser } from './ad.strategy';
@@ -9,11 +9,24 @@ export interface LocalAuthDbUser extends AuthDbUser {
   passwordHash: string | null;
   status: string;
   isActive: boolean;
+  directLoginEnabled: boolean;
 }
+
+const LOCAL_AUTH_COLUMNS = {
+  id: users.id,
+  roleId: users.roleId,
+  adUsername: users.adUsername,
+  adDisplayName: users.adDisplayName,
+  adEmail: users.adEmail,
+  passwordHash: users.passwordHash,
+  status: users.status,
+  isActive: users.isActive,
+  directLoginEnabled: userSettings.directLoginEnabled,
+} as const;
 
 /**
  * Local auth strategy: find user by email (case-insensitive).
- * Returns password hash and status along with standard auth fields.
+ * Returns password hash, status, and directLoginEnabled along with standard auth fields.
  */
 export async function findUserByEmailLocal(
   db: Database,
@@ -22,21 +35,14 @@ export async function findUserByEmailLocal(
   const normalized = email.trim().toLowerCase();
 
   const [row] = await db
-    .select({
-      id: users.id,
-      roleId: users.roleId,
-      adUsername: users.adUsername,
-      adDisplayName: users.adDisplayName,
-      adEmail: users.adEmail,
-      passwordHash: users.passwordHash,
-      status: users.status,
-      isActive: users.isActive,
-    })
+    .select(LOCAL_AUTH_COLUMNS)
     .from(users)
+    .leftJoin(userSettings, eq(userSettings.userId, users.id))
     .where(sql`lower(${users.adEmail}) = ${normalized}`)
     .limit(1);
 
-  return row ?? null;
+  if (!row) return null;
+  return { ...row, directLoginEnabled: row.directLoginEnabled ?? false };
 }
 
 /**
@@ -47,21 +53,14 @@ export async function findUserByIdLocal(
   userId: number
 ): Promise<LocalAuthDbUser | null> {
   const [row] = await db
-    .select({
-      id: users.id,
-      roleId: users.roleId,
-      adUsername: users.adUsername,
-      adDisplayName: users.adDisplayName,
-      adEmail: users.adEmail,
-      passwordHash: users.passwordHash,
-      status: users.status,
-      isActive: users.isActive,
-    })
+    .select(LOCAL_AUTH_COLUMNS)
     .from(users)
+    .leftJoin(userSettings, eq(userSettings.userId, users.id))
     .where(eq(users.id, userId))
     .limit(1);
 
-  return row ?? null;
+  if (!row) return null;
+  return { ...row, directLoginEnabled: row.directLoginEnabled ?? false };
 }
 
 /**

--- a/calendar-service/src/auth/strategies/local.strategy.ts
+++ b/calendar-service/src/auth/strategies/local.strategy.ts
@@ -2,7 +2,10 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { users, userSettings } from '@corpcal/database/schema';
 
-import type { Database } from '../../database/database.provider';
+import type {
+  Database,
+  DrizzleDbExecutor,
+} from '../../database/database.provider';
 import type { AuthDbUser } from './ad.strategy';
 
 export interface LocalAuthDbUser extends AuthDbUser {
@@ -87,7 +90,7 @@ export async function updateUserPassword(
  * Update only the status of a user (e.g. when admin triggers a reset).
  */
 export async function updateUserStatus(
-  db: Database,
+  db: DrizzleDbExecutor,
   userId: number,
   status: string
 ): Promise<void> {

--- a/calendar-ui/src/pages/Login.test.tsx
+++ b/calendar-ui/src/pages/Login.test.tsx
@@ -2,7 +2,7 @@
  * Login page tests — Azure AD sign-in button visibility and error handling.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -347,15 +347,50 @@ describe('Login page — local email/password auth', () => {
       expect(await screen.findByText(/deactivated/i)).toBeInTheDocument();
     });
 
-    it('shows an error for a deactivated account', async () => {
+    it('shows an error for a deactivated account without Microsoft rescue', async () => {
+      setupBothMethods();
       mockCheckEmail.mockResolvedValue({ status: 'inactive' });
       renderLogin();
+      await userEvent.click(
+        await screen.findByRole('button', {
+          name: /sign in with a local account/i,
+        })
+      );
       await userEvent.type(
         await screen.findByLabelText('Email'),
-        'gone@example.com'
+        'gone@gov.bc.ca'
       );
       await userEvent.click(screen.getByRole('button', { name: /continue/i }));
       expect(await screen.findByText(/deactivated/i)).toBeInTheDocument();
+      const alert = screen.getByRole('alert');
+      expect(
+        within(alert).queryByRole('button', { name: /sign in with microsoft/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('offers Microsoft rescue for sso_recommended when Azure is enabled', async () => {
+      setupBothMethods();
+      mockCheckEmail.mockResolvedValue({
+        status: 'sso_recommended',
+        email: 'idir@gov.bc.ca',
+      });
+      renderLogin();
+      await userEvent.click(
+        await screen.findByRole('button', {
+          name: /sign in with a local account/i,
+        })
+      );
+      await userEvent.type(
+        await screen.findByLabelText('Email'),
+        'idir@gov.bc.ca'
+      );
+      await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+      expect(await screen.findByText(/microsoft sign-in/i)).toBeInTheDocument();
+      expect(
+        within(screen.getByRole('alert')).getByRole('button', {
+          name: /sign in with microsoft/i,
+        })
+      ).toBeInTheDocument();
     });
   });
 

--- a/calendar-ui/src/pages/Login.test.tsx
+++ b/calendar-ui/src/pages/Login.test.tsx
@@ -150,6 +150,32 @@ describe('Login page — Azure AD', () => {
       ).toBeInTheDocument();
     });
 
+    it('displays the correct message for azure_deactivated', async () => {
+      mockGetAzureConfig.mockResolvedValue({ enabled: false });
+      setLocationSearch('?error=azure_deactivated');
+      renderLogin();
+
+      await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
+
+      expect(
+        screen.getByText(/This account has been deactivated/i)
+      ).toBeInTheDocument();
+    });
+
+    it('displays the correct message for azure_reset_required', async () => {
+      mockGetAzureConfig.mockResolvedValue({ enabled: false });
+      setLocationSearch('?error=azure_reset_required');
+      renderLogin();
+
+      await waitFor(() => expect(mockGetAzureConfig).toHaveBeenCalledOnce());
+
+      expect(
+        screen.getByText(
+          /password reset is required before you can sign in with microsoft/i
+        )
+      ).toBeInTheDocument();
+    });
+
     it('displays a generic message for any other azure error', async () => {
       mockGetAzureConfig.mockResolvedValue({ enabled: false });
       setLocationSearch('?error=azure_auth_failed');
@@ -530,6 +556,29 @@ describe('Login page — local email/password auth', () => {
         screen.getByRole('button', { name: /set password/i })
       );
       expect(await screen.findByText(/server error/i)).toBeInTheDocument();
+    });
+
+    it('offers Microsoft sign-in on the set-password step when Azure is enabled', async () => {
+      setupBothMethods();
+      mockCheckEmail.mockResolvedValue({
+        status: 'pending',
+        email: 'new@example.com',
+      });
+      renderLogin();
+      await userEvent.click(
+        await screen.findByRole('button', {
+          name: /sign in with a local account/i,
+        })
+      );
+      await userEvent.type(
+        await screen.findByLabelText('Email'),
+        'new@example.com'
+      );
+      await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+      await screen.findByText(/create your password/i);
+      expect(
+        screen.getByTestId('login-set-password-azure')
+      ).toBeInTheDocument();
     });
   });
 

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -184,7 +184,18 @@ export function Login() {
     setErrorAction(null);
     setSuccessMessage('');
     setVerifiedEmail('');
+    setEmailInput('');
+    setShowLocalForm(false);
   };
+
+  const handleAzureLogin = () => {
+    setIsAzureLoading(true);
+    startAzureLogin();
+  };
+
+  const showMicrosoftPrimary = azureEnabled === true && !showLocalForm;
+  const showEmailForm =
+    azureEnabled === false || (localEnabled && showLocalForm);
 
   // -------------------------------------------------------------------------
   // Step 1: Check email status
@@ -359,7 +370,8 @@ export function Login() {
   const renderNewPasswordForm = (
     title: string,
     description: string,
-    onSubmit: (e: React.FormEvent) => Promise<void>
+    onSubmit: (e: React.FormEvent) => Promise<void>,
+    options?: { showMicrosoftPrimary?: boolean }
   ) => (
     <div
       className="flex min-h-screen items-center justify-center bg-linear-to-br from-slate-50 to-slate-100 p-4"
@@ -383,6 +395,33 @@ export function Login() {
         </CardHeader>
 
         <CardContent className="pt-6">
+          {options?.showMicrosoftPrimary && (
+            <div className="mb-6 space-y-4">
+              <Button
+                type="button"
+                className="h-11 w-full font-medium"
+                disabled={isLoading || isAzureLoading}
+                onClick={handleAzureLogin}
+                data-testid="login-set-password-azure"
+              >
+                {isAzureLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Redirecting to Microsoft...
+                  </>
+                ) : (
+                  <>
+                    <MicrosoftLogo />
+                    Sign in with Microsoft
+                  </>
+                )}
+              </Button>
+              <p className="text-center text-xs text-slate-500">
+                or set a password below
+              </p>
+            </div>
+          )}
+
           <form onSubmit={(e) => void onSubmit(e)} className="space-y-5">
             <div className="space-y-2">
               <Label
@@ -489,7 +528,8 @@ export function Login() {
     return renderNewPasswordForm(
       'Create your password',
       `Set a password to activate your account for ${verifiedEmail}`,
-      handleSetPassword
+      handleSetPassword,
+      { showMicrosoftPrimary: azureEnabled === true }
     );
   }
 
@@ -764,15 +804,12 @@ export function Login() {
           )}
 
           {/* Azure IDIR button — primary when available, hidden once local form is open */}
-          {azureEnabled === true && !showLocalForm && (
+          {showMicrosoftPrimary && (
             <Button
               type="button"
               className="h-11 w-full"
               disabled={isLoading || isAzureLoading}
-              onClick={() => {
-                setIsAzureLoading(true);
-                startAzureLogin();
-              }}
+              onClick={handleAzureLogin}
             >
               {isAzureLoading ? (
                 <>
@@ -789,7 +826,7 @@ export function Login() {
           )}
 
           {/* Email-first local login form */}
-          {azureEnabled !== null && localEnabled && showLocalForm && (
+          {azureEnabled !== null && showEmailForm && (
             <form
               onSubmit={(e) => void handleCheckEmail(e)}
               className="space-y-5"
@@ -830,10 +867,7 @@ export function Login() {
                       type="button"
                       variant="outline"
                       className="h-10 w-full border-red-200 bg-white font-medium text-slate-700 hover:bg-red-50"
-                      onClick={() => {
-                        setIsAzureLoading(true);
-                        startAzureLogin();
-                      }}
+                      onClick={handleAzureLogin}
                       disabled={isAzureLoading}
                     >
                       {isAzureLoading ? (
@@ -972,7 +1006,7 @@ export function Login() {
             </div>
           )}
 
-          {error && view === 'email-entry' && !showLocalForm && (
+          {error && view === 'email-entry' && !showEmailForm && (
             <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
               {error}
             </div>
@@ -980,7 +1014,7 @@ export function Login() {
 
           <div className="relative mt-4 border-t pt-6 text-center">
             {/* ChevronDown toggle — only shown when Azure is primary and local is available */}
-            {azureEnabled === true && localEnabled && !showLocalForm && (
+            {azureEnabled === true && localEnabled && showMicrosoftPrimary && (
               <button
                 type="button"
                 onClick={() => setShowLocalForm(true)}

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -653,10 +653,11 @@ export function Login() {
                   />
                   <button
                     type="button"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    aria-pressed={showPassword}
                     data-testid="login-password-toggle"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-600"
-                    tabIndex={-1}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -185,7 +185,6 @@ export function Login() {
     setSuccessMessage('');
     setVerifiedEmail('');
     setEmailInput('');
-    setShowLocalForm(false);
   };
 
   const handleAzureLogin = () => {

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -136,6 +136,14 @@ export function Login() {
         setError(
           'Your Microsoft account is not linked to an active Corporate Calendar user.'
         );
+      } else if (azureError === 'azure_deactivated') {
+        setError(
+          'This account has been deactivated. Please contact your administrator.'
+        );
+      } else if (azureError === 'azure_reset_required') {
+        setError(
+          'A password reset is required before you can sign in with Microsoft. Please use the email/password flow and follow the reset instructions.'
+        );
       } else {
         setError('Microsoft sign-in failed. Please try again.');
       }

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -52,6 +52,9 @@ type LoginView =
   | 'enter-reset-code'
   | 'reset-password';
 
+const isBcGovEmail = (input: string) =>
+  input.trim().toLowerCase().endsWith('@gov.bc.ca');
+
 function validatePassword(pwd: string): string | null {
   if (pwd.length < 12) return 'Password must be at least 12 characters';
   if (!/[A-Z]/.test(pwd)) return 'Must contain at least one uppercase letter';
@@ -83,11 +86,10 @@ export function Login() {
   const navigate = useNavigate();
   const { login } = useAuth();
 
-  // Auth method availability
-  const [azureEnabled, setAzureEnabled] = useState(false);
+  // Auth method availability — null means config is still loading
+  const [azureEnabled, setAzureEnabled] = useState<boolean | null>(null);
   const [localEnabled, setLocalEnabled] = useState(false);
   const [mockEnabled, setMockEnabled] = useState(false);
-  const [configLoaded, setConfigLoaded] = useState(false);
   // When Azure is enabled, the local form is hidden by default and shown on request
   const [showLocalForm, setShowLocalForm] = useState(false);
 
@@ -96,6 +98,7 @@ export function Login() {
 
   // Shared state
   const [error, setError] = useState('');
+  const [errorAction, setErrorAction] = useState<'azure' | null>(null);
   const [successMessage, setSuccessMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isAzureLoading, setIsAzureLoading] = useState(false);
@@ -141,16 +144,15 @@ export function Login() {
     void Promise.all([
       getAzureConfig().catch(() => ({ enabled: false })),
       getLocalConfig().catch(() => ({ enabled: false, mockEnabled: false })),
-    ])
-      .then(([azure, local]) => {
-        setAzureEnabled(azure.enabled === true);
-        setLocalEnabled(local.enabled === true);
-        setMockEnabled(local.mockEnabled === true);
-        // If Azure is not the primary method, show the local form immediately
-        if (!azure.enabled && (local.enabled || local.mockEnabled))
-          setShowLocalForm(true);
-      })
-      .finally(() => setConfigLoaded(true));
+    ]).then(([azure, local]) => {
+      const azureOn = azure.enabled === true;
+      setAzureEnabled(azureOn);
+      setLocalEnabled(local.enabled === true);
+      setMockEnabled(local.mockEnabled === true);
+      // If Azure is not the primary method, show the local form immediately
+      if (!azureOn && (local.enabled || local.mockEnabled))
+        setShowLocalForm(true);
+    });
   }, []);
 
   // -------------------------------------------------------------------------
@@ -170,6 +172,7 @@ export function Login() {
     setResetCodeInput('');
     setResetToken('');
     setError('');
+    setErrorAction(null);
     setSuccessMessage('');
     setVerifiedEmail('');
   };
@@ -180,6 +183,7 @@ export function Login() {
   const handleCheckEmail = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+    setErrorAction(null);
     setSuccessMessage('');
     setIsLoading(true);
 
@@ -199,11 +203,16 @@ export function Login() {
           setView('enter-reset-code');
           break;
         case 'inactive':
-          setError(
-            azureEnabled
-              ? 'This account cannot sign in with a password. If you are BC Government staff, try signing in with IDIR.'
-              : 'This account has been deactivated. Please contact your administrator.'
-          );
+          if (azureEnabled && isBcGovEmail(emailInput)) {
+            setError(
+              'This account cannot sign in with a password. If you are BC Government staff, try signing in with IDIR.'
+            );
+            setErrorAction('azure');
+          } else {
+            setError(
+              'This account has been deactivated. Please contact your administrator.'
+            );
+          }
           break;
         default:
           setError('Unable to verify account status. Please try again.');
@@ -411,7 +420,7 @@ export function Login() {
                 <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
                 <Input
                   id="confirm-password"
-                  type="password"
+                  type={showNewPassword ? 'text' : 'password'}
                   placeholder="Re-enter your password"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
@@ -497,6 +506,17 @@ export function Login() {
               onSubmit={(e) => void handleVerifyResetCode(e)}
               className="space-y-5"
             >
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                Account: <strong>{verifiedEmail}</strong>
+                <button
+                  type="button"
+                  onClick={resetToEmailEntry}
+                  className="ml-2 text-xs text-amber-600 underline-offset-2 hover:underline"
+                >
+                  Change
+                </button>
+              </div>
+
               <div className="space-y-2">
                 <Label
                   htmlFor="reset-code"
@@ -504,18 +524,24 @@ export function Login() {
                 >
                   Reset Code
                 </Label>
-                <Input
-                  id="reset-code"
-                  type="text"
-                  placeholder="Paste the code from your administrator"
-                  value={resetCodeInput}
-                  onChange={(e) => setResetCodeInput(e.target.value)}
-                  className="h-11"
-                  autoComplete="off"
-                  autoFocus
-                  disabled={isLoading}
-                  required
-                />
+                <div className="relative">
+                  <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    id="reset-code"
+                    type="text"
+                    placeholder="Paste the code from your administrator"
+                    value={resetCodeInput}
+                    onChange={(e) => setResetCodeInput(e.target.value)}
+                    className="h-11 pl-10 font-mono"
+                    autoComplete="off"
+                    autoFocus
+                    disabled={isLoading}
+                    required
+                  />
+                </div>
+                <p className="text-xs text-slate-500">
+                  Contact your administrator if you don&apos;t have a reset code
+                </p>
               </div>
 
               {error && (
@@ -566,7 +592,126 @@ export function Login() {
   }
 
   // -------------------------------------------------------------------------
-  // Render: main login card (email-entry + password-entry)
+  // Render: password-entry view (separate card for better UX)
+  // -------------------------------------------------------------------------
+  if (view === 'password-entry') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-linear-to-br from-slate-50 to-slate-100 p-4">
+        <Card className="w-full max-w-md border-0 shadow-xl">
+          <CardHeader className="space-y-4 pb-2 text-center">
+            <div className="flex flex-col items-center space-y-4">
+              <div className="bg-primary/10 flex h-16 w-16 items-center justify-center rounded-full">
+                <Lock className="text-primary h-8 w-8" />
+              </div>
+              <div>
+                <CardTitle className="text-2xl font-bold text-slate-800">
+                  Welcome back
+                </CardTitle>
+                <CardDescription className="mt-2 text-slate-500">
+                  Enter your password to sign in
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="pt-6">
+            <form
+              onSubmit={(e) => void handlePasswordSubmit(e)}
+              className="space-y-5"
+            >
+              <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
+                Signing in as: <strong>{verifiedEmail}</strong>
+                <button
+                  type="button"
+                  onClick={resetToEmailEntry}
+                  className="ml-2 text-xs text-blue-600 underline-offset-2 hover:underline"
+                >
+                  Change
+                </button>
+              </div>
+
+              <div className="space-y-2">
+                <Label
+                  htmlFor="password"
+                  className="text-sm font-medium text-slate-700"
+                >
+                  Password
+                </Label>
+                <div className="relative">
+                  <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="Enter your password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="h-11 pr-10 pl-10"
+                    autoComplete="current-password"
+                    autoFocus
+                    disabled={isLoading}
+                    required
+                  />
+                  <button
+                    type="button"
+                    data-testid="login-password-toggle"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-600"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                className="h-11 w-full font-medium"
+                data-testid="login-submit-password"
+                disabled={isLoading || !password}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Signing in...
+                  </>
+                ) : (
+                  'Sign In'
+                )}
+              </Button>
+
+              {azureEnabled && (
+                <div className="text-center">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowLocalForm(false);
+                      resetToEmailEntry();
+                    }}
+                    className="text-sm text-slate-500 underline underline-offset-2 hover:text-slate-800"
+                  >
+                    Use Microsoft instead
+                  </button>
+                </div>
+              )}
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Render: main login card (email-entry)
   // -------------------------------------------------------------------------
   return (
     <div
@@ -591,8 +736,16 @@ export function Login() {
         </CardHeader>
 
         <CardContent className="space-y-4 pt-6">
+          {/* Loading skeleton while auth config is being fetched */}
+          {azureEnabled === null && (
+            <div className="animate-pulse" aria-hidden="true">
+              <div className="mb-3 h-11 rounded bg-slate-200" />
+              <div className="mx-auto h-4 w-1/2 rounded bg-slate-200" />
+            </div>
+          )}
+
           {/* Azure IDIR button — primary when available, hidden once local form is open */}
-          {configLoaded && azureEnabled && !showLocalForm && (
+          {azureEnabled === true && !showLocalForm && (
             <Button
               type="button"
               className="h-11 w-full"
@@ -616,177 +769,106 @@ export function Login() {
             </Button>
           )}
 
-          {/* Local auth toggle link — removed; chevron on footer divider handles this */}
-
           {/* Email-first local login form */}
-          {configLoaded && localEnabled && showLocalForm && (
-            <>
-              {/* Step: email entry */}
-              {view === 'email-entry' && (
-                <form
-                  onSubmit={(e) => void handleCheckEmail(e)}
-                  className="space-y-5"
+          {azureEnabled !== null && localEnabled && showLocalForm && (
+            <form
+              onSubmit={(e) => void handleCheckEmail(e)}
+              className="space-y-5"
+            >
+              <div className="space-y-2">
+                <Label
+                  htmlFor="email"
+                  className="text-sm font-medium text-slate-700"
                 >
-                  <div className="space-y-2">
-                    <Label
-                      htmlFor="email"
-                      className="text-sm font-medium text-slate-700"
-                    >
-                      Email
-                    </Label>
-                    <div className="relative">
-                      <Mail className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                      <Input
-                        id="email"
-                        type="email"
-                        placeholder="you@example.com"
-                        value={emailInput}
-                        onChange={(e) => setEmailInput(e.target.value)}
-                        className="h-11 pl-10"
-                        autoComplete="email"
-                        autoFocus={!azureEnabled}
-                        disabled={isLoading}
-                        required
-                      />
-                    </div>
-                  </div>
+                  Email
+                </Label>
+                <div className="relative">
+                  <Mail className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={emailInput}
+                    onChange={(e) => setEmailInput(e.target.value)}
+                    className="h-11 pl-10"
+                    autoComplete="email"
+                    autoFocus={!azureEnabled}
+                    disabled={isLoading}
+                    required
+                  />
+                </div>
+              </div>
 
-                  {error && (
-                    <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-                      {error}
-                    </div>
-                  )}
-
-                  <Button
-                    type="submit"
-                    className="h-11 w-full font-medium"
-                    data-testid="login-continue-email"
-                    disabled={isLoading || !emailInput.trim()}
-                  >
-                    {isLoading ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Checking...
-                      </>
-                    ) : (
-                      'Continue'
-                    )}
-                  </Button>
-
-                  {azureEnabled && (
-                    <div className="text-center">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setShowLocalForm(false);
-                          setError('');
-                        }}
-                        className="text-sm text-slate-500 underline underline-offset-2 hover:text-slate-800"
-                      >
-                        Use Microsoft instead
-                      </button>
-                    </div>
-                  )}
-                </form>
-              )}
-
-              {/* Step: password entry */}
-              {view === 'password-entry' && (
-                <form
-                  onSubmit={(e) => void handlePasswordSubmit(e)}
-                  className="space-y-5"
+              {error && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="space-y-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
                 >
-                  <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
-                    {verifiedEmail}
-                    <button
+                  <p>{error}</p>
+                  {errorAction === 'azure' && azureEnabled === true && (
+                    <Button
                       type="button"
-                      onClick={resetToEmailEntry}
-                      className="ml-2 text-xs text-slate-400 underline-offset-2 hover:underline"
+                      variant="outline"
+                      className="h-10 w-full border-red-200 bg-white font-medium text-slate-700 hover:bg-red-50"
+                      onClick={() => {
+                        setIsAzureLoading(true);
+                        startAzureLogin();
+                      }}
+                      disabled={isAzureLoading}
                     >
-                      Change
-                    </button>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label
-                      htmlFor="password"
-                      className="text-sm font-medium text-slate-700"
-                    >
-                      Password
-                    </Label>
-                    <div className="relative">
-                      <Lock className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                      <Input
-                        id="password"
-                        type={showPassword ? 'text' : 'password'}
-                        placeholder="Enter your password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        className="h-11 pr-10 pl-10"
-                        autoComplete="current-password"
-                        autoFocus
-                        disabled={isLoading}
-                        required
-                      />
-                      <button
-                        type="button"
-                        data-testid="login-password-toggle"
-                        onClick={() => setShowPassword(!showPassword)}
-                        className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 transition-colors hover:text-slate-600"
-                        tabIndex={-1}
-                      >
-                        {showPassword ? (
-                          <EyeOff className="h-4 w-4" />
-                        ) : (
-                          <Eye className="h-4 w-4" />
-                        )}
-                      </button>
-                    </div>
-                  </div>
-
-                  {error && (
-                    <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-                      {error}
-                    </div>
+                      {isAzureLoading ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Redirecting...
+                        </>
+                      ) : (
+                        <>
+                          <MicrosoftLogo />
+                          Sign in with Microsoft
+                        </>
+                      )}
+                    </Button>
                   )}
-
-                  <Button
-                    type="submit"
-                    className="h-11 w-full font-medium"
-                    data-testid="login-submit-password"
-                    disabled={isLoading || !password}
-                  >
-                    {isLoading ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Signing in...
-                      </>
-                    ) : (
-                      'Sign In'
-                    )}
-                  </Button>
-
-                  {azureEnabled && (
-                    <div className="text-center">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setShowLocalForm(false);
-                          resetToEmailEntry();
-                        }}
-                        className="text-sm text-slate-500 underline underline-offset-2 hover:text-slate-800"
-                      >
-                        Use Microsoft instead
-                      </button>
-                    </div>
-                  )}
-                </form>
+                </div>
               )}
-            </>
+
+              <Button
+                type="submit"
+                className="h-11 w-full font-medium"
+                data-testid="login-continue-email"
+                disabled={isLoading || !emailInput.trim()}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Checking...
+                  </>
+                ) : (
+                  'Continue'
+                )}
+              </Button>
+
+              {azureEnabled && (
+                <div className="text-center">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowLocalForm(false);
+                      setError('');
+                      setErrorAction(null);
+                    }}
+                    className="text-sm text-slate-500 underline underline-offset-2 hover:text-slate-800"
+                  >
+                    Use Microsoft instead
+                  </button>
+                </div>
+              )}
+            </form>
           )}
 
           {/* Mock mode (development only) — simple username form */}
-          {configLoaded && mockEnabled && (
+          {azureEnabled !== null && mockEnabled && (
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -856,11 +938,14 @@ export function Login() {
           )}
 
           {/* Neither strategy is available yet */}
-          {configLoaded && !azureEnabled && !localEnabled && !mockEnabled && (
-            <p className="text-center text-sm text-slate-500">
-              No login method is configured. Contact your administrator.
-            </p>
-          )}
+          {azureEnabled !== null &&
+            !azureEnabled &&
+            !localEnabled &&
+            !mockEnabled && (
+              <p className="text-center text-sm text-slate-500">
+                No login method is configured. Contact your administrator.
+              </p>
+            )}
 
           {successMessage && view === 'email-entry' && (
             <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
@@ -876,7 +961,7 @@ export function Login() {
 
           <div className="relative mt-4 border-t pt-6 text-center">
             {/* ChevronDown toggle — only shown when Azure is primary and local is available */}
-            {configLoaded && azureEnabled && localEnabled && !showLocalForm && (
+            {azureEnabled === true && localEnabled && !showLocalForm && (
               <button
                 type="button"
                 onClick={() => setShowLocalForm(true)}

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -7,8 +7,9 @@
  *                             → set-password     (pending account)
  *                             → enter-reset-code → reset-password  (password_reset_required)
  *
- * When Azure AD is also configured the IDIR button is shown as the primary
- * action, with local login accessible via a toggle link.
+ * When Azure AD is also configured the Microsoft button is shown first.
+ * Users with Microsoft-linked accounts can sign in directly without a local
+ * password; local login remains available for password-based accounts.
  */
 import {
   CheckCircle,
@@ -653,7 +654,9 @@ export function Login() {
                   />
                   <button
                     type="button"
-                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    aria-label={
+                      showPassword ? 'Hide password' : 'Show password'
+                    }
                     aria-pressed={showPassword}
                     data-testid="login-password-toggle"
                     onClick={() => setShowPassword(!showPassword)}

--- a/calendar-ui/src/pages/Login.tsx
+++ b/calendar-ui/src/pages/Login.tsx
@@ -203,17 +203,24 @@ export function Login() {
           setVerifiedEmail(data.email ?? emailInput.trim());
           setView('enter-reset-code');
           break;
-        case 'inactive':
-          if (azureEnabled && isBcGovEmail(emailInput)) {
+        case 'sso_recommended':
+          if (azureEnabled) {
             setError(
-              'This account cannot sign in with a password. If you are BC Government staff, try signing in with IDIR.'
+              isBcGovEmail(emailInput)
+                ? 'This account uses Microsoft sign-in (IDIR). Password login is not enabled.'
+                : 'This account uses Microsoft sign-in. Password login is not enabled.'
             );
             setErrorAction('azure');
           } else {
             setError(
-              'This account has been deactivated. Please contact your administrator.'
+              'This account cannot sign in with a password. Please contact your administrator.'
             );
           }
+          break;
+        case 'inactive':
+          setError(
+            'This account has been deactivated. Please contact your administrator.'
+          );
           break;
         default:
           setError('Unable to verify account status. Please try again.');

--- a/packages/shared/src/auth/schemas.ts
+++ b/packages/shared/src/auth/schemas.ts
@@ -21,10 +21,23 @@ export const checkEmailBodySchema = z.object({
 
 export type CheckEmailBody = z.infer<typeof checkEmailBodySchema>;
 
+/**
+ * POST /auth/check-email status contract.
+ *
+ * Anti-enumeration: unknown addresses return `inactive` (same as deactivated).
+ * UI must not suggest Microsoft for generic `inactive` — only for `sso_recommended`.
+ *
+ * - `active` — password login
+ * - `pending` — set initial password (includes active + directLoginEnabled, no hash)
+ * - `requires_reset` — admin reset code flow
+ * - `sso_recommended` — known active SSO-only user (no password, directLogin off)
+ * - `inactive` — deactivated, unknown email, or not eligible for local login
+ */
 export type CheckEmailStatus =
   | 'active'
   | 'pending'
   | 'requires_reset'
+  | 'sso_recommended'
   | 'inactive';
 
 export interface CheckEmailResponse {


### PR DESCRIPTION
# PR: fix/CORPCAL-000-direct-login-improvements-c

## Summary

Fixes Microsoft SSO for admin-created users stuck in `pending` status. Azure login now finds pending accounts, activates them on first SSO, and the login UI matches Media Hub by promoting Microsoft sign-in first.

## Important

- `npm run build:packages` (shared check-email contract updated)

## Changes

1. **Auth (Azure SSO):** pending users can sign in with Microsoft.
   - AD lookup no longer requires `status = active` (still requires `isActive`).
   - First successful SSO promotes `pending` → `active` and syncs identity in one transaction.
   - Clearer error when no matching Corporate Calendar account exists.

2. **Auth (local / IDIR):** check-email and password flows aligned with `directLoginEnabled`.
   - `sso_recommended` for SSO-only accounts; local password paths for direct-login IDIR users.

3. **Login UI:** Media Hub–style SSO-first layout.
   - Microsoft button is primary; email/password behind chevron toggle.
   - Pending set-password step offers Microsoft sign-in before local password setup.
   - Azure callback errors for deactivated and reset-required accounts.

4. **Tests:** auth service and Login page coverage for pending SSO, transactions, and UI flows.

## Testing

- `npm run test -w calendar-service -- auth.service.spec.ts` (41 passed)
- `npm run test -w calendar-ui -- Login.test.tsx` (33 passed)
- Manual: create pending user → sign in with Microsoft → confirm session and `status = active`
