### PR TITLE
Chore/CORPCAL-0000 Naming label changes Openshift

### DIFF
--- a/openshift/emerald/deploy/base/calendar-service/configmap.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/configmap.yaml
@@ -1,12 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: calendar-service-config
+  name: corpcal-service-config
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 data:
   NODE_ENV: production
   AUTH_STRATEGY: azure

--- a/openshift/emerald/deploy/base/calendar-service/deployment.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/deployment.yaml
@@ -1,26 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: calendar-service
+  name: corpcal-service
   labels:
-    app: calendar-service
-    app.kubernetes.io/name: calendar
+    DataClass: Low #Does not affect directly as such
+    app: corpcal-service
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: calendar-service
+      app: corpcal-service
   template:
     metadata:
       labels:
-        app: calendar-service
+        DataClass: Low
+        Internet-Egress: ALLOW
+        Internet-Ingress: ALLOW
+        app: corpcal-service
     spec:
       containers:
-        - name: calendar-service
-          image: calendar-service:latest
+        - name: corpcal-service
+          image: corpcal-service:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -30,58 +35,68 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: DATABASE_URL
             - name: CORS_ALLOWED_ORIGINS
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-service-config
+                  name: corpcal-service-config
                   key: CORS_ALLOWED_ORIGINS
             - name: NODE_ENV
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-service-config
+                  name: corpcal-service-config
                   key: NODE_ENV
             - name: AUTH_STRATEGY
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-service-config
+                  name: corpcal-service-config
                   key: AUTH_STRATEGY
             - name: AUTH_COOKIE_DOMAIN
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-service-config
+                  name: corpcal-service-config
                   key: AUTH_COOKIE_DOMAIN
             - name: POST_LOGIN_REDIRECT_URL
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-service-config
+                  name: corpcal-service-config
                   key: POST_LOGIN_REDIRECT_URL
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: JWT_SECRET
             - name: AZURE_TENANT_ID
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: AZURE_TENANT_ID
             - name: AZURE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: AZURE_CLIENT_ID
             - name: AZURE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: AZURE_CLIENT_SECRET
             - name: AZURE_REDIRECT_URI
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: AZURE_REDIRECT_URI
+            #Session_Secret not required (need to check)
+            - name: SESSION_SECRET
+              value: be7f200b-8324-46b2-8628-378dd8bc3d00
+            - name: HTTP_PROXY
+              value: 'http://swpxkam.gov.bc.ca:8080'
+            - name: HTTPS_PROXY
+              value: 'http://swpxkam.gov.bc.ca:8080'
+            - name: NO_PROXY
+              value: '.cluster.local,.svc,10.91.0.0/16,10.93.0.0/16,172.30.0.0/16,127.0.0.1,localhost,.gov.bc.ca'
+
           readinessProbe:
             httpGet:
               path: /ready

--- a/openshift/emerald/deploy/base/calendar-service/deployment.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/deployment.yaml
@@ -87,9 +87,6 @@ spec:
                 secretKeyRef:
                   name: corpcal-service-secret
                   key: AZURE_REDIRECT_URI
-            #Session_Secret not required (need to check)
-            - name: SESSION_SECRET
-              value: be7f200b-8324-46b2-8628-378dd8bc3d00
             - name: HTTP_PROXY
               value: 'http://swpxkam.gov.bc.ca:8080'
             - name: HTTPS_PROXY

--- a/openshift/emerald/deploy/base/calendar-service/imagestream.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/imagestream.yaml
@@ -1,9 +1,10 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: calendar-service
+  name: corpcal-service
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions

--- a/openshift/emerald/deploy/base/calendar-service/route.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/route.yaml
@@ -1,16 +1,19 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: calendar-service
+  name: corpcal-service-route
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
+  annotations:
+    aviinfrasetting.ako.vmware.com/name: dataclass-public
 spec:
   to:
     kind: Service
-    name: calendar-service
+    name: corpcal-service
   port:
     targetPort: http
   tls:

--- a/openshift/emerald/deploy/base/calendar-service/secret.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/secret.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: calendar-service-secrets
+  name: corpcal-service-secret
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 type: Opaque
 stringData:
-  DATABASE_URL: postgres://postgres:calendarpwd@calendar-postgres:5432/calendar
+  DATABASE_URL: postgres://postgres:calendarpwd@corpcal-postgres:5432/calendar
   JWT_SECRET: ${JWT_SECRET}
   AZURE_TENANT_ID: ${AZURE_TENANT_ID}
   AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}

--- a/openshift/emerald/deploy/base/calendar-service/service.yaml
+++ b/openshift/emerald/deploy/base/calendar-service/service.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: calendar-service
+  name: corpcal-service
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   selector:
-    app: calendar-service
+    app: corpcal-service
   ports:
     - protocol: TCP
       port: 3001

--- a/openshift/emerald/deploy/base/calendar-ui/configmap.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/configmap.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: calendar-ui-config
+  name: corpcal-ui-config
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 data:
   NODE_ENV: development
   VITE_API_BASE_URL: /api
-  API_PROXY_UPSTREAM: http://calendar-service:3001
+  API_PROXY_UPSTREAM: http://corpcal-service:3001

--- a/openshift/emerald/deploy/base/calendar-ui/deployment.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/deployment.yaml
@@ -1,27 +1,29 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: calendar-ui
+  name: corpcal-ui
   labels:
-    app: calendar-ui
-    app.kubernetes.io/name: calendar
+    app: corpcal-ui
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: calendar-ui
+      app: corpcal-ui
   template:
     metadata:
       labels:
-        app: calendar-ui
+        DataClass: Low
+        Internet-Ingress: ALLOW
+        app: corpcal-ui
     spec:
       containers:
-        - name: calendar-ui
-          image: calendar-ui:latest
+        - name: corpcal-ui
+          image: corpcal-ui:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -31,22 +33,22 @@ spec:
             - name: VITE_API_BASE_URL
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-ui-config
+                  name: corpcal-ui-config
                   key: VITE_API_BASE_URL
             - name: API_PROXY_UPSTREAM
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-ui-config
+                  name: corpcal-ui-config
                   key: API_PROXY_UPSTREAM
             - name: NODE_ENV
               valueFrom:
                 configMapKeyRef:
-                  name: calendar-ui-config
+                  name: corpcal-ui-config
                   key: NODE_ENV
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: calendar-ui-secrets
+                  name: corpcal-ui-secret
                   key: DATABASE_URL
           readinessProbe:
             httpGet:

--- a/openshift/emerald/deploy/base/calendar-ui/imagestream.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/imagestream.yaml
@@ -1,10 +1,10 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: calendar-ui
+  name: corpcal-ui
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions

--- a/openshift/emerald/deploy/base/calendar-ui/route.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/route.yaml
@@ -1,17 +1,17 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: calendar-ui
+  name: corpcal-ui-route
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   to:
     kind: Service
-    name: calendar-ui
+    name: corpcal-ui
   port:
     targetPort: http
   tls:

--- a/openshift/emerald/deploy/base/calendar-ui/secret.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/secret.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: calendar-ui-secrets
+  name: corpcal-ui-secret
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 type: Opaque
 stringData:
-  DATABASE_URL: postgresql://postgres:calendarpwd@calendar-postgres:5432/calendar
+  DATABASE_URL: postgresql://postgres:calendarpwd@corpcal-postgres:5432/calendar

--- a/openshift/emerald/deploy/base/calendar-ui/service.yaml
+++ b/openshift/emerald/deploy/base/calendar-ui/service.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: calendar-ui
+  name: corpcal-ui
   labels:
-    app.kubernetes.io/name: calendar
+    app.kubernetes.io/name: corpcal
     app.kubernetes.io/component: ui
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   selector:
-    app: calendar-ui
+    app: corpcal-ui
   ports:
     - protocol: TCP
       port: 8080

--- a/openshift/emerald/deploy/base/database/migration/calendar-db-migrate-job.yaml
+++ b/openshift/emerald/deploy/base/database/migration/calendar-db-migrate-job.yaml
@@ -1,36 +1,36 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: calendar-db-migrate
+  name: corpcal-db-migrate-job
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     argocd.argoproj.io/sync-wave: '1'
   labels:
-    app: calendar-db-migrate
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: job
+    app: corpcal-db-migrate-job
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: migration
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   backoffLimit: 1
   template:
     metadata:
       labels:
-        app: calendar-db-migrate
+        app: corpcal-db-migrate-job
         DataClass: Low
         Internet-Ingress: DENY
     spec:
       restartPolicy: Never
       containers:
         - name: migrate
-          image: calendar-db-migrate:latest
+          image: corpcal-db-migrate:latest
           env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: DATABASE_URL
           command:
             - sh

--- a/openshift/emerald/deploy/base/database/migration/calendar-db-seed-job.yaml
+++ b/openshift/emerald/deploy/base/database/migration/calendar-db-seed-job.yaml
@@ -1,28 +1,28 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: calendar-db-seed
+  name: corpcal-db-seed-job
   labels:
-    app: calendar-db-seed
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: job
+    app: corpcal-db-seed-job
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: seed
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: ${APP_VERSION}
+    app.kubernetes.io/managed-by: github-actions
 spec:
   backoffLimit: 1
   template:
     metadata:
       labels:
-        app: calendar-db-seed
+        app: corpcal-db-seed-job
     spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: image-registry.openshift-image-registry.svc:5000/${DEV_NAMESPACE}/calendar-db-seed:${APP_VERSION}
+          image: image-registry.openshift-image-registry.svc:5000/${DEV_NAMESPACE}/corpcal-db-seed:${APP_VERSION}
           env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: calendar-service-secrets
+                  name: corpcal-service-secret
                   key: DATABASE_URL

--- a/openshift/emerald/deploy/base/database/postgres-pvc.yaml
+++ b/openshift/emerald/deploy/base/database/postgres-pvc.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: postgres-pvc
+  name: corpcal-postgres-pvc
   labels:
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: postgres
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: database
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: '16'
+    app.kubernetes.io/managed-by: github-actions
 spec:
   accessModes:
     - ReadWriteOnce

--- a/openshift/emerald/deploy/base/database/postgres-secret.yaml
+++ b/openshift/emerald/deploy/base/database/postgres-secret.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: calendar-postgres-secret
+  name: corpcal-postgres-secret
   labels:
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: postgres
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: database
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: '16'
+    app.kubernetes.io/managed-by: github-actions
 type: Opaque
 stringData:
   POSTGRES_DB: calendar

--- a/openshift/emerald/deploy/base/database/postgres-service.yaml
+++ b/openshift/emerald/deploy/base/database/postgres-service.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: calendar-postgres
+  name: corpcal-postgres
   labels:
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: postgres
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: database
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: '16'
+    app.kubernetes.io/managed-by: github-actions
 spec:
   clusterIP: None # headless service
   selector:
-    app: calendar-postgres
+    app: corpcal-postgres
   ports:
     - port: 5432
       targetPort: 5432

--- a/openshift/emerald/deploy/base/database/postgres-statefulset.yaml
+++ b/openshift/emerald/deploy/base/database/postgres-statefulset.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: calendar-postgres
+  name: corpcal-postgres
   labels:
-    app: calendar-postgres
-    app.kubernetes.io/name: calendar
-    app.kubernetes.io/component: postgres
+    app: corpcal-postgres
+    app.kubernetes.io/name: corpcal
+    app.kubernetes.io/component: database
     app.kubernetes.io/part-of: corporate-calendar
-    app.kubernetes.io/instance: dev
-    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/version: '16'
+    app.kubernetes.io/managed-by: github-actions
 spec:
-  serviceName: calendar-postgres
+  serviceName: corpcal-postgres
   replicas: 1
   selector:
     matchLabels:
-      app: calendar-postgres
+      app: corpcal-postgres
 
   template:
     metadata:
       labels:
-        app: calendar-postgres
+        app: corpcal-postgres
     spec:
       # OpenShift restricted SCC safe
       securityContext: {}
@@ -31,17 +31,17 @@ spec:
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: calendar-postgres-secret
+                  name: corpcal-postgres-secret
                   key: POSTGRES_DB
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: calendar-postgres-secret
+                  name: corpcal-postgres-secret
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: calendar-postgres-secret
+                  name: corpcal-postgres-secret
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
@@ -65,4 +65,4 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: postgres-pvc
+            claimName: corpcal-postgres-pvc

--- a/openshift/emerald/deploy/overlays/dev/kustomization.yaml
+++ b/openshift/emerald/deploy/overlays/dev/kustomization.yaml
@@ -4,17 +4,22 @@ resources:
   - ../../base
 
 namespace: dc4c90-dev
+labels:
+  - pairs:
+      app.kubernetes.io/instance: corpcal-dev
+      env: dev
+    includeSelectors: false
 
 # Replace images built into the OpenShift internal registry.
 images:
-  - name: calendar-service:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-service
+  - name: corpcal-service:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-service
     newTag: 0.0.1
-  - name: calendar-ui:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-ui
+  - name: corpcal-ui:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-ui
     newTag: 0.0.1
-  - name: calendar-db-migrate:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-db-migrate
+  - name: corpcal-db-migrate:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-db-migrate
     newTag: 0.0.1
 
 patches:

--- a/openshift/emerald/deploy/overlays/dev/patches/calendar-service-configmap.patch.yaml
+++ b/openshift/emerald/deploy/overlays/dev/patches/calendar-service-configmap.patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: calendar-service-config
+  name: corpcal-service-config
 data:
   AUTH_COOKIE_DOMAIN: calendar-ui-dc4c90-dev.apps.emerald.devops.gov.bc.ca
   POST_LOGIN_REDIRECT_URL: https://calendar-ui-dc4c90-dev.apps.emerald.devops.gov.bc.ca

--- a/openshift/emerald/deploy/overlays/dev/patches/calendar-ui-configmap.patch.yaml
+++ b/openshift/emerald/deploy/overlays/dev/patches/calendar-ui-configmap.patch.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: calendar-ui-config
+  name: corpcal-ui-config
 data:
-  API_PROXY_UPSTREAM: http://calendar-service:3001
+  API_PROXY_UPSTREAM: http://corpcal-service:3001

--- a/openshift/emerald/deploy/overlays/prod/kustomization.yaml
+++ b/openshift/emerald/deploy/overlays/prod/kustomization.yaml
@@ -4,15 +4,20 @@ resources:
   - ../../base
 
 namespace: dc4c90-prod
+labels:
+  - pairs:
+      app.kubernetes.io/instance: corpcal-prod
+      env: prod
+    includeSelectors: false
 
 # Replace images built into the OpenShift internal registry.
 images:
-  - name: calendar-service:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-service
+  - name: corpcal-service:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-service
     newTag: 0.0.1
-  - name: calendar-ui:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-ui
+  - name: corpcal-ui:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-ui
     newTag: 0.0.1
-  - name: calendar-db-migrate:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-db-migrate
+  - name: corpcal-db-migrate:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-db-migrate
     newTag: 0.0.1

--- a/openshift/emerald/deploy/overlays/test/kustomization.yaml
+++ b/openshift/emerald/deploy/overlays/test/kustomization.yaml
@@ -4,15 +4,20 @@ resources:
   - ../../base
 
 namespace: dc4c90-test
+labels:
+  - pairs:
+      app.kubernetes.io/instance: corpcal-test
+      env: test
+    includeSelectors: false
 
 # Replace images built into the OpenShift internal registry.
 images:
-  - name: calendar-service:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-service
+  - name: corpcal-service:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-service
     newTag: 0.0.1
-  - name: calendar-ui:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-ui
+  - name: corpcal-ui:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-ui
     newTag: 0.0.1
-  - name: calendar-db-migrate:latest
-    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/calendar-db-migrate
+  - name: corpcal-db-migrate:latest
+    newName: artifacts.developer.gov.bc.ca/gdc4-corpcal-dev/corpcal-db-migrate
     newTag: 0.0.1


### PR DESCRIPTION
Changed **calendar** to **corpcal** for openshift manifest files to standardize the naming convention. 
This will require the change to Network policies in the Emerald namespaces. Only affects Emerald deployments. 
Added other labels like DataClass and avi routing etc for the deployments to work around network restrictions in Emerald.
The Silver cluster deployments are untouched and should work as it is. 