### PR TITLE
fix(ui): set activity list defaults to startDate asc and page size 25

### DIFF
--- a/calendar-ui/docs/ACTIVITY_FILTER_PERSIST.md
+++ b/calendar-ui/docs/ACTIVITY_FILTER_PERSIST.md
@@ -58,10 +58,10 @@ Defined in [calendar-ui/src/hooks/useActivityTablePreferences.ts](src/hooks/useA
 | Preference    | URL param   | Type                                    | Default     |
 | ------------- | ----------- | --------------------------------------- | ----------- |
 | sortKey       | `sort`      | string (must be in VALID_SORT_KEYS)     | `startDate` |
-| sortDirection | `dir`       | `asc` \| `desc`                         | `desc`      |
+| sortDirection | `dir`       | `asc` \| `desc`                         | `asc`       |
 | showCompleted | `completed` | boolean                                 | `false`     |
 | showDeleted   | `deleted`   | boolean                                 | `false`     |
-| pageSize      | `pageSize`  | number (1–100)                          | `10`        |
+| pageSize      | `pageSize`  | number (1–100)                          | `25`        |
 | searchKeyword | `search`    | string (keyword; sync to URL debounced) | `''`        |
 
 - **sessionStorage key**: `activityTablePreferences`. Stored value is a single JSON object with these keys.

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.spec.tsx
@@ -57,7 +57,7 @@ function makeActivity(id: number) {
   };
 }
 
-const mockActivities = Array.from({ length: 12 }, (_, i) =>
+const mockActivities = Array.from({ length: 30 }, (_, i) =>
   makeActivity(i + 1)
 );
 
@@ -118,12 +118,12 @@ vi.mock('@/hooks/useActivityTableFilterLookups', () => ({
 vi.mock('@/hooks/useActivityTablePreferences', () => ({
   useActivityTablePreferences: () => ({
     preferences: {
-      sortKey: null,
-      sortDirection: 'desc',
+      sortKey: 'startDate',
+      sortDirection: 'asc',
       showCompleted: false,
       showDeleted: false,
       searchKeyword: '',
-      pageSize: 10,
+      pageSize: 25,
       filterState: DEFAULT_ACTIVITY_FILTER_STATE,
     },
     setPreferences: mockSetPreferences,

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -146,7 +146,7 @@ import { compareActivityRowsByLevels } from './activityTableSort';
  */
 
 const DEFAULT_SORT_KEY = 'startDate';
-const DEFAULT_SORT_DIRECTION = 'desc' as const;
+const DEFAULT_SORT_DIRECTION = 'asc' as const;
 
 const ACTIVITY_SORT_COLUMNS: SortColumnConfig[] = [
   { id: 'activityId', label: 'Activity ID', defaultDirection: 'asc' },

--- a/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
+++ b/calendar-ui/src/hooks/useActivityTablePreferences.test.ts
@@ -65,10 +65,10 @@ describe('useActivityTablePreferences', () => {
       );
 
       expect(result.current.preferences.sortKey).toBe('startDate');
-      expect(result.current.preferences.sortDirection).toBe('desc');
+      expect(result.current.preferences.sortDirection).toBe('asc');
       expect(result.current.preferences.showCompleted).toBe(false);
       expect(result.current.preferences.showDeleted).toBe(false);
-      expect(result.current.preferences.pageSize).toBe(10);
+      expect(result.current.preferences.pageSize).toBe(25);
       expect(result.current.preferences.searchKeyword).toBe('');
       expect(result.current.preferences.filterState).toEqual(
         expect.objectContaining({
@@ -133,7 +133,7 @@ describe('useActivityTablePreferences', () => {
         useActivityTablePreferences(canSeeDeleted)
       );
 
-      expect(result.current.preferences.pageSize).toBe(10);
+      expect(result.current.preferences.pageSize).toBe(25);
     });
 
     it('parses search from URL', () => {

--- a/calendar-ui/src/lib/activityTablePreferencesParams.ts
+++ b/calendar-ui/src/lib/activityTablePreferencesParams.ts
@@ -45,8 +45,8 @@ const VALID_SORT_KEYS = new Set([
 ]);
 
 const DEFAULT_SORT_KEY = 'startDate';
-const DEFAULT_SORT_DIRECTION = 'desc' as const;
-const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_SORT_DIRECTION = 'asc' as const;
+const DEFAULT_PAGE_SIZE = 25;
 const MIN_PAGE_SIZE = 1;
 const MAX_PAGE_SIZE = 100;
 


### PR DESCRIPTION
## Summary

Update to expected default sort column and direction.

- change default sort direction from desc to asc in activityTablePreferencesParams
- increase default page size from 10 to 25 for sessions without stored preferences
- align ActivityTable fallback sort direction with preferences default
- update ACTIVITY_FILTER_PERSIST.md defaults table and related tests
- expand ActivityTable.spec mock data for pagination at page size 25