### PR TITLE
Fix/corpcal 000 rate limiter and lints

### DIFF
--- a/calendar-service/.env.example
+++ b/calendar-service/.env.example
@@ -13,8 +13,13 @@ DB_CONNECT_TIMEOUT=10
 API_KEY=your-api-key-here
 
 # Rate Limiting Configuration
-# Optional - defaults to 100 requests/minute
+# Optional - defaults to 100 requests/minute for general endpoints
 RATE_LIMIT_MAX=100
+# Optional - defaults to 5 requests/minute for sensitive auth endpoints
+# RATE_LIMIT_AUTH_MAX=5
+# Optional - defaults to 20 requests per 15 minutes for Azure OIDC endpoints
+# RATE_LIMIT_AZURE_MAX=20
+# RATE_LIMIT_AZURE_WINDOW_MS=900000
 
 # Public application URL (calendar-ui) used to build absolute links in
 # server-generated artifacts such as report PDFs. Must be set per environment.

--- a/calendar-service/API.md
+++ b/calendar-service/API.md
@@ -865,6 +865,7 @@ Server error occurred.
 - **Rate Limiting:** A single global rate-limit interceptor is active:
   - **General endpoints**: 100 requests/minute per IP by default (`RATE_LIMIT_MAX`).
   - **Sensitive auth endpoints** (`/auth/login`, `/auth/check-email`, `/auth/set-password`, `/auth/verify-reset-code`, `/auth/change-password`): 5 requests/minute per IP by default (`RATE_LIMIT_AUTH_MAX`).
+  - **Azure OIDC endpoints** (`/auth/azure`, `/auth/azure/callback`): 20 requests per 15 minutes per IP by default (`RATE_LIMIT_AZURE_MAX`, `RATE_LIMIT_AZURE_WINDOW_MS`).
   - **Storage backend**: Configurable via `RATE_LIMIT_STORE` (default: `memory`, set to `redis` for multi-replica consistency).
   - **429 Response**: When rate limit is exceeded:
     ```json

--- a/calendar-service/package.json
+++ b/calendar-service/package.json
@@ -37,7 +37,6 @@
     "@nestjs/schedule": "^5.0.1",
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/swagger": "^11.2.0",
-    "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^11.1.9",
     "axios": "^1.13.1",
     "bcryptjs": "^3.0.3",

--- a/calendar-service/src/auth/auth.controller.ts
+++ b/calendar-service/src/auth/auth.controller.ts
@@ -205,7 +205,6 @@ export class AuthController {
 
   @Public()
   @Get('azure')
-  @Throttle({ default: { limit: 20, ttl: 900_000 } })
   @ApiOperation({
     summary: 'Start Azure AD login',
     description: 'Initiates OIDC auth flow and redirects to Microsoft login',
@@ -246,7 +245,6 @@ export class AuthController {
 
   @Public()
   @Get('azure/callback')
-  @Throttle({ default: { limit: 20, ttl: 900_000 } })
   @ApiOperation({
     summary: 'Azure AD callback',
     description: 'Handles OIDC callback and signs user into local app session',

--- a/calendar-service/src/common/interceptors/rate-limit.interceptor.spec.ts
+++ b/calendar-service/src/common/interceptors/rate-limit.interceptor.spec.ts
@@ -242,6 +242,62 @@ describe('RateLimitInterceptor', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('applies Azure OIDC limits on /auth/azure routes', async () => {
+      vi.spyOn(ConfigService.prototype, 'get').mockImplementation((key) => {
+        if (key === 'RATE_LIMIT_AZURE_MAX') return '2';
+        if (key === 'RATE_LIMIT_AZURE_WINDOW_MS') return '900000';
+        if (key === 'RATE_LIMIT_STORE') return 'memory';
+        return undefined;
+      });
+
+      const testConfigService = new ConfigService();
+      const azureLimitedInterceptor = new RateLimitInterceptor(
+        testConfigService
+      );
+
+      const azureRequest = {
+        url: '/auth/azure',
+        ip: '127.0.0.12',
+        headers: {},
+      };
+      mockContext = {
+        switchToHttp: () => createHttpArgumentsHost(azureRequest),
+      };
+
+      for (let i = 0; i < 2; i++) {
+        await new Promise<void>((resolve) => {
+          azureLimitedInterceptor
+            .intercept(mockContext as ExecutionContext, mockNext)
+            .subscribe({
+              next: () => resolve(),
+              error: (err) => {
+                throw err;
+              },
+            });
+        });
+      }
+
+      await expect(
+        new Promise<void>((resolve, reject) => {
+          azureLimitedInterceptor
+            .intercept(mockContext as ExecutionContext, mockNext)
+            .subscribe({
+              next: () =>
+                reject(new Error('Azure request should have been blocked')),
+              error: (error) => {
+                if (error.getStatus() === 429) {
+                  resolve();
+                } else {
+                  reject(
+                    error instanceof Error ? error : new Error(String(error))
+                  );
+                }
+              },
+            });
+        })
+      ).resolves.toBeUndefined();
+    });
+
     it('uses general limits for non-sensitive auth endpoints', async () => {
       vi.spyOn(ConfigService.prototype, 'get').mockImplementation((key) => {
         if (key === 'RATE_LIMIT_MAX') return '2';

--- a/calendar-service/src/common/interceptors/rate-limit.interceptor.spec.ts
+++ b/calendar-service/src/common/interceptors/rate-limit.interceptor.spec.ts
@@ -26,6 +26,10 @@ describe('RateLimitInterceptor', () => {
     } as unknown as HttpArgumentsHost;
   }
 
+  function toError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
+  }
+
   describe('store selection', () => {
     it('uses InMemoryRateLimitStore by default (memory mode)', () => {
       vi.spyOn(ConfigService.prototype, 'get').mockImplementation((key) => {
@@ -140,7 +144,7 @@ describe('RateLimitInterceptor', () => {
           .intercept(mockContext as ExecutionContext, mockNext)
           .subscribe({
             next: () => resolve(),
-            error: (err) => reject(err),
+            error: (err) => reject(toError(err)),
           });
       });
     });
@@ -158,7 +162,7 @@ describe('RateLimitInterceptor', () => {
             .intercept(mockContext as ExecutionContext, mockNext)
             .subscribe({
               next: () => resolve(),
-              error: (err) => reject(err),
+              error: (err) => reject(toError(err)),
             });
         });
       }
@@ -306,7 +310,7 @@ describe('RateLimitInterceptor', () => {
           .intercept(mockContext as ExecutionContext, mockNext)
           .subscribe({
             next: () => resolve(),
-            error: (err) => reject(err),
+            error: (err) => reject(toError(err)),
           });
       });
     });
@@ -327,7 +331,7 @@ describe('RateLimitInterceptor', () => {
           .intercept(mockContext as ExecutionContext, mockNext)
           .subscribe({
             next: () => resolve(),
-            error: (err) => reject(err),
+            error: (err) => reject(toError(err)),
           });
       });
 
@@ -339,7 +343,7 @@ describe('RateLimitInterceptor', () => {
           .intercept(mockContext as ExecutionContext, mockNext)
           .subscribe({
             next: () => resolve(),
-            error: (err) => reject(err),
+            error: (err) => reject(toError(err)),
           });
       });
     });
@@ -407,7 +411,7 @@ describe('RateLimitInterceptor', () => {
           .intercept(mockContext as ExecutionContext, mockNext)
           .subscribe({
             next: () => resolve(),
-            error: (err) => reject(err),
+            error: (err) => reject(toError(err)),
           });
       });
 

--- a/calendar-service/src/common/interceptors/rate-limit.interceptor.ts
+++ b/calendar-service/src/common/interceptors/rate-limit.interceptor.ts
@@ -5,6 +5,7 @@
  *
  * - General endpoints: RATE_LIMIT_MAX requests per minute per IP (default: 100)
  * - Sensitive auth endpoints: RATE_LIMIT_AUTH_MAX requests per minute per IP (default: 5)
+ * - Azure OIDC endpoints: RATE_LIMIT_AZURE_MAX requests per window per IP (default: 20 / 15 min)
  * - Store backend: RATE_LIMIT_STORE=memory|redis (default: memory)
  */
 
@@ -19,6 +20,12 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { defer, from, Observable, switchMap } from 'rxjs';
+
+interface RateLimitPolicy {
+  maxRequests: number;
+  windowMs: number;
+  bucket: string;
+}
 
 interface RateLimitEntry {
   count: number;
@@ -177,6 +184,8 @@ export class RateLimitInterceptor implements NestInterceptor {
   private readonly store: RateLimitStore;
   private readonly maxRequests: number;
   private readonly authMaxRequests: number;
+  private readonly azureMaxRequests: number;
+  private readonly azureWindowMs: number;
   private readonly windowMs: number = 60000; // 1 minute
 
   constructor(private readonly configService: ConfigService) {
@@ -189,6 +198,17 @@ export class RateLimitInterceptor implements NestInterceptor {
         this.configService.get<string>('RATE_LIMIT_AUTH_MAX') || '5',
         10
       ) || 5;
+    this.azureMaxRequests =
+      parseInt(
+        this.configService.get<string>('RATE_LIMIT_AZURE_MAX') || '20',
+        10
+      ) || 20;
+    this.azureWindowMs =
+      parseInt(
+        this.configService.get<string>('RATE_LIMIT_AZURE_WINDOW_MS') ||
+          '900000',
+        10
+      ) || 900000;
 
     const configuredStoreType =
       this.configService.get<string>('RATE_LIMIT_STORE', 'memory') || 'memory';
@@ -263,19 +283,19 @@ export class RateLimitInterceptor implements NestInterceptor {
       return;
     }
 
-    const maxRequests = this.getMaxRequestsForUrl(url);
+    const policy = this.getRateLimitPolicy(url);
     const ip = this.getClientIp(request);
     const now = Date.now();
-    const key = `ip:${ip}:limit:${maxRequests}`;
+    const key = `ip:${ip}:${policy.bucket}`;
 
     if (now - this.lastCleanupAt > this.windowMs) {
       await this.store.cleanup(now, this.windowMs);
       this.lastCleanupAt = now;
     }
 
-    const entry = await this.store.increment(key, this.windowMs, now);
+    const entry = await this.store.increment(key, policy.windowMs, now);
 
-    if (entry.count > maxRequests) {
+    if (entry.count > policy.maxRequests) {
       throw new HttpException(
         {
           statusCode: HttpStatus.TOO_MANY_REQUESTS,
@@ -287,16 +307,31 @@ export class RateLimitInterceptor implements NestInterceptor {
     }
   }
 
-  private getMaxRequestsForUrl(url: string): number {
+  private getRateLimitPolicy(url: string): RateLimitPolicy {
     switch (url) {
       case '/auth/login':
       case '/auth/check-email':
       case '/auth/set-password':
       case '/auth/verify-reset-code':
       case '/auth/change-password':
-        return this.authMaxRequests;
+        return {
+          maxRequests: this.authMaxRequests,
+          windowMs: this.windowMs,
+          bucket: 'auth',
+        };
+      case '/auth/azure':
+      case '/auth/azure/callback':
+        return {
+          maxRequests: this.azureMaxRequests,
+          windowMs: this.azureWindowMs,
+          bucket: 'azure',
+        };
       default:
-        return this.maxRequests;
+        return {
+          maxRequests: this.maxRequests,
+          windowMs: this.windowMs,
+          bucket: 'general',
+        };
     }
   }
 }

--- a/calendar-service/src/users/users.service.spec.ts
+++ b/calendar-service/src/users/users.service.spec.ts
@@ -5,6 +5,8 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import type { UpdateUserBody } from '@corpcal/shared/api/types';
+
 import { ActivityHistoryService } from '../activities/services/activity-history.service';
 import { ActivityUtilsService } from '../activities/services/activity-utils.service';
 import {
@@ -371,9 +373,9 @@ describe('UsersService', () => {
         .mockReturnValueOnce(createChain(roleRow, 'limit'))
         .mockReturnValueOnce(createChain(teamRows, 'where'));
 
-      await expect(service.update(1, { email: null } as any, 1)).rejects.toThrow(
-        BadRequestException
-      );
+      await expect(
+        service.update(1, { email: null } as unknown as UpdateUserBody, 1)
+      ).rejects.toThrow(BadRequestException);
       expect(mockDatabaseService.db.update).not.toHaveBeenCalled();
     });
   });

--- a/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
+++ b/calendar-ui/src/components/activity/ActivityTable/ActivityTable.tsx
@@ -1704,8 +1704,10 @@ export function ActivityTable({
                     onSelect={() =>
                       selectActivityIds(
                         sortedData
-                          .filter((row) =>
-                            (user?.teamIds ?? []).includes(row.leadTeamId)
+                          .filter(
+                            (row) =>
+                              row.leadTeamId != null &&
+                              (user?.teamIds ?? []).includes(row.leadTeamId)
                           )
                           .map((row) => row.id)
                       )

--- a/calendar-ui/src/components/users/UserEditModal.tsx
+++ b/calendar-ui/src/components/users/UserEditModal.tsx
@@ -185,7 +185,9 @@ export function UserEditModal({ user, onClose, onSaved }: UserEditModalProps) {
                 className={canEditProfile ? undefined : 'bg-slate-50'}
               />
               {emailError ? (
-                <p className="text-destructive text-sm font-medium">{emailError}</p>
+                <p className="text-destructive text-sm font-medium">
+                  {emailError}
+                </p>
               ) : null}
             </div>
 

--- a/docs/OPENSHIFT_KUSTOMIZE.md
+++ b/docs/OPENSHIFT_KUSTOMIZE.md
@@ -141,6 +141,8 @@ Related variables are wired in both base trees:
 
 - `RATE_LIMIT_MAX` (ConfigMap): max requests per minute per IP for general endpoints.
 - `RATE_LIMIT_AUTH_MAX` (ConfigMap): max requests per minute per IP for sensitive auth endpoints.
+- `RATE_LIMIT_AZURE_MAX` (optional): max requests per window for Azure OIDC endpoints (default: 20).
+- `RATE_LIMIT_AZURE_WINDOW_MS` (optional): Azure OIDC rate-limit window in ms (default: 900000 / 15 min).
 - `RATE_LIMIT_STORE` (ConfigMap): `memory` or `redis`.
 - `RATE_LIMIT_REDIS_URL` (Secret): Redis connection URL used when store mode is `redis`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "@nestjs/schedule": "^5.0.1",
         "@nestjs/serve-static": "^5.0.4",
         "@nestjs/swagger": "^11.2.0",
-        "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^11.1.9",
         "axios": "^1.13.1",
         "bcryptjs": "^3.0.3",
@@ -3041,17 +3040,6 @@
         "@nestjs/platform-express": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nestjs/throttler": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
-      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/websockets": {

--- a/performance_tests/README.md
+++ b/performance_tests/README.md
@@ -74,8 +74,12 @@ npm run perf:k6:browser:auth:local
 
 ## Rate limits (calendar-service)
 
-- `POST /auth/login`: **5 requests / minute / IP** (`@Throttle` on auth controller)
-- Global: `ThrottlerModule` **200/min**; `RateLimitInterceptor` default **100/min** (health/ready excluded)
+Rate limiting is enforced by a single global `RateLimitInterceptor`:
+
+- **Sensitive auth** (`POST /auth/login`, `/auth/check-email`, `/auth/set-password`, `/auth/verify-reset-code`, `/auth/change-password`): **5 req/min per IP** (`RATE_LIMIT_AUTH_MAX`)
+- **Azure OIDC** (`GET /auth/azure`, `/auth/azure/callback`): **20 req / 15 min per IP** (`RATE_LIMIT_AZURE_MAX`, `RATE_LIMIT_AZURE_WINDOW_MS`)
+- **General API**: **100 req/min per IP** by default (`RATE_LIMIT_MAX`; OpenShift configmaps use 200)
+- **Health/readiness** (`/health`, `/ready`): excluded
 
 Load tests sleep between iterations to stay under general limits; login is handled once via `setup()` or `PERF_BEARER_TOKEN`.
 

--- a/performance_tests/tests/corpcal-api.js
+++ b/performance_tests/tests/corpcal-api.js
@@ -19,7 +19,7 @@
  *   BASE_URL=http://localhost:3000/api k6 run performance_tests/tests/corpcal-api.js
  *
  * Shared environments: prefer PERF_BEARER_TOKEN. POST /activities creates real rows — avoid shared DEV unless intended.
- * General API limits: ThrottlerModule 200 req/min; RateLimitInterceptor default 100 req/min (health/ready excluded).
+ * General API limits: RateLimitInterceptor default 100 req/min (health/ready excluded).
  */
 
 import { sleep } from 'k6';


### PR DESCRIPTION
# PR: fix/CORPCAL-000-rate-limiter-and-lints

## Summary

Finishes the calendar-service rate limiter migration by moving Azure OIDC throttling into `RateLimitInterceptor` and removing the unused `@nestjs/throttler` dependency.

Also clears lint/TS issues: null guard on activity bulk-select and a typed test cast in `users.service.spec.ts`.

## Important

- `npm i` (removed `@nestjs/throttler`)
- Optional env vars for Azure OIDC limits: `RATE_LIMIT_AZURE_MAX` (default 20), `RATE_LIMIT_AZURE_WINDOW_MS` (default 900000)

## Changes

1. **Rate limiting (calendar-service):** add Azure OIDC tier to global interceptor; remove orphaned `@Throttle` decorators and `@nestjs/throttler`.
   - 20 req / 15 min per IP for `/auth/azure` and `/auth/azure/callback`.
   - Policy refactor with stable bucket keys (`auth`, `azure`, `general`).
2. **Docs:** update `.env.example`, `API.md`, OpenShift kustomize notes, and performance test README.
3. **Tests:** Azure OIDC rate-limit unit test; lint-safe error handling in interceptor spec.
4. **UI:** null guard on "My teams" bulk-select (`leadTeamId` may be null).
5. **Lint:** format fix in `UserEditModal`; replace `as any` with typed cast in `users.service.spec.ts`.

## Testing

- `npm test -- rate-limit.interceptor.spec.ts -w calendar-service` (16 passed)
- `npx tsc --noEmit -w calendar-ui` (clean)
